### PR TITLE
fix(state): unify framework selector subscriptions

### DIFF
--- a/.changeset/state-selector-parity-issue-6.md
+++ b/.changeset/state-selector-parity-issue-6.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Unify plain and reducer selector subscriptions across the React, Vue, Angular, Solid, and Svelte adapters. All adapters now use `Store.subscribeSelector` with shared shallow equality, skip unrelated updates, preserve framework lifecycle cleanup, and retain React's initial-state server snapshot behavior.

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -9,7 +9,7 @@
 ## 주요 기능
 
 - 일반 상태나 Reducer로부터 프레임워크 친화적인 상태 어댑터 생성
-- 프레임워크가 자연스럽게 지원하는 방식의 Selector 기반 상태 구독
+- 모든 프레임워크에서 하나의 공통 shallow 동등성 계약으로 Selector 기반 상태 구독
 - `readOnly()`를 사용해 프레임워크 생명주기 밖에서 상태 조회
 - `writeOnly()`를 사용해 프레임워크 생명주기 밖에서 상태 업데이트
 - `logger`, `debounce`, `persist`, `devtools` 등의 미들웨어로 스토어 구성
@@ -22,6 +22,19 @@ pnpm add @ilokesto/state
 ```
 
 `immer`는 선택적 피어 의존성(peer dependency)이며, `adaptor()`를 사용할 때만 필요합니다.
+
+## Selector 구독 계약
+
+React, Vue, Angular, Svelte, Solid는 일반 상태와 Reducer 상태 모두에서 동일한 Selector 구독 동작을 사용합니다.
+
+- 원시값 선택은 `Object.is` 의미론을 사용합니다.
+- 객체, 배열, `Map`, `Set`, `Date` 선택은 패키지의 1단계 `shallow` 비교를 사용합니다.
+- Store가 변경되어도 선택 결과가 shallow 비교에서 같으면 프레임워크 consumer에 알리지 않습니다.
+- 선택 결과와 관련된 업데이트는 consumer에 정확히 한 번 알립니다.
+- React unmount, Vue scope dispose, Angular `DestroyRef`, Solid owner cleanup, Svelte unsubscribe 시 구독을 해제합니다.
+- React server snapshot은 Store의 초기 상태에서 값을 선택하므로 현재 상태가 이미 변경되었어도 hydration 의미론을 유지합니다.
+
+이 계약은 `Store.subscribeSelector`를 기반으로 하며, 어댑터는 프레임워크별 동등성 옵션을 노출하지 않습니다. `create(initialState)`와 `create(reducer, initialState)`에 동일하게 적용됩니다.
 
 ## React
 
@@ -355,11 +368,11 @@ counterStore.getState().count;
 - `@ilokesto/state/middleware` → 미들웨어 헬퍼
 - `@ilokesto/state/utils` → `adaptor`, `pipe`, `definePipeableMiddleware`, pipe 타입
 
-## 마이그레이션: deep compare → shallow (v2.0.0)
+## 마이그레이션: 통합 shallow Selector 구독
 
 ### 변경 사항
 
-React 어댑터는 이전에 **깊은 비교** (`deepCompare`)를 사용하여 selector 결과가 리렌더를 트리거해야 하는지 판단했습니다. v2.0.0부터는 **shallow 비교**를 사용합니다 — zustand가 사용하는 패턴과 동일합니다. 이는 breaking change입니다.
+React 어댑터는 이전에 **깊은 비교** (`deepCompare`)를 사용하여 selector 결과가 리렌더를 트리거해야 하는지 판단했습니다. 이후 zustand가 사용하는 패턴과 같은 **shallow 비교**로 전환했습니다. 이제 React, Vue, Angular, Svelte, Solid의 일반 상태와 Reducer 상태가 모두 같은 shallow Selector 구독 계약을 사용합니다.
 
 ### 이유
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -9,7 +9,7 @@ This package keeps the store core framework-agnostic and exposes thin adapters f
 ## Features
 
 - Create framework-friendly state adapters from plain state or a reducer
-- Subscribe to slices with selectors where the framework supports it naturally
+- Subscribe to slices with selectors using one shared shallow-equality contract
 - Read state outside framework lifecycles with `readOnly()`
 - Update state outside framework lifecycles with `writeOnly()`
 - Compose stores with middleware like `logger`, `debounce`, `persist`, and `devtools`
@@ -24,6 +24,19 @@ pnpm add @ilokesto/state
 ```
 
 `immer` is an optional peer dependency and is only needed when you use `adaptor()`.
+
+## Selector Subscription Contract
+
+React, Vue, Angular, Svelte, and Solid use the same selector subscription behavior for both plain and reducer state:
+
+- Primitive selections use `Object.is` semantics.
+- Object, array, `Map`, `Set`, and `Date` selections use the package's one-level `shallow` comparison.
+- An update that changes the store but leaves the selected value shallow-equal does not notify the framework consumer.
+- A relevant update notifies the consumer exactly once.
+- Subscriptions are removed by the framework lifecycle: React unmount, Vue scope disposal, Angular `DestroyRef`, Solid owner cleanup, or Svelte unsubscribe.
+- React's server snapshot selects from the store's initial state, preserving hydration semantics even if the current state has already changed.
+
+This contract is built on `Store.subscribeSelector`; adapters do not expose framework-specific equality options. It applies equally to `create(initialState)` and `create(reducer, initialState)`.
 
 ## React
 
@@ -357,11 +370,11 @@ This is a breaking change. Callable and variadic pipe syntax has been removed. R
 - `@ilokesto/state/middleware` → middleware helpers
 - `@ilokesto/state/utils` → `adaptor`, `pipe`, `definePipeableMiddleware`, and pipe types
 
-## Migration: deep compare → shallow (v2.0.0)
+## Migration: unified shallow selector subscriptions
 
 ### What changed
 
-The React adapter previously used **deep comparison** (`deepCompare`) to determine whether a selector result should trigger a re-render. Starting from v2.0.0, it uses **shallow comparison** instead — matching the pattern used by zustand. This is a breaking change.
+The React adapter previously used **deep comparison** (`deepCompare`) to determine whether a selector result should trigger a re-render. It switched to **shallow comparison**, matching the pattern used by zustand. React, Vue, Angular, Svelte, and Solid now all use that same shallow selector subscription contract for plain and reducer state.
 
 ### Why
 

--- a/packages/state/src/core/Angular/createUseSignal.ts
+++ b/packages/state/src/core/Angular/createUseSignal.ts
@@ -1,8 +1,9 @@
 import type { Store } from '@ilokesto/store';
-import { DestroyRef, computed, inject, signal } from '@angular/core';
+import { DestroyRef, inject, signal } from '@angular/core';
 
 import { dispatchStoreAction } from '../../lib/actionMetadata.js';
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import { shallow } from '../shared/shallow.js';
 import type {
   ActionWriter,
   AngularOptions,
@@ -33,14 +34,19 @@ function resolveDestroyRef(options?: AngularOptions): DestroyRef {
 }
 
 function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>, options?: AngularOptions) {
-  const snapshot = signal(store.getState() as T);
-  const unsubscribe = store.subscribe(() => {
-    snapshot.set(store.getState() as T);
-  });
+  const destroyRef = resolveDestroyRef(options);
+  const selection = signal(selector(store.getState() as T));
+  const unsubscribe = store.subscribeSelector(
+    selector,
+    (nextSelection) => {
+      selection.set(nextSelection);
+    },
+    shallow,
+  );
 
-  resolveDestroyRef(options).onDestroy(unsubscribe);
+  destroyRef.onDestroy(unsubscribe);
 
-  return computed(() => selector(snapshot()));
+  return selection.asReadonly();
 }
 
 export function createUseSignal<T, Action extends ReducerAction>(store: Store<T>, isReduce: boolean) {

--- a/packages/state/src/core/React/createUseState.ts
+++ b/packages/state/src/core/React/createUseState.ts
@@ -13,18 +13,16 @@ const identity = <Value>(value: Value): Value => value;
 function createShallowSelector<T, S>(
   selector: (state: T) => S,
 ): (state: T) => S {
-  let prev: S | undefined;
-  let hasPrev = false;
+  let previous: Readonly<{ value: S }> | undefined;
 
   return (state: T): S => {
     const next = selector(state);
 
-    if (hasPrev && shallow(prev as S, next)) {
-      return prev as S;
+    if (previous && shallow(previous.value, next)) {
+      return previous.value;
     }
 
-    hasPrev = true;
-    prev = next;
+    previous = { value: next };
     return next;
   };
 }
@@ -34,7 +32,11 @@ export function useStoreState<T, S, Writer>(
   selector: (state: T) => S,
   write: Writer,
 ) {
-  const subscribe = useMemo(() => store.subscribe.bind(store), [store]);
+  const subscribe = useMemo(
+    () => (listener: () => void) =>
+      store.subscribeSelector(selector, listener, shallow),
+    [store, selector],
+  );
 
   const getSnapshot = useMemo(() => {
     const shallowSelector = createShallowSelector(selector);

--- a/packages/state/src/core/Solid/createUseAccessor.ts
+++ b/packages/state/src/core/Solid/createUseAccessor.ts
@@ -1,8 +1,9 @@
 import type { Store } from '@ilokesto/store';
-import { createMemo, from, getOwner } from 'solid-js';
+import { createSignal, getOwner, onCleanup } from 'solid-js';
 
 import { dispatchStoreAction } from '../../lib/actionMetadata.js';
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import { shallow } from '../shared/shallow.js';
 import type { ActionWriter, Selector, StateWriter } from './types.js';
 
 const identity = <Value>(value: Value): Value => value;
@@ -20,16 +21,20 @@ function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
     );
   }
 
-  const snapshot = from<T>(
-    (set) => {
-      return store.subscribe(() => {
-        set(() => store.getState() as T);
-      });
-    },
-    store.getState() as T,
+  const [selection, setSelection] = createSignal(
+    selector(store.getState() as T),
+    { equals: Object.is },
   );
+  const unsubscribe = store.subscribeSelector(
+    selector,
+    (nextSelection) => {
+      setSelection(() => nextSelection);
+    },
+    shallow,
+  );
+  onCleanup(unsubscribe);
 
-  return createMemo(() => selector(snapshot() as T));
+  return selection;
 }
 
 export function createUseAccessor<T, Action extends ReducerAction>(store: Store<T>, isReduce: boolean) {

--- a/packages/state/src/core/Svelte/createStore.ts
+++ b/packages/state/src/core/Svelte/createStore.ts
@@ -4,6 +4,7 @@ import type { Readable, Subscriber, Unsubscriber, Updater } from 'svelte/store';
 
 import { dispatchStoreAction } from '../../lib/actionMetadata.js';
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import { shallow } from '../shared/shallow.js';
 import type {
   ActionWriter,
   Selector,
@@ -22,11 +23,11 @@ function createDispatch<T, Action extends ReducerAction>(store: Store<T>): Actio
 function createReadable<T, S>(store: Store<T>, selector: Selector<T, S>): Readable<S> {
   return {
     subscribe(run: Subscriber<S>): Unsubscriber {
-      run(selector(store.getState() as T));
+      const initialSelection = selector(store.getState() as T);
+      const unsubscribe = store.subscribeSelector(selector, run, shallow);
 
-      return store.subscribe(() => {
-        run(selector(store.getState() as T));
-      });
+      run(initialSelection);
+      return unsubscribe;
     },
   };
 }
@@ -35,11 +36,11 @@ export function createStore<T, Action extends ReducerAction>(store: Store<T>, is
   const write = store.setState.bind(store);
   const dispatch = createDispatch<T, Action>(store);
   const subscribe = (run: Subscriber<T>): Unsubscriber => {
-    run(store.getState() as T);
+    const initialState = store.getState() as T;
+    const unsubscribe = store.subscribeSelector(identity<T>, run, shallow);
 
-    return store.subscribe(() => {
-      run(store.getState() as T);
-    });
+    run(initialState);
+    return unsubscribe;
   };
   const select = <S>(selector: Selector<T, S>) => createReadable(store, selector);
   const readOnly = <S = T>(selector?: Selector<T, S>): S => {

--- a/packages/state/src/core/Vue/createUseComposable.ts
+++ b/packages/state/src/core/Vue/createUseComposable.ts
@@ -3,6 +3,7 @@ import { computed, getCurrentScope, onScopeDispose, shallowRef } from 'vue';
 
 import { dispatchStoreAction } from '../../lib/actionMetadata.js';
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import { shallow } from '../shared/shallow.js';
 import type { ActionWriter, Selector, StateWriter } from './types.js';
 
 const identity = <Value>(value: Value): Value => value;
@@ -20,15 +21,19 @@ function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
     );
   }
 
-  const snapshot = shallowRef(store.getState());
+  const snapshot = shallowRef(selector(store.getState() as T));
 
-  const unsubscribe = store.subscribe(() => {
-    snapshot.value = store.getState();
-  });
+  const unsubscribe = store.subscribeSelector(
+    selector,
+    (nextSelection) => {
+      snapshot.value = nextSelection as typeof snapshot.value;
+    },
+    shallow,
+  );
 
   onScopeDispose(unsubscribe);
 
-  return computed(() => selector(snapshot.value as T));
+  return computed(() => snapshot.value as S);
 }
 
 export function createUseComposable<T, Action extends ReducerAction>(store: Store<T>, isReduce: boolean) {

--- a/packages/state/test/selector-subscriptions/angular.test.ts
+++ b/packages/state/test/selector-subscriptions/angular.test.ts
@@ -1,0 +1,97 @@
+import { DestroyRef } from '@angular/core';
+import { describe, expect, test } from 'bun:test';
+
+import { create } from '../../src/core/Angular';
+import {
+  counterReducer,
+  initialState,
+  TrackingStore,
+} from './helpers';
+
+class TestDestroyRef extends DestroyRef {
+  readonly callbacks = new Set<() => void>();
+  destroyed = false;
+
+  override onDestroy(callback: () => void): () => void {
+    this.callbacks.add(callback);
+    return () => {
+      this.callbacks.delete(callback);
+    };
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    for (const callback of this.callbacks) callback();
+    this.callbacks.clear();
+  }
+}
+
+describe('Angular selector subscriptions', () => {
+  test('Given no injection context or DestroyRef, When a selection is created, Then the failure leaves no subscription', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(store);
+
+    // When / Then
+    expect(() => counter((state) => state.count)).toThrow();
+    expect(store.activeSelectorSubscriptions).toBe(0);
+  });
+
+  test('Given a plain adapter primitive selector, When state changes, Then only relevant updates notify until destroy', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(store);
+    const destroyRef = new TestDestroyRef();
+    const selected = counter((state) => state.count, { destroyRef });
+
+    expect(selected.state()).toBe(1);
+    expect(store.activeSelectorSubscriptions).toBe(1);
+
+    // When
+    store.setState((state) => ({ ...state, label: 'unrelated' }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    store.setState((state) => ({ ...state, count: 2 }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(selected.state()).toBe(2);
+
+    // When
+    destroyRef.destroy();
+    store.setState((state) => ({ ...state, count: 3 }));
+
+    // Then
+    expect(store.activeSelectorSubscriptions).toBe(0);
+    expect(store.selectorNotifications).toBe(1);
+  });
+
+  test('Given a reducer adapter object selector, When actions run, Then shallow-equal updates are skipped and relevant updates notify once', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(counterReducer, store);
+    const destroyRef = new TestDestroyRef();
+    const selected = counter((state) => ({ count: state.count }), {
+      destroyRef,
+    });
+
+    // When
+    selected.dispatch({ type: 'rename', label: 'unrelated' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    selected.dispatch({ type: 'increment' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(selected.state()).toEqual({ count: 2 });
+
+    destroyRef.destroy();
+    expect(store.activeSelectorSubscriptions).toBe(0);
+  });
+});

--- a/packages/state/test/selector-subscriptions/helpers.ts
+++ b/packages/state/test/selector-subscriptions/helpers.ts
@@ -1,0 +1,63 @@
+import { Store } from '@ilokesto/store';
+
+export type CounterState = Readonly<{
+  count: number;
+  label: string;
+}>;
+
+export type CounterAction =
+  | Readonly<{ type: 'increment' }>
+  | Readonly<{ type: 'rename'; label: string }>;
+
+type Selector<State, Selection> = (state: Readonly<State>) => Selection;
+type SelectorListener<Selection> = (
+  nextSelection: Selection,
+  previousSelection: Selection,
+) => void;
+type EqualityFn<Selection> = (
+  previousSelection: Selection,
+  nextSelection: Selection,
+) => boolean;
+
+export class TrackingStore<State> extends Store<State> {
+  activeSelectorSubscriptions = 0;
+  selectorNotifications = 0;
+
+  override subscribeSelector<Selection>(
+    selector: Selector<State, Selection>,
+    listener: SelectorListener<Selection>,
+    equalityFn: EqualityFn<Selection> = Object.is,
+  ): () => void {
+    this.activeSelectorSubscriptions += 1;
+    const unsubscribe = super.subscribeSelector(
+      selector,
+      (nextSelection, previousSelection) => {
+        this.selectorNotifications += 1;
+        listener(nextSelection, previousSelection);
+      },
+      equalityFn,
+    );
+
+    return () => {
+      this.activeSelectorSubscriptions -= 1;
+      unsubscribe();
+    };
+  }
+}
+
+export const initialState: CounterState = {
+  count: 1,
+  label: 'initial',
+};
+
+export const counterReducer = (
+  state: CounterState,
+  action: CounterAction,
+): CounterState => {
+  switch (action.type) {
+    case 'increment':
+      return { ...state, count: state.count + 1 };
+    case 'rename':
+      return { ...state, label: action.label };
+  }
+};

--- a/packages/state/test/selector-subscriptions/react.test.ts
+++ b/packages/state/test/selector-subscriptions/react.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import {
+  counterReducer,
+  initialState,
+  TrackingStore,
+} from './helpers';
+
+const cleanupCallbacks: (() => void)[] = [];
+let useServerSnapshot = false;
+
+mock.module('react', () => ({
+  useMemo: <Value>(factory: () => Value): Value => factory(),
+  useSyncExternalStore: <Snapshot>(
+    subscribe: (onStoreChange: () => void) => () => void,
+    getSnapshot: () => Snapshot,
+    getServerSnapshot?: () => Snapshot,
+  ): Snapshot => {
+    cleanupCallbacks.push(subscribe(() => undefined));
+    if (useServerSnapshot && getServerSnapshot) return getServerSnapshot();
+    return getSnapshot();
+  },
+}));
+
+const { create } = await import('../../src/core/React');
+
+describe('React selector subscriptions', () => {
+  test('Given a plain adapter primitive selector, When state changes, Then only relevant updates notify until hook cleanup', () => {
+    // Given
+    useServerSnapshot = false;
+    const store = new TrackingStore(initialState);
+    const useCounter = create(store);
+    const selected = useCounter((state) => state.count);
+
+    expect(selected[0]).toBe(1);
+    expect(store.activeSelectorSubscriptions).toBe(1);
+
+    // When
+    store.setState((state) => ({ ...state, label: 'unrelated' }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    store.setState((state) => ({ ...state, count: 2 }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+
+    // When
+    cleanupCallbacks.pop()?.();
+    expect(store.activeSelectorSubscriptions).toBe(0);
+    store.setState((state) => ({ ...state, count: 3 }));
+
+    // Then
+    expect(store.activeSelectorSubscriptions).toBe(0);
+    expect(store.selectorNotifications).toBe(1);
+  });
+
+  test('Given a reducer adapter object selector, When actions run, Then shallow-equal updates are skipped and relevant updates notify once', () => {
+    // Given
+    useServerSnapshot = false;
+    const store = new TrackingStore(initialState);
+    const useCounter = create(counterReducer, store);
+    const selected = useCounter((state) => ({ count: state.count }));
+
+    // When
+    selected[1]({ type: 'rename', label: 'unrelated' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    selected[1]({ type: 'increment' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+
+    cleanupCallbacks.pop()?.();
+  });
+
+  test('Given current state differs from initial state, When React reads the server snapshot, Then the selected initial value is returned', () => {
+    // Given
+    useServerSnapshot = true;
+    const store = new TrackingStore(initialState);
+    store.setState({ count: 9, label: 'current' });
+    const useCounter = create(store);
+
+    // When
+    const selected = useCounter((state) => ({ count: state.count }));
+
+    // Then
+    expect(selected[0]).toEqual({ count: 1 });
+
+    cleanupCallbacks.pop()?.();
+  });
+});

--- a/packages/state/test/selector-subscriptions/solid.test.ts
+++ b/packages/state/test/selector-subscriptions/solid.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+import { createRoot } from 'solid-js';
+
+import { create } from '../../src/core/Solid';
+import {
+  counterReducer,
+  initialState,
+  TrackingStore,
+} from './helpers';
+import type { CounterAction } from './helpers';
+
+describe('Solid selector subscriptions', () => {
+  test('Given negative zero is selected, When state changes to positive zero, Then the accessor delivers positive zero', () => {
+    // Given
+    const store = new TrackingStore(-0);
+    const useNumber = create(store);
+    let dispose = (): void => undefined;
+    let selectedNumber = (): number => Number.NaN;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      selectedNumber = useNumber().state;
+    });
+
+    // When
+    store.setState(0);
+
+    // Then
+    expect(Object.is(selectedNumber(), 0)).toBe(true);
+    expect(Object.is(selectedNumber(), -0)).toBe(false);
+
+    dispose();
+  });
+
+  test('Given a plain adapter primitive selector, When state changes, Then only relevant updates notify until owner cleanup', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const useCounter = create(store);
+    let dispose = (): void => undefined;
+    let selectedCount = (): number => -1;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      selectedCount = useCounter((state) => state.count).state;
+    });
+
+    expect(selectedCount()).toBe(1);
+    expect(store.activeSelectorSubscriptions).toBe(1);
+
+    // When
+    store.setState((state) => ({ ...state, label: 'unrelated' }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    store.setState((state) => ({ ...state, count: 2 }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(selectedCount()).toBe(2);
+
+    // When
+    dispose();
+    store.setState((state) => ({ ...state, count: 3 }));
+
+    // Then
+    expect(store.activeSelectorSubscriptions).toBe(0);
+    expect(store.selectorNotifications).toBe(1);
+  });
+
+  test('Given a reducer adapter object selector, When actions run, Then shallow-equal updates are skipped and relevant updates notify once', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const useCounter = create(counterReducer, store);
+    let dispose = (): void => undefined;
+    let selectedCount = (): Readonly<{ count: number }> => ({ count: -1 });
+    let dispatch = (_action: CounterAction): void => undefined;
+
+    createRoot((rootDispose) => {
+      dispose = rootDispose;
+      const selected = useCounter((state) => ({ count: state.count }));
+      selectedCount = selected.state;
+      dispatch = selected.dispatch;
+    });
+
+    // When
+    dispatch({ type: 'rename', label: 'unrelated' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    dispatch({ type: 'increment' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(selectedCount()).toEqual({ count: 2 });
+
+    dispose();
+    expect(store.activeSelectorSubscriptions).toBe(0);
+  });
+});

--- a/packages/state/test/selector-subscriptions/svelte.test.ts
+++ b/packages/state/test/selector-subscriptions/svelte.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+
+import { create } from '../../src/core/Svelte';
+import {
+  counterReducer,
+  initialState,
+  TrackingStore,
+} from './helpers';
+
+describe('Svelte selector subscriptions', () => {
+  test('Given a select subscriber updates synchronously during initial delivery, When it subscribes, Then the selected update is observed', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(store);
+    const values: number[] = [];
+
+    // When
+    const unsubscribe = counter.select((state) => state.count).subscribe((value) => {
+      values.push(value);
+      if (values.length === 1) {
+        store.setState((state) => ({ ...state, count: 2 }));
+      }
+    });
+
+    // Then
+    expect(values).toEqual([1, 2]);
+
+    unsubscribe();
+  });
+
+  test('Given a root subscriber updates synchronously during initial delivery, When it subscribes, Then the state update is observed', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(store);
+    const values: number[] = [];
+
+    // When
+    const unsubscribe = counter.subscribe((state) => {
+      values.push(state.count);
+      if (values.length === 1) {
+        store.setState((currentState) => ({ ...currentState, count: 2 }));
+      }
+    });
+
+    // Then
+    expect(values).toEqual([1, 2]);
+
+    unsubscribe();
+  });
+
+  test('Given a plain adapter primitive selector, When state changes, Then only relevant updates notify until unsubscribe', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(store);
+    const values: number[] = [];
+    const unsubscribe = counter.select((state) => state.count).subscribe((value) => {
+      values.push(value);
+    });
+
+    expect(values).toEqual([1]);
+    expect(store.activeSelectorSubscriptions).toBe(1);
+
+    // When
+    store.setState((state) => ({ ...state, label: 'unrelated' }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+    expect(values).toEqual([1]);
+
+    // When
+    store.setState((state) => ({ ...state, count: 2 }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(values).toEqual([1, 2]);
+
+    // When
+    unsubscribe();
+    store.setState((state) => ({ ...state, count: 3 }));
+
+    // Then
+    expect(store.activeSelectorSubscriptions).toBe(0);
+    expect(store.selectorNotifications).toBe(1);
+    expect(values).toEqual([1, 2]);
+  });
+
+  test('Given a reducer adapter object selector, When actions run, Then shallow-equal updates are skipped and relevant updates notify once', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const counter = create(counterReducer, store);
+    const values: Readonly<{ count: number }>[] = [];
+    const unsubscribe = counter
+      .select((state) => ({ count: state.count }))
+      .subscribe((value) => {
+        values.push(value);
+      });
+
+    // When
+    counter.dispatch({ type: 'rename', label: 'unrelated' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+    expect(values).toEqual([{ count: 1 }]);
+
+    // When
+    counter.dispatch({ type: 'increment' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(values).toEqual([{ count: 1 }, { count: 2 }]);
+
+    unsubscribe();
+    expect(store.activeSelectorSubscriptions).toBe(0);
+  });
+});

--- a/packages/state/test/selector-subscriptions/vue.test.ts
+++ b/packages/state/test/selector-subscriptions/vue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { effectScope } from 'vue';
+
+import { create } from '../../src/core/Vue';
+import {
+  counterReducer,
+  initialState,
+  TrackingStore,
+} from './helpers';
+
+describe('Vue selector subscriptions', () => {
+  test('Given a plain adapter primitive selector, When state changes, Then only relevant updates notify until scope cleanup', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const useCounter = create(store);
+    const scope = effectScope();
+    const selected = scope.run(() => useCounter((state) => state.count));
+
+    expect(selected?.state.value).toBe(1);
+    expect(store.activeSelectorSubscriptions).toBe(1);
+
+    // When
+    store.setState((state) => ({ ...state, label: 'unrelated' }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    store.setState((state) => ({ ...state, count: 2 }));
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(selected?.state.value).toBe(2);
+
+    // When
+    scope.stop();
+    store.setState((state) => ({ ...state, count: 3 }));
+
+    // Then
+    expect(store.activeSelectorSubscriptions).toBe(0);
+    expect(store.selectorNotifications).toBe(1);
+  });
+
+  test('Given a reducer adapter object selector, When actions run, Then shallow-equal updates are skipped and relevant updates notify once', () => {
+    // Given
+    const store = new TrackingStore(initialState);
+    const useCounter = create(counterReducer, store);
+    const scope = effectScope();
+    const selected = scope.run(() =>
+      useCounter((state) => ({ count: state.count })),
+    );
+
+    // When
+    selected?.dispatch({ type: 'rename', label: 'unrelated' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(0);
+
+    // When
+    selected?.dispatch({ type: 'increment' });
+
+    // Then
+    expect(store.selectorNotifications).toBe(1);
+    expect(selected?.state.value).toEqual({ count: 2 });
+
+    scope.stop();
+    expect(store.activeSelectorSubscriptions).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- route React, Vue, Angular, Solid, and Svelte adapters through Store.subscribeSelector with shared shallow equality
- preserve lifecycle cleanup and React initial-state server snapshots
- cover plain/reducer adapters, reentrant Svelte delivery, Solid Object.is edge cases, and Angular failure cleanup

Closes #6

## Verification
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test (171 passed)
- pnpm --filter @ilokesto/state test:typecheck
- pnpm --filter @ilokesto/state build
- pnpm build
- pnpm test:monorepo
- pnpm typecheck
- pnpm test
- pnpm changeset:status