### PR TITLE
ci: split verification and release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,21 +1,76 @@
-name: CI
+name: Verify
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      expected_head_sha:
+        description: Exact changeset release PR head SHA
+        required: true
+        type: string
+      release_pr_number:
+        description: Changeset release PR number
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: verify-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   verify:
+    name: verify
+    if: >-
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'workflow_dispatch' &&
+        github.ref == 'refs/heads/changeset-release/main'
+      )
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          RELEASE_PR_NUMBER: ${{ inputs.release_pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ "$EXPECTED_HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RELEASE_PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+          [[ "$GITHUB_REF" == "refs/heads/changeset-release/main" ]]
+          [[ "$GITHUB_SHA" == "$EXPECTED_HEAD_SHA" ]]
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$RELEASE_PR_NUMBER")"
+          readarray -t fields < <(
+            jq -r '.state, .base.ref, .head.ref, .head.repo.full_name, .head.sha' <<<"$pr_json"
+          )
+
+          [[ "${fields[0]}" == "open" ]]
+          [[ "${fields[1]}" == "main" ]]
+          [[ "${fields[2]}" == "changeset-release/main" ]]
+          [[ "${fields[3]}" == "$GITHUB_REPOSITORY" ]]
+          [[ "${fields[4]}" == "$EXPECTED_HEAD_SHA" ]]
+
+          current_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/changeset-release/main" \
+              --jq '.object.sha'
+          )"
+          [[ "$current_sha" == "$EXPECTED_HEAD_SHA" ]]
+
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_head_sha || github.sha }}
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
@@ -65,44 +120,3 @@ jobs:
 
       - name: Check changesets
         run: pnpm changeset:status
-
-  release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: verify
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Set up Node.js 22
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-          registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build packages
-        run: pnpm build
-
-      - name: Create release PR or publish packages
-        uses: changesets/action@v1
-        with:
-          version: pnpm version-packages
-          publish: pnpm release
-          commit: "ci: release"
-          title: "ci: release"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Prepare changeset base branch
+        run: git branch --force main origin/main
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_head_sha || github.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,114 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    if: >-
+      github.repository == 'ayden94/ilokesto' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Create or update release PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          branch: main
+          version: pnpm version-packages
+          commit: "ci: release"
+          title: "ci: release"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Resolve release PR head
+        id: release_pr
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]
+
+          pr_json="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")"
+          readarray -t fields < <(
+            jq -r '.state, .base.ref, .head.ref, .head.repo.full_name, .head.sha' <<<"$pr_json"
+          )
+
+          [[ "${fields[0]}" == "open" ]]
+          [[ "${fields[1]}" == "main" ]]
+          [[ "${fields[2]}" == "changeset-release/main" ]]
+          [[ "${fields[3]}" == "$GITHUB_REPOSITORY" ]]
+          [[ "${fields[4]}" =~ ^[0-9a-f]{40}$ ]]
+
+          branch_sha="$(
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/changeset-release/main" \
+              --jq '.object.sha'
+          )"
+          [[ "$branch_sha" == "${fields[4]}" ]]
+
+          printf 'number=%s\nhead_sha=%s\n' \
+            "$PR_NUMBER" "${fields[4]}" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch release-head verification
+        if: steps.release_pr.outputs.head_sha != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ steps.release_pr.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.release_pr.outputs.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          jq -n \
+            --arg ref "changeset-release/main" \
+            --arg sha "$HEAD_SHA" \
+            --arg pr "$PR_NUMBER" \
+            '{
+              ref: $ref,
+              inputs: {
+                expected_head_sha: $sha,
+                release_pr_number: $pr
+              }
+            }' |
+            gh api \
+              --method POST \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/dispatches" \
+              --input -

--- a/tests/monorepo/ci-workflow.test.mjs
+++ b/tests/monorepo/ci-workflow.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const readWorkflow = (name) =>
+  readFile(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8");
+
+test("verification is read-only and runs only for PRs or guarded dispatches", async () => {
+  const workflow = await readWorkflow("ci.yml");
+
+  assert.match(workflow, /pull_request:\n\s+branches:\n\s+- main/);
+  assert.match(workflow, /workflow_dispatch:\n\s+inputs:/);
+  assert.match(workflow, /expected_head_sha:[\s\S]*required: true/);
+  assert.match(workflow, /release_pr_number:[\s\S]*required: true/);
+  assert.doesNotMatch(workflow, /^\s+push:/m);
+  assert.match(workflow, /permissions:\n\s+contents: read\n\s+pull-requests: read/);
+  assert.doesNotMatch(workflow, /contents: write|actions: write|id-token: write/);
+  assert.match(workflow, /name: verify/);
+  assert.match(workflow, /github\.ref == 'refs\/heads\/changeset-release\/main'/);
+});
+
+test("release dispatch validation precedes checkout and binds the exact PR head", async () => {
+  const workflow = await readWorkflow("ci.yml");
+  const validation = workflow.indexOf("name: Validate release dispatch");
+  const checkout = workflow.indexOf("name: Checkout repository");
+
+  assert.ok(validation >= 0);
+  assert.ok(checkout > validation);
+  assert.match(workflow, /GITHUB_SHA.*EXPECTED_HEAD_SHA/);
+  assert.match(workflow, /\.base\.ref, \.head\.ref, \.head\.repo\.full_name, \.head\.sha/);
+  assert.match(workflow, /git\/ref\/heads\/changeset-release\/main/);
+  assert.match(workflow, /ref: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.expected_head_sha \|\| github\.sha \}\}/);
+  assert.match(workflow, /persist-credentials: false/);
+});

--- a/tests/monorepo/ci-workflow.test.mjs
+++ b/tests/monorepo/ci-workflow.test.mjs
@@ -33,3 +33,13 @@ test("release dispatch validation precedes checkout and binds the exact PR head"
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /persist-credentials: false/);
 });
+
+test("changeset status receives a local main base ref", async () => {
+  const workflow = await readWorkflow("ci.yml");
+  const prepareBase = workflow.indexOf("name: Prepare changeset base branch");
+  const changesetStatus = workflow.indexOf("name: Check changesets");
+
+  assert.ok(prepareBase >= 0);
+  assert.ok(changesetStatus > prepareBase);
+  assert.match(workflow, /git branch --force main origin\/main/);
+});

--- a/tests/monorepo/ci-workflow.test.mjs
+++ b/tests/monorepo/ci-workflow.test.mjs
@@ -30,5 +30,6 @@ test("release dispatch validation precedes checkout and binds the exact PR head"
   assert.match(workflow, /\.base\.ref, \.head\.ref, \.head\.repo\.full_name, \.head\.sha/);
   assert.match(workflow, /git\/ref\/heads\/changeset-release\/main/);
   assert.match(workflow, /ref: \$\{\{ github\.event_name == 'workflow_dispatch' && inputs\.expected_head_sha \|\| github\.sha \}\}/);
+  assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /persist-credentials: false/);
 });

--- a/tests/monorepo/release-workflow.test.mjs
+++ b/tests/monorepo/release-workflow.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("main pushes run only serialized release automation", async () => {
+  const workflow = await readFile(
+    new URL("../../.github/workflows/release.yml", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(workflow, /push:\n\s+branches:\n\s+- main/);
+  assert.doesNotMatch(workflow, /pull_request:|workflow_dispatch:/);
+  assert.match(workflow, /group: release-main/);
+  assert.match(workflow, /cancel-in-progress: false/);
+  assert.match(workflow, /actions: write/);
+  assert.match(workflow, /contents: write/);
+  assert.match(workflow, /pull-requests: write/);
+  assert.doesNotMatch(workflow, /NPM_TOKEN|publish: pnpm release|id-token: write/);
+  assert.match(workflow, /id: changesets/);
+  assert.match(workflow, /steps\.changesets\.outputs\.pullRequestNumber/);
+  assert.match(workflow, /actions\/workflows\/ci\.yml\/dispatches/);
+  assert.match(workflow, /expected_head_sha: \$sha/);
+  assert.match(workflow, /release_pr_number: \$pr/);
+});


### PR DESCRIPTION
## Summary
- run the full verify check only for pull requests and guarded release-head dispatches
- isolate privileged Changesets automation in a main-push-only workflow
- bind generated release PR verification to its exact current head SHA
- pause npm publishing until destination-only authentication is configured

## Verification
- pnpm test:monorepo
- workflow contract tests
- YAML parse validation