### PR TITLE
ci: skip changeset status on release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,5 +126,5 @@ jobs:
         run: pnpm --filter @ilokesto/fetcher test:dist
 
       - name: Check changesets
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.head_ref != 'changeset-release/main'
         run: pnpm changeset:status

--- a/tests/monorepo/ci-workflow.test.mjs
+++ b/tests/monorepo/ci-workflow.test.mjs
@@ -49,6 +49,6 @@ test("changeset status is required only for ordinary pull requests", async () =>
 
   assert.match(
     workflow,
-    /- name: Check changesets\n\s+if: github\.event_name == 'pull_request'\n\s+run: pnpm changeset:status/,
+    /- name: Check changesets\n\s+if: github\.event_name == 'pull_request' && github\.head_ref != 'changeset-release\/main'\n\s+run: pnpm changeset:status/,
   );
 });


### PR DESCRIPTION
## Summary
- keep changeset status required for ordinary pull requests
- skip the consumed-changeset check only for the trusted changeset-release/main branch
- lock the workflow condition with a monorepo contract test

## Verification
- pnpm test:monorepo
- node --check tests/monorepo/ci-workflow.test.mjs
- git diff --check