### PR TITLE
feat(form): add reactive values parity

### DIFF
--- a/.changeset/form-reactive-values-parity.md
+++ b/.changeset/form-reactive-values-parity.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/form": minor
+---
+
+Add reference-based reactive `values` and value-driven `resetOptions` contracts for the React, Vue, Solid, and Svelte adapters.

--- a/packages/form/README.ko.md
+++ b/packages/form/README.ko.md
@@ -148,7 +148,7 @@ const { form, useRegister, handleSubmit } = useForm({
 });
 ```
 
-`useForm(options)`에 전달한 options는 해당 component lifetime 동안 form instance를 만들 때 사용된다. React adapter에서는 외부 `values`도 받을 수 있다. `values` reference가 바뀌면 adapter가 `form.reset(values, resetOptions)`를 대신 호출한다. `useQuery` 같은 async data로 값을 hydrate할 때 사용자 편집값을 덮어쓰고 싶지 않다면 `keepDirtyValues`를 사용한다.
+`defaultValues`와 다른 `CreateForm` options는 component-owned form을 한 번만 생성한다. `ReactFormOptions`는 현재 render의 `values`와 plain `resetOptions`도 받는다. 처음 정의된 값과 이후 `Object.is` identity가 달라진 값마다 `form.reset(values, resetOptions)`를 호출한다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 전달해도 no-op이다. `resetOptions`만 바꾸는 것도 no-op이며 새 `values` reference가 reset을 일으킬 때만 적용된다.
 
 ```tsx
 const { useRegister } = useForm({
@@ -160,6 +160,8 @@ const { useRegister } = useForm({
   },
 });
 ```
+
+Values effect는 component unmount 시 종료된다. `useForm(existingForm)` overload는 기존 동작을 유지하며 external-value synchronization을 설치하지 않는다.
 
 React adapter의 첫 버전 hook은 세 가지다. `useRegister`는 단일, 배열, rest-argument 등록을 모두 처리하도록 overload되어 있다.
 
@@ -187,7 +189,7 @@ Event model은 DOM event 중심이다. Custom component도 DOM-compatible `value
 
 Vue binding은 `./vue` subpath로 노출된다. React adapter와 같은 `useForm(form)` 형태를 쓰지만, Vue template의 `v-bind`에 바로 전달할 수 있도록 `onInput`, `onChange`, `onBlur`, `onFocus` handler를 가진 props를 반환한다.
 
-`useForm`은 `values` 필드(`ref`, `computed`, getter, 평면 값 모두 가능)와 optional `resetOptions`를 가진 `VueFormOptions` 객체도 받는다. `values` reference가 바뀌면 adapter가 `form.reset(values, resetOptions)`를 호출한다 — React adapter와 동일한 모델. 추적을 보장하려면 반응형 소스(`ref`/`computed`)를 직접 전달하라. 평면 값은 생성 시 1회 평가되며 컴포넌트가 다시 렌더링되어 `useForm`이 다시 호출될 때 다시 평가된다.
+`useForm`은 `VueFormOptions`도 받는다. `values` source는 `MaybeRefOrGetter<TValues | undefined>`이고 `resetOptions`는 plain이다. 처음 정의된 값과 이후 `Object.is` identity가 달라진 값마다 `form.reset(values, resetOptions)`를 호출한다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 emit해도 no-op이다. 변경을 추적하려면 `ref`, `computed`, getter를 전달하라. 평면 값은 한 번만 평가된다. Reactive values에는 active Vue effect scope가 필요하며, scope가 없으면 adapter는 form을 만들기 전에 실패한다. Watcher는 해당 scope와 함께 중지되며 `useForm(existingForm)`은 watcher를 설치하지 않는다.
 
 ```vue
 <script setup lang="ts">
@@ -307,6 +309,19 @@ function LoginForm() {
 
 Solid adapter는 Vue와 같은 의미의 `useRegister`, `useField`, `useFormState`를 제공한다. Text input은 `input` event에서, checkbox/radio/multiple select는 `change` event에서 갱신하고, field-local schema는 현재 Solid owner와 함께 dispose된다.
 
+Component-owned form에서는 `SolidFormOptions`가 `values`를 `Accessor<TValues | undefined>`로 받고 plain `resetOptions`를 받는다.
+
+```tsx
+const [serverValues, setServerValues] = createSignal<User | undefined>();
+const { form } = useForm({
+  defaultValues: emptyUser,
+  values: serverValues,
+  resetOptions: { keepDirtyValues: true },
+});
+```
+
+처음 정의된 accessor 값과 이후 `Object.is` identity가 달라진 값마다 form을 reset한다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 emit해도 no-op이며, `resetOptions`는 value-driven reset에만 적용된다. Reactive values에는 active Solid owner가 필요하며, owner가 없으면 adapter는 form을 만들기 전에 실패한다. Tracking은 해당 owner와 함께 dispose된다. `useForm(existingForm)`은 tracking을 설치하지 않는다.
+
 ## Svelte adapter
 
 Svelte binding은 `./svelte` subpath로 노출된다. Adapter는 register action과 함께 form-wide 및 field-local state를 위한 readable store를 제공한다.
@@ -348,6 +363,24 @@ Svelte binding은 `./svelte` subpath로 노출된다. Adapter는 register action
 ```
 
 Svelte action은 DOM synchronization을 직접 담당한다. `useField`는 `$email`로 소비하는 `Readable<SvelteFieldSnapshot>`이며 최신 `value`, `errors`, `dirty`, `touched`를 emit하고 마지막 subscriber가 해제되면 core subscription도 정리한다.
+
+Component-owned form에서는 `SvelteFormOptions`가 `values`를 `Readable<TValues | undefined>`로 받고 plain `resetOptions`를 받는다.
+
+```svelte
+<script lang="ts">
+  import { writable } from 'svelte/store';
+  import { useForm } from '@ilokesto/form/svelte';
+
+  const serverValues = writable<User | undefined>(undefined);
+  const { form } = useForm({
+    defaultValues: emptyUser,
+    values: serverValues,
+    resetOptions: { keepDirtyValues: true },
+  });
+</script>
+```
+
+처음 정의된 emission과 이후 `Object.is` identity가 달라진 emission마다 form을 reset한다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 emit해도 no-op이며, `resetOptions`는 value-driven reset에만 적용된다. 이 overload는 component initialization 중 호출해야 하며 subscription은 unmount 시 종료된다. `useForm(existingForm)`은 external values를 구독하지 않는다.
 
 ## Core concepts
 

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -148,9 +148,7 @@ const { form, useRegister, handleSubmit } = useForm({
 });
 ```
 
-Options passed to `useForm(options)` are used only to create the form instance for that component lifetime. They are not reactive. When hydrating values from async data such as a query result, initialize with safe defaults and call `form.reset(nextValues)` explicitly when you want that data to become the new default baseline.
-
-The React adapter also accepts reactive external `values`. When the `values` reference changes, the adapter calls `form.reset(values, resetOptions)` for you. This is useful for server/query data; use `keepDirtyValues` when refetches should not overwrite fields the user already edited.
+`defaultValues` and the other `CreateForm` options create the component-owned form once. `ReactFormOptions` also accepts the current render `values` and plain `resetOptions`. The first defined value and each later value with a different `Object.is` identity call `form.reset(values, resetOptions)`. `undefined` pauses synchronization without resetting; passing the last defined object again remains a no-op. Changing only `resetOptions` is also a no-op because it applies only when a new `values` reference drives a reset.
 
 ```tsx
 const { useRegister } = useForm({
@@ -162,6 +160,8 @@ const { useRegister } = useForm({
   },
 });
 ```
+
+The values effect ends on component unmount. `useForm(existingForm)` keeps its existing overload behavior and does not install external-value synchronization.
 
 The React adapter has three first-version hooks. `useRegister` is overloaded for single, array, and rest-argument registration:
 
@@ -189,7 +189,7 @@ The event model is DOM-event centered. Custom components can use `useRegister` w
 
 Vue bindings are exposed through the `./vue` subpath. They use the same `useForm(form)` shape as the React adapter, but return Vue-friendly `v-bind` props with `onInput`, `onChange`, `onBlur`, and `onFocus` handlers.
 
-`useForm` also accepts a `VueFormOptions` object with a `values` field (a `ref`, `computed`, getter, or plain value) and an optional `resetOptions`. When `values` changes by reference, the adapter calls `form.reset(values, resetOptions)` — the same model as the React adapter. Pass reactive sources (`ref`/`computed`) directly so Vue can track them; plain values are evaluated once on creation and re-evaluated when the component re-renders and `useForm` is called again.
+`useForm` also accepts `VueFormOptions`. Its `values` source is `MaybeRefOrGetter<TValues | undefined>` and `resetOptions` stays plain. The first defined value and each later value with a different `Object.is` identity call `form.reset(values, resetOptions)`. `undefined` pauses synchronization without resetting, and re-emitting the last defined object remains a no-op. Pass `ref`, `computed`, or a getter to track changes; a plain value is evaluated once. Reactive values require an active Vue effect scope; the adapter fails before creating a form when none exists. The watcher stops with that scope, and `useForm(existingForm)` does not install it.
 
 ```vue
 <script setup lang="ts">
@@ -309,6 +309,19 @@ function LoginForm() {
 
 The Solid adapter exposes `useRegister`, `useField`, and `useFormState` with the same semantics as Vue: text inputs update on `input`, checkbox/radio/multiple select update on `change`, and field-local schemas are disposed with the current Solid owner.
 
+For component-owned forms, `SolidFormOptions` accepts `values` as `Accessor<TValues | undefined>` and plain `resetOptions`:
+
+```tsx
+const [serverValues, setServerValues] = createSignal<User | undefined>();
+const { form } = useForm({
+  defaultValues: emptyUser,
+  values: serverValues,
+  resetOptions: { keepDirtyValues: true },
+});
+```
+
+The first defined accessor value and each later value with a different `Object.is` identity reset the form. `undefined` pauses without resetting, re-emitting the last defined object is a no-op, and `resetOptions` applies only to value-driven resets. Reactive values require an active Solid owner; the adapter fails before creating a form when none exists. Tracking is disposed with that owner. `useForm(existingForm)` does not install it.
+
 ## Svelte adapter
 
 Svelte bindings are exposed through the `./svelte` subpath. The adapter exposes register actions plus readable stores for both form-wide and field-local state.
@@ -350,6 +363,24 @@ Svelte bindings are exposed through the `./svelte` subpath. The adapter exposes 
 ```
 
 The Svelte action owns DOM synchronization directly. `useField` is a `Readable<SvelteFieldSnapshot>` consumed as `$email`; it emits current `value`, `errors`, `dirty`, and `touched` state and releases its core subscription when the last subscriber leaves.
+
+For component-owned forms, `SvelteFormOptions` accepts `values` as `Readable<TValues | undefined>` and plain `resetOptions`:
+
+```svelte
+<script lang="ts">
+  import { writable } from 'svelte/store';
+  import { useForm } from '@ilokesto/form/svelte';
+
+  const serverValues = writable<User | undefined>(undefined);
+  const { form } = useForm({
+    defaultValues: emptyUser,
+    values: serverValues,
+    resetOptions: { keepDirtyValues: true },
+  });
+</script>
+```
+
+The first defined emission and each later emission with a different `Object.is` identity reset the form. `undefined` pauses without resetting, re-emitting the last defined object is a no-op, and `resetOptions` applies only to value-driven resets. Call this overload during component initialization; its subscription ends on unmount. `useForm(existingForm)` does not subscribe.
 
 ## Core concepts
 

--- a/packages/form/docs/integrations/react.ko.mdx
+++ b/packages/form/docs/integrations/react.ko.mdx
@@ -30,6 +30,20 @@ function ProfileForm({ form }) {
 
 text input은 `onChange`로 갱신됩니다. checkbox와 radio는 checked 상태를 사용합니다. select와 textarea 바인딩은 제네릭으로 좁힐 수 있습니다. 오류를 렌더링하거나 `setValue`를 호출해야 하면 `useField`를 쓰고, 평범한 입력에 속성만 필요하면 `useRegister`를 사용하세요.
 
+## 외부 값 동기화
+
+`ReactFormOptions`는 현재 render의 `values`와 plain `resetOptions`를 받습니다. 처음 정의된 값과 이후 `Object.is` identity가 달라진 값마다 `form.reset(values, resetOptions)`를 호출합니다. `undefined`는 reset 없이 동기화를 중단하고, 그 뒤 마지막으로 정의되었던 같은 object를 다시 전달해도 no-op입니다. `resetOptions`만 바꾸는 것도 no-op이며 새 `values` reference가 reset을 일으킬 때만 읽힙니다.
+
+```tsx
+const { form } = useForm({
+  defaultValues: emptyProfile,
+  values: query.data,
+  resetOptions: { keepDirtyValues: true },
+});
+```
+
+`defaultValues`는 component-owned form을 한 번만 생성합니다. values effect는 component unmount 시 종료됩니다. `useForm(existingForm)` overload는 기존 동작을 유지하며 external-value synchronization을 설치하지 않습니다.
+
 ## 주의할 점
 
 코어 폼은 안정적인 위치에서 만들고, 해당 프레임워크 피어 의존성을 설치하며, 프레임워크 컴포넌트에서는 이 어댑터 하위 경로에서만 가져오세요. 서버 액션이나 도메인 도우미처럼 렌더링이 필요 없는 코드는 루트 `@ilokesto/form` API에 남겨두는 편이 좋습니다.

--- a/packages/form/docs/integrations/react.mdx
+++ b/packages/form/docs/integrations/react.mdx
@@ -30,6 +30,20 @@ function ProfileForm({ form }) {
 
 Text inputs update through `onChange`; checkbox and radio fields use checked state; select and textarea bindings can be narrowed with a generic. Use `useField` when rendering errors or calling `setValue`, and `useRegister` when a plain input only needs props.
 
+## Syncing external values
+
+`ReactFormOptions` accepts the current render `values` and plain `resetOptions`. The first defined value and each later value with a different `Object.is` identity call `form.reset(values, resetOptions)`. `undefined` pauses synchronization without resetting, and passing the last defined object again remains a no-op. Changing only `resetOptions` is also a no-op; it is read only when a new `values` reference drives a reset.
+
+```tsx
+const { form } = useForm({
+  defaultValues: emptyProfile,
+  values: query.data,
+  resetOptions: { keepDirtyValues: true },
+});
+```
+
+`defaultValues` creates the component-owned form once. The values effect ends when the component unmounts. `useForm(existingForm)` keeps its existing overload behavior and does not install external-value synchronization.
+
 ## Cautions
 
 Create the core form in a stable place, install the matching peer dependency, and import only from this adapter subpath in framework components. Keep server actions and domain helpers on the root `@ilokesto/form` API when they do not need rendering.

--- a/packages/form/docs/integrations/solid.ko.mdx
+++ b/packages/form/docs/integrations/solid.ko.mdx
@@ -30,6 +30,21 @@ function Phones({ form }) {
 
 오류 렌더링과 직접 setter가 필요하면 `useField`를 사용하세요. text, checkbox, radio, select, textarea, DOM 호환 커스텀 컨트롤에는 `useRegister`를 사용합니다. React에서처럼 배열 키와 튜플 인덱스 경로는 분리해서 관리하세요.
 
+## 외부 값 동기화
+
+`SolidFormOptions`는 `values`를 `Accessor<T | undefined>`로 받고 plain `resetOptions`를 받습니다. 처음 정의된 값과 이후 `Object.is` identity가 달라진 값마다 `form.reset(values, resetOptions)`를 호출합니다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 emit해도 no-op입니다. `resetOptions`는 value-driven reset에만 적용됩니다.
+
+```tsx
+const [serverValues, setServerValues] = createSignal<Profile | undefined>();
+const { form } = useForm({
+  defaultValues: emptyProfile,
+  values: serverValues,
+  resetOptions: { keepDirtyValues: true },
+});
+```
+
+이 overload에는 active Solid owner가 필요하며 owner가 없으면 form 생성 전에 실패합니다. Tracking computation은 해당 owner와 함께 dispose됩니다. `useForm(existingForm)`은 values tracking을 설치하지 않습니다.
+
 ## 주의할 점
 
 코어 폼은 안정적인 위치에서 만들고, 해당 프레임워크 피어 의존성을 설치하며, 프레임워크 컴포넌트에서는 이 어댑터 하위 경로에서만 가져오세요. 서버 액션이나 도메인 도우미처럼 렌더링이 필요 없는 코드는 루트 `@ilokesto/form` API에 남겨두는 편이 좋습니다.

--- a/packages/form/docs/integrations/solid.mdx
+++ b/packages/form/docs/integrations/solid.mdx
@@ -30,6 +30,21 @@ function Phones({ form }) {
 
 Use `useField` for error rendering and direct setters. Use `useRegister` for text, checkbox, radio, select, textarea, and DOM-compatible custom controls. Keep array keys separate from tuple index paths, just as you would in React.
 
+## Syncing external values
+
+`SolidFormOptions` accepts `values` as `Accessor<T | undefined>` and accepts plain `resetOptions`. The first defined value and each later value with a different `Object.is` identity call `form.reset(values, resetOptions)`. `undefined` pauses synchronization without resetting, and re-emitting the last defined object remains a no-op. `resetOptions` applies only to value-driven resets.
+
+```tsx
+const [serverValues, setServerValues] = createSignal<Profile | undefined>();
+const { form } = useForm({
+  defaultValues: emptyProfile,
+  values: serverValues,
+  resetOptions: { keepDirtyValues: true },
+});
+```
+
+This overload requires an active Solid owner and fails before form creation when none exists. The tracking computation is disposed with that owner. `useForm(existingForm)` does not install values tracking.
+
 ## Cautions
 
 Create the core form in a stable place, install the matching peer dependency, and import only from this adapter subpath in framework components. Keep server actions and domain helpers on the root `@ilokesto/form` API when they do not need rendering.

--- a/packages/form/docs/integrations/svelte.ko.mdx
+++ b/packages/form/docs/integrations/svelte.ko.mdx
@@ -26,6 +26,26 @@ description: "@ilokesto/form/svelte의 register 액션과 읽기 가능한 폼 �
 
 액션은 DOM 리스너를 붙이고 요소가 사라질 때 정리합니다. `useFormState()`는 errors, dirty fields, touched fields, validity, submitting state, submitCount 같은 전체 상태 요약을 담은 Svelte readable store를 반환합니다.
 
+## 외부 값 동기화
+
+`SvelteFormOptions`는 `values`를 `Readable<T | undefined>`로 받고 plain `resetOptions`를 받습니다. 처음 정의된 emission과 이후 `Object.is` identity가 달라진 emission마다 `form.reset(values, resetOptions)`를 호출합니다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 emit해도 no-op입니다. `resetOptions`는 value-driven reset에만 적용됩니다.
+
+```svelte
+<script lang="ts">
+  import { writable } from 'svelte/store';
+  import { useForm } from '@ilokesto/form/svelte';
+
+  const serverValues = writable<Profile | undefined>(undefined);
+  const { form } = useForm({
+    defaultValues: emptyProfile,
+    values: serverValues,
+    resetOptions: { keepDirtyValues: true },
+  });
+</script>
+```
+
+이 options overload는 component initialization 중 호출해야 합니다. Readable subscription은 component unmount 시 해제됩니다. `useForm(existingForm)`은 external values를 구독하지 않습니다.
+
 ## 주의할 점
 
 코어 폼은 안정적인 위치에서 만들고, 해당 프레임워크 피어 의존성을 설치하며, 프레임워크 컴포넌트에서는 이 어댑터 하위 경로에서만 가져오세요. 서버 액션이나 도메인 도우미처럼 렌더링이 필요 없는 코드는 루트 `@ilokesto/form` API에 남겨두는 편이 좋습니다.

--- a/packages/form/docs/integrations/svelte.mdx
+++ b/packages/form/docs/integrations/svelte.mdx
@@ -26,6 +26,26 @@ Install `svelte` as the peer and import from `@ilokesto/form/svelte`. Svelte is 
 
 The action attaches DOM listeners and cleans them up when the element is destroyed. `useFormState()` returns a Svelte readable store containing aggregate state such as errors, dirty fields, touched fields, validity, submitting state, and submitCount.
 
+## Syncing external values
+
+`SvelteFormOptions` accepts `values` as `Readable<T | undefined>` and accepts plain `resetOptions`. The first defined emission and each later emission with a different `Object.is` identity call `form.reset(values, resetOptions)`. `undefined` pauses synchronization without resetting, and re-emitting the last defined object remains a no-op. `resetOptions` applies only to value-driven resets.
+
+```svelte
+<script lang="ts">
+  import { writable } from 'svelte/store';
+  import { useForm } from '@ilokesto/form/svelte';
+
+  const serverValues = writable<Profile | undefined>(undefined);
+  const { form } = useForm({
+    defaultValues: emptyProfile,
+    values: serverValues,
+    resetOptions: { keepDirtyValues: true },
+  });
+</script>
+```
+
+Call this options overload during component initialization. Its readable subscription is released on component unmount. `useForm(existingForm)` does not subscribe to external values.
+
 ## Cautions
 
 Create the core form in a stable place, install the matching peer dependency, and import only from this adapter subpath in framework components. Keep server actions and domain helpers on the root `@ilokesto/form` API when they do not need rendering.

--- a/packages/form/docs/integrations/vue.ko.mdx
+++ b/packages/form/docs/integrations/vue.ko.mdx
@@ -31,7 +31,7 @@ const state = useFormState();
 
 ## 외부 값 동기화
 
-`useForm`에 `values` 옵션(`ref`, `computed`, getter, 평면 값 모두 가능)과 optional `resetOptions`를 전달하면, `values` reference가 바뀔 때 adapter가 `form.reset(values, resetOptions)`를 호출합니다 — React adapter와 동일한 모델입니다.
+`VueFormOptions`는 `values`를 `MaybeRefOrGetter<T | undefined>`로 받고 plain `resetOptions`를 받습니다. 처음 정의된 값과 이후 `Object.is` identity가 달라진 값마다 `form.reset(values, resetOptions)`를 호출합니다. `undefined`는 reset 없이 동기화를 중단하고, 마지막으로 정의되었던 같은 object를 다시 emit해도 no-op입니다. `resetOptions`는 value-driven reset에만 사용됩니다.
 
 ```vue
 <script setup lang="ts">
@@ -42,11 +42,12 @@ const serverValues = ref({ email: 'initial@example.com' });
 const { form, useRegister } = useForm({
   defaultValues: { email: '' },
   values: serverValues,
+  resetOptions: { keepDirtyValues: true },
 });
 </script>
 ```
 
-변화 추적을 보장하려면 반응형 소스(`ref`/`computed`)를 직접 전달하세요. 평면 값은 생성 시 1회 평가되며 컴포넌트가 다시 렌더링되어 `useForm`이 다시 호출될 때 다시 평가됩니다.
+변화 추적을 보장하려면 반응형 소스(`ref`/`computed`/getter)를 직접 전달하세요. 평면 값은 생성 시 한 번만 평가됩니다. 이 overload에는 active Vue effect scope가 필요하며 scope가 없으면 form 생성 전에 실패합니다. Watcher는 해당 scope와 함께 중지되며 `useForm(existingForm)`은 values watcher를 설치하지 않습니다.
 
 ## 주의할 점
 

--- a/packages/form/docs/integrations/vue.mdx
+++ b/packages/form/docs/integrations/vue.mdx
@@ -31,7 +31,7 @@ The returned state uses getter-backed reads so templates see fresh values. Field
 
 ## Syncing external values
 
-Pass a `values` option (a `ref`, `computed`, getter, or plain value) and optional `resetOptions` to `useForm`. When `values` changes by reference, the adapter calls `form.reset(values, resetOptions)` — the same model as the React adapter.
+`VueFormOptions` accepts `values` as `MaybeRefOrGetter<T | undefined>` and accepts plain `resetOptions`. The first defined value and each later value with a different `Object.is` identity call `form.reset(values, resetOptions)`. `undefined` pauses synchronization without resetting, and re-emitting the last defined object remains a no-op. `resetOptions` is used only by a value-driven reset.
 
 ```vue
 <script setup lang="ts">
@@ -42,11 +42,12 @@ const serverValues = ref({ email: 'initial@example.com' });
 const { form, useRegister } = useForm({
   defaultValues: { email: '' },
   values: serverValues,
+  resetOptions: { keepDirtyValues: true },
 });
 </script>
 ```
 
-Pass reactive sources (`ref`/`computed`) directly so Vue can track changes. Plain values are evaluated once on creation and re-evaluated when the component re-renders and `useForm` is called again.
+Pass reactive sources (`ref`/`computed`/getter) directly so Vue can track changes. A plain value is evaluated once. This overload requires an active Vue effect scope and fails before form creation when none exists. The watcher stops with that scope, and `useForm(existingForm)` does not install a values watcher.
 
 ## Cautions
 

--- a/packages/form/scripts/verify-package.mjs
+++ b/packages/form/scripts/verify-package.mjs
@@ -39,6 +39,7 @@ try {
       dependencies: {
         '@ilokesto/form': `file:${formTarball}`,
         '@ilokesto/store': `file:${storeTarball}`,
+        '@types/react': '^19.2.15',
         immer: '11.1.8',
         react: '^19.0.0',
         'solid-js': '^1.9.0',
@@ -73,11 +74,41 @@ if (form.getValue('email') !== 'packed') throw new TypeError('Packed form runtim
   );
   writeFileSync(
     path.join(consumerDirectory, 'types.ts'),
-    `import type { VueFormOptions } from '@ilokesto/form/vue';
-import type { SvelteFieldSnapshot } from '@ilokesto/form/svelte';
+    `import type { ReactFormOptions } from '@ilokesto/form/react';
+import type { SolidFormOptions } from '@ilokesto/form/solid';
+import type { SvelteFieldSnapshot, SvelteFormOptions } from '@ilokesto/form/svelte';
+import type { VueFormOptions } from '@ilokesto/form/vue';
+import type { Accessor } from 'solid-js';
+import type { Readable } from 'svelte/store';
 
-const options: VueFormOptions<{ readonly email: string }> = {
+type Values = { readonly email: string };
+const externalValues: Values = { email: 'packed@example.com' };
+const reactOptions: ReactFormOptions<Values> = {
   defaultValues: { email: '' },
+  resetOptions: { keepDirtyValues: true },
+  values: externalValues,
+};
+const vueOptions: VueFormOptions<Values> = {
+  defaultValues: { email: '' },
+  resetOptions: { keepDirtyValues: true },
+  values: () => externalValues,
+};
+const solidValues: Accessor<Values | undefined> = () => externalValues;
+const solidOptions: SolidFormOptions<Values> = {
+  defaultValues: { email: '' },
+  resetOptions: { keepDirtyValues: true },
+  values: solidValues,
+};
+const svelteValues: Readable<Values | undefined> = {
+  subscribe(run) {
+    run(externalValues);
+    return () => undefined;
+  },
+};
+const svelteOptions: SvelteFormOptions<Values> = {
+  defaultValues: { email: '' },
+  resetOptions: { keepDirtyValues: true },
+  values: svelteValues,
 };
 const snapshot: SvelteFieldSnapshot = {
   dirty: false,
@@ -85,8 +116,11 @@ const snapshot: SvelteFieldSnapshot = {
   touched: false,
   value: '',
 };
-void options;
+void reactOptions;
+void solidOptions;
 void snapshot;
+void svelteOptions;
+void vueOptions;
 `,
   );
   writeFileSync(

--- a/packages/form/src/adapters/FormInput.ts
+++ b/packages/form/src/adapters/FormInput.ts
@@ -1,13 +1,11 @@
 import { CreateForm, type CreateFormOptions, type Form, type ResetOptions } from '../core/index';
 
-export type ReactiveFormOptions<TValues> = CreateFormOptions<TValues> & {
-  /** 외부 서버/query/props 값이 바뀔 때 adapter가 reset을 트리거하기 위한 값이다. */
-  values?: TValues;
-  /** adapter가 values 변경으로 reset을 호출할 때 적용할 보존 옵션이다. */
-  resetOptions?: ResetOptions;
+export type ReactiveFormOptions<TValues, TSource> = CreateFormOptions<TValues> & {
+  readonly values?: TSource;
+  readonly resetOptions?: ResetOptions;
 };
 
-export type FormInput<TValues> = Form<TValues> | ReactiveFormOptions<TValues>;
+export type FormInput<TValues, TOptions extends CreateFormOptions<TValues>> = Form<TValues> | TOptions;
 
 export function isFormInstance<TValues>(
   input: Form<TValues> | CreateFormOptions<TValues>,
@@ -15,11 +13,22 @@ export function isFormInstance<TValues>(
   return 'subscribe' in input && 'submit' in input;
 }
 
-export function createFormFromOptions<TValues>(options: ReactiveFormOptions<TValues>): Form<TValues> {
-  const { values, resetOptions, ...createOptions } = options;
+export function createFormFromOptions<TValues>(options: CreateFormOptions<TValues>): Form<TValues> {
+  const { defaultValues, schema, schemaOptions, validateOn } = options;
+  return new CreateForm({ defaultValues, schema, schemaOptions, validateOn });
+}
 
-  void values;
-  void resetOptions;
+export function createExternalValuesSynchronizer<TValues>(
+  form: Form<TValues>,
+): (values: TValues | undefined, resetOptions: ResetOptions | undefined) => void {
+  let previousDefinedValues: TValues | undefined;
 
-  return new CreateForm(createOptions);
+  return (values, resetOptions) => {
+    if (values === undefined || Object.is(previousDefinedValues, values)) {
+      return;
+    }
+
+    previousDefinedValues = values;
+    form.reset(values, resetOptions);
+  };
 }

--- a/packages/form/src/react/types.ts
+++ b/packages/form/src/react/types.ts
@@ -6,18 +6,14 @@ import type {
   TextareaHTMLAttributes,
   FormEvent,
 } from 'react';
-import type { CreateFormOptions, FieldPathInput, FieldPathValue, FieldState, Form, FormError, FormState, ResetOptions } from '../core/index';
+import type { FieldPathInput, FieldPathValue, FieldState, Form, FormError, FormState } from '../core/index';
 import type { RegisterOptions, SubmitHandler, SubmitInvalidHandler, SubmitValidHandler } from '../adapters/dom';
+import type { ReactiveFormOptions } from '../adapters/FormInput';
 
 export type { RegisterOptions } from '../adapters/dom';
 
 /** React adapter가 form 생성 옵션에 더해 reactive external values를 받을 때 쓰는 옵션이다. */
-export type ReactFormOptions<TValues> = CreateFormOptions<TValues> & {
-  /** 외부 서버/query/props 값이다. reference가 바뀌면 adapter가 reset을 트리거한다. */
-  values?: TValues;
-  /** `values` 변경으로 reset할 때 적용할 상태 보존 옵션이다. */
-  resetOptions?: ResetOptions;
-};
+export type ReactFormOptions<TValues> = ReactiveFormOptions<TValues, TValues | undefined>;
 
 type InputValue = InputHTMLAttributes<HTMLInputElement>['value'];
 type InputType = InputHTMLAttributes<HTMLInputElement>['type'];

--- a/packages/form/src/react/useForm.ts
+++ b/packages/form/src/react/useForm.ts
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { createSubmitHandler } from '../adapters/dom';
-import { createFormFromOptions, isFormInstance, type FormInput } from '../adapters/FormInput';
+import {
+  createExternalValuesSynchronizer,
+  createFormFromOptions,
+  isFormInstance,
+  type FormInput,
+} from '../adapters/FormInput';
 import type { FieldPathInput, Form } from '../core/index';
 import type { ReactForm, ReactFormOptions, RegisterOptions } from './types';
 import { useFieldWithForm } from './useField';
@@ -11,24 +16,19 @@ import { useRegisterWithForm } from './useRegister';
 /** React hook surface를 core Form 인스턴스에 바인딩한다. */
 export function useForm<TValues>(form: Form<TValues>): ReactForm<TValues>;
 export function useForm<TValues>(options: ReactFormOptions<TValues>): ReactForm<TValues>;
-export function useForm<TValues>(input: FormInput<TValues>): ReactForm<TValues> {
+export function useForm<TValues>(input: FormInput<TValues, ReactFormOptions<TValues>>): ReactForm<TValues> {
   const optionsFormRef = useRef<Form<TValues> | undefined>(undefined);
-  const previousValuesRef = useRef<TValues | undefined>(undefined);
   const isForm = isFormInstance(input);
   const form = isForm
     ? input
     : (optionsFormRef.current ??= createFormFromOptions(input));
   const values = isForm ? undefined : input.values;
   const resetOptions = isForm ? undefined : input.resetOptions;
+  const synchronizeValues = useMemo(() => createExternalValuesSynchronizer(form), [form]);
 
   useEffect(() => {
-    if (values === undefined || previousValuesRef.current === values) {
-      return;
-    }
-
-    previousValuesRef.current = values;
-    form.reset(values, resetOptions);
-  }, [form, resetOptions, values]);
+    synchronizeValues(values, resetOptions);
+  }, [resetOptions, synchronizeValues, values]);
 
   const useRegister = ((
     first: RegisterOptions | readonly RegisterOptions[],

--- a/packages/form/src/solid/index.ts
+++ b/packages/form/src/solid/index.ts
@@ -1,4 +1,5 @@
 export { useForm } from './useForm';
 export type {
   RegisterOptions,
+  SolidFormOptions,
 } from './types';

--- a/packages/form/src/solid/types.ts
+++ b/packages/form/src/solid/types.ts
@@ -1,7 +1,15 @@
+import type { Accessor } from 'solid-js';
 import type { Form, FormError, FormState } from '../core/index';
 import type { DomValue, RegisterOptions, SubmitHandler, SubmitInvalidHandler, SubmitValidHandler } from '../adapters/dom';
+import type { ReactiveFormOptions } from '../adapters/FormInput';
 
 export type { RegisterOptions } from '../adapters/dom';
+
+/** Solid owner가 외부 values accessor와 함께 form을 만들 때 쓰는 옵션이다. */
+export type SolidFormOptions<TValues> = ReactiveFormOptions<
+  TValues,
+  Accessor<TValues | undefined>
+>;
 
 type SolidBindingHandlers<TElement extends HTMLElement> = {
   onInput: (event: InputEvent & { currentTarget: TElement }) => void;

--- a/packages/form/src/solid/useForm.ts
+++ b/packages/form/src/solid/useForm.ts
@@ -1,16 +1,36 @@
+import { createRenderEffect, getOwner } from 'solid-js';
 import { createSubmitHandler } from '../adapters/dom';
-import { createFormFromOptions, isFormInstance, type FormInput } from '../adapters/FormInput';
-import type { CreateFormOptions, Form } from '../core/index';
-import type { RegisterOptions, SolidForm } from './types';
+import {
+  createExternalValuesSynchronizer,
+  createFormFromOptions,
+  isFormInstance,
+  type FormInput,
+} from '../adapters/FormInput';
+import type { Form } from '../core/index';
+import type { RegisterOptions, SolidForm, SolidFormOptions } from './types';
 import { useFieldWithForm } from './useField';
 import { useFormStateWithForm } from './useFormState';
 import { useRegisterWithForm } from './useRegister';
 
 /** Solid helper surface를 core Form 인스턴스에 바인딩한다. */
 export function useForm<TValues>(form: Form<TValues>): SolidForm<TValues>;
-export function useForm<TValues>(options: CreateFormOptions<TValues>): SolidForm<TValues>;
-export function useForm<TValues>(input: FormInput<TValues>): SolidForm<TValues> {
-  const form = isFormInstance(input) ? input : createFormFromOptions(input);
+export function useForm<TValues>(options: SolidFormOptions<TValues>): SolidForm<TValues>;
+export function useForm<TValues>(input: FormInput<TValues, SolidFormOptions<TValues>>): SolidForm<TValues> {
+  const isForm = isFormInstance(input);
+  if (!isForm && input.values !== undefined && getOwner() === null) {
+    throw new TypeError('Reactive Solid form options require an active owner');
+  }
+
+  const form = isForm ? input : createFormFromOptions(input);
+  if (!isForm && input.values !== undefined) {
+    const synchronizeValues = createExternalValuesSynchronizer(form);
+    const values = input.values;
+    const resetOptions = input.resetOptions;
+    createRenderEffect(() => {
+      synchronizeValues(values(), resetOptions);
+    });
+  }
+
   const useRegister = ((first: RegisterOptions | readonly RegisterOptions[], ...rest: readonly RegisterOptions[]) => useRegisterWithForm(form, first, ...rest)) as SolidForm<TValues>['useRegister'];
   const useField = ((options: RegisterOptions) => useFieldWithForm(form, options)) as SolidForm<TValues>['useField'];
   const useFormState = (): ReturnType<SolidForm<TValues>['useFormState']> => useFormStateWithForm(form);

--- a/packages/form/src/svelte/index.ts
+++ b/packages/form/src/svelte/index.ts
@@ -3,4 +3,5 @@ export type {
   RegisterOptions,
   SvelteFieldReturn,
   SvelteFieldSnapshot,
+  SvelteFormOptions,
 } from './types';

--- a/packages/form/src/svelte/types.ts
+++ b/packages/form/src/svelte/types.ts
@@ -3,8 +3,15 @@ import type { Readable } from 'svelte/store';
 import type { Form, FormError } from '../core/index';
 import type { FormStateSummary } from '../adapters/FormStateSummary';
 import type { RegisterOptions, SubmitHandler, SubmitInvalidHandler, SubmitValidHandler } from '../adapters/dom';
+import type { ReactiveFormOptions } from '../adapters/FormInput';
 
 export type { RegisterOptions } from '../adapters/dom';
+
+/** Svelte component가 외부 values readable과 함께 form을 만들 때 쓰는 옵션이다. */
+export type SvelteFormOptions<TValues> = ReactiveFormOptions<
+  TValues,
+  Readable<TValues | undefined>
+>;
 
 export type SvelteRegisterAction = Action<HTMLElement, RegisterOptions>;
 

--- a/packages/form/src/svelte/useForm.ts
+++ b/packages/form/src/svelte/useForm.ts
@@ -1,16 +1,34 @@
+import { onDestroy } from 'svelte';
 import { createSubmitHandler } from '../adapters/dom';
-import { createFormFromOptions, isFormInstance, type FormInput } from '../adapters/FormInput';
-import type { CreateFormOptions, Form } from '../core/index';
-import type { SvelteForm } from './types';
+import {
+  createExternalValuesSynchronizer,
+  createFormFromOptions,
+  isFormInstance,
+  type FormInput,
+} from '../adapters/FormInput';
+import type { Form } from '../core/index';
+import type { SvelteForm, SvelteFormOptions } from './types';
 import { createRegisterAction } from './RegisterAction';
 import { useFieldWithForm } from './useField';
 import { useFormStateWithForm } from './useFormState';
 
 /** Svelte action surface를 core Form 인스턴스에 바인딩한다. */
 export function useForm<TValues>(form: Form<TValues>): SvelteForm<TValues>;
-export function useForm<TValues>(options: CreateFormOptions<TValues>): SvelteForm<TValues>;
-export function useForm<TValues>(input: FormInput<TValues>): SvelteForm<TValues> {
+export function useForm<TValues>(options: SvelteFormOptions<TValues>): SvelteForm<TValues>;
+export function useForm<TValues>(input: FormInput<TValues, SvelteFormOptions<TValues>>): SvelteForm<TValues> {
   const form = isFormInstance(input) ? input : createFormFromOptions(input);
+  if (!isFormInstance(input) && input.values !== undefined) {
+    const synchronizeValues = createExternalValuesSynchronizer(form);
+    const resetOptions = input.resetOptions;
+    let unsubscribe: (() => void) | undefined;
+    onDestroy(() => {
+      unsubscribe?.();
+    });
+    unsubscribe = input.values.subscribe(values => {
+      synchronizeValues(values, resetOptions);
+    });
+  }
+
   return {
     form,
     register: createRegisterAction(form),

--- a/packages/form/src/vue/types.ts
+++ b/packages/form/src/vue/types.ts
@@ -1,6 +1,7 @@
 import type { MaybeRefOrGetter } from 'vue';
-import type { CreateFormOptions, Form, FormError, FormState, ResetOptions } from '../core/index';
+import type { Form, FormError, FormState } from '../core/index';
 import type { DomValue, RegisterOptions, SubmitHandler, SubmitInvalidHandler, SubmitValidHandler } from '../adapters/dom';
+import type { ReactiveFormOptions } from '../adapters/FormInput';
 
 export type { RegisterOptions } from '../adapters/dom';
 
@@ -8,15 +9,13 @@ export type { RegisterOptions } from '../adapters/dom';
  * Vue adapter가 form 생성 옵션에 더해 reactive external values를 받을 때 쓰는 옵션이다.
  *
  * @remarks
- * React 어댑터와 동일한 의미이지만, Vue의 반응형 모델에 맞춰 `values`를 `MaybeRefOrGetter<TValues>`로 받는다.
- * ref, computed, getter, 평면 값 모두 전달할 수 있으며 adapter는 `watch`로 참조 변화를 감지해 `form.reset()`을 호출한다.
+ * React 어댑터와 동일한 의미이지만, Vue의 반응형 모델에 맞춰 `values`를 `MaybeRefOrGetter<TValues | undefined>`로 받는다.
+ * ref, computed, getter, 평면 값 모두 전달할 수 있으며 adapter는 defined reference 변화를 감지해 `form.reset()`을 호출한다.
  */
-export type VueFormOptions<TValues> = CreateFormOptions<TValues> & {
-  /** 외부 서버/query/props 값이다. ref, computed, getter, 평면 값 모두 가능하며 값이 바뀌면 adapter가 reset을 트리거한다. */
-  values?: MaybeRefOrGetter<TValues>;
-  /** `values` 변경으로 reset할 때 적용할 상태 보존 옵션이다. */
-  resetOptions?: ResetOptions;
-};
+export type VueFormOptions<TValues> = ReactiveFormOptions<
+  TValues,
+  MaybeRefOrGetter<TValues | undefined>
+>;
 
 type VueBindingHandlers<TElement extends HTMLElement> = {
   onInput: (event: Event) => void;

--- a/packages/form/src/vue/useForm.ts
+++ b/packages/form/src/vue/useForm.ts
@@ -1,9 +1,9 @@
-import { ref, toValue, watch } from 'vue';
+import { getCurrentScope, toValue, watch } from 'vue';
 import type { MaybeRefOrGetter } from 'vue';
 
 import { createSubmitHandler } from '../adapters/dom';
-import { isFormInstance } from '../adapters/FormInput';
-import { CreateForm, type Form, type ResetOptions } from '../core/index';
+import { createExternalValuesSynchronizer, createFormFromOptions, isFormInstance } from '../adapters/FormInput';
+import type { Form, ResetOptions } from '../core/index';
 import type { RegisterOptions, VueForm, VueFormOptions } from './types';
 import { useFieldWithForm } from './useField';
 import { useFormStateWithForm } from './useFormState';
@@ -13,11 +13,16 @@ import { useRegisterWithForm } from './useRegister';
 export function useForm<TValues>(form: Form<TValues>): VueForm<TValues>;
 export function useForm<TValues>(options: VueFormOptions<TValues>): VueForm<TValues>;
 export function useForm<TValues>(input: Form<TValues> | VueFormOptions<TValues>): VueForm<TValues> {
+  const isForm = isFormInstance(input);
+  if (!isForm && input.values !== undefined && getCurrentScope() === undefined) {
+    throw new TypeError('Reactive Vue form options require an active effect scope');
+  }
+
   let form: Form<TValues>;
-  let values: MaybeRefOrGetter<TValues> | undefined;
+  let values: MaybeRefOrGetter<TValues | undefined> | undefined;
   let resetOptions: ResetOptions | undefined;
 
-  if (isFormInstance(input)) {
+  if (isForm) {
     form = input;
     values = undefined;
     resetOptions = undefined;
@@ -28,29 +33,20 @@ export function useForm<TValues>(input: Form<TValues> | VueFormOptions<TValues>)
       ...createOptions
     } = input;
 
-    form = new CreateForm(createOptions);
+    form = createFormFromOptions(createOptions);
     values = reactiveValues;
     resetOptions = reactiveResetOptions;
   }
 
   if (values !== undefined) {
-    const previousValuesRef = ref<TValues | undefined>(undefined);
+    const synchronizeValues = createExternalValuesSynchronizer(form);
 
-    const sync = (nextValues: TValues) => {
-      if (previousValuesRef.value === nextValues) {
-        return;
-      }
-
-      previousValuesRef.value = nextValues;
-      form.reset(nextValues, resetOptions);
-    };
-
-    sync(toValue(values));
+    synchronizeValues(toValue(values), resetOptions);
 
     watch(
       () => toValue(values),
       nextValues => {
-        sync(nextValues);
+        synchronizeValues(nextValues, resetOptions);
       },
     );
   }

--- a/packages/form/test/fixtures/SvelteReactiveValuesConsumer.svelte
+++ b/packages/form/test/fixtures/SvelteReactiveValuesConsumer.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { Readable } from 'svelte/store';
+
+  import type { Form, ResetOptions } from '../../src/index';
+  import { useForm } from '../../src/svelte/index';
+
+  type Values = {
+    readonly email: string;
+    readonly name: string;
+  };
+
+  let { onForm, resetOptions, values }: {
+    readonly onForm: (form: Form<Values>) => void;
+    readonly resetOptions?: ResetOptions;
+    readonly values: Readable<Values | undefined>;
+  } = $props();
+
+  const { form } = untrack(() => useForm({
+      defaultValues: { email: '', name: '' },
+      resetOptions,
+      values,
+    }));
+
+  untrack(() => onForm(form));
+</script>

--- a/packages/form/test/form-input.test.ts
+++ b/packages/form/test/form-input.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'vitest';
+
+import { createFormFromOptions } from '../src/adapters/FormInput';
+import type { ResetOptions } from '../src/index';
+
+test('Given adapter-only option getters, when a core form is created, then those options are not read or forwarded', () => {
+  type Values = { readonly email: string };
+  const options = {
+    defaultValues: { email: '' },
+    get resetOptions(): ResetOptions {
+      throw new TypeError('resetOptions crossed the adapter boundary');
+    },
+    get values(): Values {
+      throw new TypeError('values crossed the adapter boundary');
+    },
+  };
+
+  const form = createFormFromOptions(options);
+
+  expect(form.getValues()).toEqual({ email: '' });
+});

--- a/packages/form/test/react-reactive-values.test.tsx
+++ b/packages/form/test/react-reactive-values.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, expect, test } from 'vitest';
+
+import type { Form, ResetOptions } from '../src/index';
+import { useForm } from '../src/react/index';
+
+type Values = {
+  readonly email: string;
+  readonly name: string;
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+test('Given external values, when render references change, then React resets only for new defined references', async () => {
+  const first = { email: 'first@example.com', name: 'First' };
+  const second = { email: 'second@example.com', name: 'Second' };
+  let form: Form<Values> | undefined;
+
+  function Example({ resetOptions, values }: {
+    readonly resetOptions?: ResetOptions;
+    readonly values: Values | undefined;
+  }) {
+    const result = useForm({
+      defaultValues: { email: '', name: '' },
+      resetOptions,
+      values,
+    });
+    form = result.form;
+    return null;
+  }
+
+  const view = render(<Example resetOptions={{ keepDirtyValues: true }} values={first} />);
+  await waitFor(() => expect(form?.getValues()).toEqual(first));
+  if (form === undefined) throw new TypeError('React form was not created');
+
+  form.setValue('email', 'user@example.com', { source: 'user' });
+  form.setErrors('name', [{ message: 'Keep until a value-driven reset' }]);
+
+  view.rerender(<Example resetOptions={{ keepDirtyValues: false }} values={first} />);
+  expect(form.getValue('email')).toBe('user@example.com');
+  expect(form.getFieldState('name').errors).toHaveLength(1);
+
+  view.rerender(<Example resetOptions={{ keepDirtyValues: true }} values={undefined} />);
+  view.rerender(<Example resetOptions={{ keepDirtyValues: true }} values={first} />);
+  expect(form.getValue('email')).toBe('user@example.com');
+  expect(form.getFieldState('name').errors).toHaveLength(1);
+
+  view.rerender(<Example resetOptions={{ keepDirtyValues: true }} values={second} />);
+  await waitFor(() => {
+    expect(form?.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+    expect(form?.getFieldState('name').errors).toEqual([]);
+  });
+});
+
+test('Given a React values owner, when it unmounts, then later parent renders cannot reset its form', async () => {
+  const first = { email: 'first@example.com', name: 'First' };
+  const second = { email: 'second@example.com', name: 'Second' };
+  let form: Form<Values> | undefined;
+
+  function Child({ values }: { readonly values: Values }) {
+    form = useForm({ defaultValues: { email: '', name: '' }, values }).form;
+    return null;
+  }
+
+  function Parent({ active, values }: { readonly active: boolean; readonly values: Values }) {
+    return active ? <Child values={values} /> : null;
+  }
+
+  const view = render(<Parent active values={first} />);
+  await waitFor(() => expect(form?.getValues()).toEqual(first));
+  if (form === undefined) throw new TypeError('React form was not created');
+
+  view.rerender(<Parent active={false} values={second} />);
+  expect(form.getValues()).toEqual(first);
+});
+
+test('Given the same NaN render value, when only resetOptions changes, then React uses Object.is and does not reset', async () => {
+  let form: Form<number> | undefined;
+
+  function Example({ resetOptions }: { readonly resetOptions: ResetOptions }) {
+    form = useForm({ defaultValues: 0, resetOptions, values: Number.NaN }).form;
+    return null;
+  }
+
+  const view = render(<Example resetOptions={{ keepErrors: true }} />);
+  await waitFor(() => expect(form?.getValues()).toBeNaN());
+  if (form === undefined) throw new TypeError('React form was not created');
+
+  form.setErrors([], [{ message: 'Keep without a value-driven reset' }]);
+  view.rerender(<Example resetOptions={{ keepErrors: false }} />);
+
+  expect(form.getFieldState([]).errors).toHaveLength(1);
+});

--- a/packages/form/test/solid-reactive-values.test.ts
+++ b/packages/form/test/solid-reactive-values.test.ts
@@ -1,0 +1,55 @@
+import { createRoot, createSignal } from 'solid-js';
+import { expect, test } from 'vitest';
+
+import { useForm } from '../src/solid/index';
+
+type Values = {
+  readonly email: string;
+  readonly name: string;
+};
+
+test('Given a Solid values accessor, when references change, then resets follow the defined reference contract', () => {
+  const first = { email: 'first@example.com', name: 'First' };
+  const second = { email: 'second@example.com', name: 'Second' };
+  const owner = createRoot(dispose => {
+    const [values, setValues] = createSignal<Values | undefined>(first);
+    const result = useForm({
+      defaultValues: { email: '', name: '' },
+      resetOptions: { keepDirtyValues: true },
+      values,
+    });
+
+    return { dispose, form: result.form, setValues };
+  });
+
+  expect(owner.form.getValues()).toEqual(first);
+  owner.form.setValue('email', 'user@example.com', { source: 'user' });
+  owner.form.setErrors('name', [{ message: 'Keep until a value-driven reset' }]);
+
+  owner.setValues(undefined);
+  owner.setValues(first);
+  expect(owner.form.getValue('email')).toBe('user@example.com');
+  expect(owner.form.getFieldState('name').errors).toHaveLength(1);
+
+  owner.setValues(second);
+  expect(owner.form.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+  expect(owner.form.getFieldState('name').errors).toEqual([]);
+
+  owner.dispose();
+  owner.setValues({ email: 'after-dispose@example.com', name: 'After dispose' });
+  expect(owner.form.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+});
+
+test('Given reactive Solid options outside an owner, when useForm runs, then it fails before creating the form', () => {
+  let defaultValuesReads = 0;
+  const options = {
+    get defaultValues(): Values {
+      defaultValuesReads += 1;
+      return { email: '', name: '' };
+    },
+    values: () => ({ email: 'first@example.com', name: 'First' }),
+  };
+
+  expect(() => useForm(options)).toThrowError(TypeError);
+  expect(defaultValuesReads).toBe(0);
+});

--- a/packages/form/test/svelte-reactive-values.test.ts
+++ b/packages/form/test/svelte-reactive-values.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { flushSync, mount, unmount } from 'svelte';
+import type { Readable, Subscriber, Unsubscriber } from 'svelte/store';
+import { expect, test } from 'vitest';
+
+import type { Form } from '../src/index';
+import { useForm } from '../src/svelte/index';
+import SvelteReactiveValuesConsumer from './fixtures/SvelteReactiveValuesConsumer.svelte';
+
+type Values = {
+  readonly email: string;
+  readonly name: string;
+};
+
+function createManualReadable<TValue>(initialValue: TValue): {
+  readonly emit: (value: TValue) => void;
+  readonly readable: Readable<TValue>;
+  readonly subscriberCount: () => number;
+} {
+  const subscribers = new Set<Subscriber<TValue>>();
+  return {
+    emit(value) {
+      for (const subscriber of subscribers) subscriber(value);
+    },
+    readable: {
+      subscribe(run: Subscriber<TValue>): Unsubscriber {
+        subscribers.add(run);
+        run(initialValue);
+        return () => {
+          subscribers.delete(run);
+        };
+      },
+    },
+    subscriberCount: () => subscribers.size,
+  };
+}
+
+test('Given a Svelte values readable, when references change, then resets and unmount cleanup follow the contract', async () => {
+  const first = { email: 'first@example.com', name: 'First' };
+  const second = { email: 'second@example.com', name: 'Second' };
+  const source = createManualReadable<Values | undefined>(first);
+  const target = document.createElement('div');
+  let form: Form<Values> | undefined;
+  const component = mount(SvelteReactiveValuesConsumer, {
+    props: {
+      onForm(nextForm) {
+        form = nextForm;
+      },
+      resetOptions: { keepDirtyValues: true },
+      values: source.readable,
+    },
+    target,
+  });
+  flushSync();
+
+  if (form === undefined) throw new TypeError('Svelte form was not created');
+  expect(form.getValues()).toEqual(first);
+  expect(source.subscriberCount()).toBe(1);
+
+  form.setValue('email', 'user@example.com', { source: 'user' });
+  form.setErrors('name', [{ message: 'Keep until a value-driven reset' }]);
+
+  source.emit(undefined);
+  source.emit(first);
+  expect(form.getValue('email')).toBe('user@example.com');
+  expect(form.getFieldState('name').errors).toHaveLength(1);
+
+  source.emit(second);
+  expect(form.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+  expect(form.getFieldState('name').errors).toEqual([]);
+
+  await unmount(component);
+  expect(source.subscriberCount()).toBe(0);
+  source.emit({ email: 'after-unmount@example.com', name: 'After unmount' });
+  expect(form.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+});
+
+test('Given reactive Svelte options outside component initialization, when useForm fails, then it never subscribes', () => {
+  const source = createManualReadable<Values | undefined>({
+    email: 'first@example.com',
+    name: 'First',
+  });
+
+  expect(() => useForm({
+    defaultValues: { email: '', name: '' },
+    values: source.readable,
+  })).toThrow();
+  expect(source.subscriberCount()).toBe(0);
+});

--- a/packages/form/test/vue-reactive-values.test.ts
+++ b/packages/form/test/vue-reactive-values.test.ts
@@ -1,0 +1,63 @@
+import { effectScope, nextTick, shallowRef } from 'vue';
+import { expect, test } from 'vitest';
+
+import type { Form } from '../src/index';
+import { useForm } from '../src/vue/index';
+
+type Values = {
+  readonly email: string;
+  readonly name: string;
+};
+
+test('Given a Vue values source, when references change, then resets follow the defined reference contract', async () => {
+  const first = { email: 'first@example.com', name: 'First' };
+  const second = { email: 'second@example.com', name: 'Second' };
+  const values = shallowRef<Values | undefined>(first);
+  const scope = effectScope();
+  let form: Form<Values> | undefined;
+
+  scope.run(() => {
+    form = useForm({
+      defaultValues: { email: '', name: '' },
+      resetOptions: { keepDirtyValues: true },
+      values,
+    }).form;
+  });
+  if (form === undefined) throw new TypeError('Vue form was not created');
+  expect(form.getValues()).toEqual(first);
+
+  form.setValue('email', 'user@example.com', { source: 'user' });
+  form.setErrors('name', [{ message: 'Keep until a value-driven reset' }]);
+
+  values.value = undefined;
+  await nextTick();
+  values.value = first;
+  await nextTick();
+  expect(form.getValue('email')).toBe('user@example.com');
+  expect(form.getFieldState('name').errors).toHaveLength(1);
+
+  values.value = second;
+  await nextTick();
+  expect(form.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+  expect(form.getFieldState('name').errors).toEqual([]);
+
+  scope.stop();
+  values.value = { email: 'after-stop@example.com', name: 'After stop' };
+  await nextTick();
+  expect(form.getValues()).toEqual({ email: 'user@example.com', name: 'Second' });
+});
+
+test('Given reactive Vue options outside an effect scope, when useForm runs, then it fails before creating the form', () => {
+  let defaultValuesReads = 0;
+  const values = shallowRef<Values | undefined>({ email: 'first@example.com', name: 'First' });
+  const options = {
+    get defaultValues(): Values {
+      defaultValuesReads += 1;
+      return { email: '', name: '' };
+    },
+    values,
+  };
+
+  expect(() => useForm(options)).toThrowError(TypeError);
+  expect(defaultValuesReads).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add a shared `Object.is` external-values synchronizer that retains the last defined reference while `undefined` pauses synchronization
- support framework-native sources for React render values, Vue `MaybeRefOrGetter`, Solid `Accessor`, and Svelte `Readable` with lifecycle-owned cleanup
- keep `resetOptions` value-driven, preserve `useForm(existingForm)`, and prevent adapter-only options from reaching `CreateForm`
- export and pack-verify all four adapter option types, with bilingual package and integration documentation

## Verification
- `git diff --check`
- `pnpm --filter @ilokesto/form typecheck`
- `pnpm --filter @ilokesto/form test` (18 files, 117 tests)
- `pnpm --filter @ilokesto/form build`
- `pnpm --filter @ilokesto/form test:pack`
- `pnpm build`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:monorepo` (15 tests)
- `pnpm changeset:status`

Closes #8