### PR TITLE
fix: validate generated version pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,4 +123,5 @@ jobs:
         run: pnpm --filter @ilokesto/fetcher test:dist
 
       - name: Check changesets
+        if: github.event_name == 'pull_request'
         run: pnpm changeset:status

--- a/tests/monorepo/ci-workflow.test.mjs
+++ b/tests/monorepo/ci-workflow.test.mjs
@@ -43,3 +43,12 @@ test("changeset status receives a local main base ref", async () => {
   assert.ok(changesetStatus > prepareBase);
   assert.match(workflow, /git branch --force main origin\/main/);
 });
+
+test("changeset status is required only for ordinary pull requests", async () => {
+  const workflow = await readWorkflow("ci.yml");
+
+  assert.match(
+    workflow,
+    /- name: Check changesets\n\s+if: github\.event_name == 'pull_request'\n\s+run: pnpm changeset:status/,
+  );
+});


### PR DESCRIPTION
## Summary
- keep changeset status mandatory for ordinary pull requests
- skip only that source-changeset assertion for exact-SHA generated version PR verification

## Verification
- node --test tests/monorepo/ci-workflow.test.mjs