### PR TITLE
feat(fetcher): add OpenAPI-aware typed HEAD support

### DIFF
--- a/.changeset/fetcher-openapi-typed-head.md
+++ b/.changeset/fetcher-openapi-typed-head.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/fetcher": minor
+---
+
+Add OpenAPI-aware typed HEAD shortcuts while keeping OPTIONS on the callable client surface.

--- a/packages/fetcher/README.ko.md
+++ b/packages/fetcher/README.ko.md
@@ -185,9 +185,14 @@ await api('/users/{id}', {
   path: { id: '42' },
   searchParams: { include: 'profile' },
 }).json();
+
+await api('/users/{id}', {
+  method: 'OPTIONS',
+  path: { id: '42' },
+}).json();
 ```
 
-이 분리는 v1에서 의도된 설계입니다. shortcut method는 grouped OSS request contract를 따르고, callable surface는 plain `ky`에 더 가깝게 남겨둡니다.
+이 분리는 v1에서 의도된 설계입니다. shortcut method는 grouped OSS request contract를 따르고, callable surface는 plain `ky`에 더 가깝게 남겨둡니다. OpenAPI `OPTIONS` operation은 이 callable 형태로 타입을 지원하며, `api.options()` shortcut은 의도적으로 제공하지 않습니다.
 
 ## `safe` surface
 
@@ -246,6 +251,8 @@ type SafeResult<Data, Error = unknown> =
 - `create()`, `extend()`, hooks, `prefixUrl`, custom `fetch`, `HTTPError`, timeout 동작, lazy body parsing은 계속 ky semantics를 따릅니다.
 - 공개 엔트리포인트 경로는 `@ilokesto/fetcher`, `@ilokesto/fetcher/core`, `@ilokesto/fetcher/openapi`로 유지됩니다.
 - typed shortcut method는 이 문서의 grouped request contract를 사용합니다.
+- `head`는 OpenAPI-aware path, parameter, metadata, 선언된 response inference를 추가하면서 실제 실행은 `ky.head`에 위임합니다.
+- `OPTIONS`는 `api(path, { method: 'OPTIONS' })` callable 형태로만 제공하며 `api.options`를 추가하지 않습니다.
 - 예전 flat shortcut alias는 unknown 또는 untyped call을 위한 runtime-only compatibility로만 남습니다.
 
 ### Path interpolation
@@ -322,6 +329,8 @@ options.context.openapi = {
 };
 ```
 
+typed `head` request는 `method: 'head'`를 기록합니다. shortcut은 일반 ky lazy `ResponsePromise`를 반환하며, fetcher는 HEAD response body를 파싱하거나 존재한다고 가정하지 않습니다.
+
 ## 응답 추론
 
 `.json()` 추론은 결정적입니다.
@@ -355,11 +364,11 @@ createFetcher<Paths>(instance: KyInstance)
 typed client는 `ky` 동작을 유지하면서 다음을 추가합니다.
 
 - typed callable request
-- `get`, `post`, `put`, `patch`, `delete`용 typed shortcut method
-- callable과 위 shortcut method를 비추는 `safe`
+- `get`, `post`, `put`, `patch`, `delete`, `head`용 typed shortcut method
+- callable과 body를 다루는 shortcut method를 비추되 `head`는 제외하는 `safe`
 - 타입을 유지하는 `create()`와 `extend()` 반환값
 
-`head`는 v1에서 의도적으로 plain `ky` surface에 남아 있습니다. 런타임에서는 사용 가능하지만, 다른 method처럼 OpenAPI shortcut typing은 붙지 않습니다.
+`head`는 선언된 HEAD route에 grouped OpenAPI typing을 추가하면서, untyped URL에서는 ky 호환 two-argument options를 유지합니다. `safe`는 JSON을 파싱하지만 HEAD는 response body를 전제하지 않으므로 `safe.head`는 의도적으로 제공하지 않습니다. `OPTIONS`는 callable surface에서만 타입을 지원하며 `api.options()` shortcut은 추가하지 않습니다.
 
 ### 공개 OpenAPI 타입
 
@@ -474,11 +483,12 @@ pnpm build
 pnpm test:dist
 ```
 
-`pnpm test:dist`는 `pnpm build` 이후에 실행해야 합니다. 이 명령은 root, core, OpenAPI 엔트리포인트 사이의 strict `createFetcher` identity를 포함해 빌드된 패키지 surface를 검증합니다. CI는 패키지 engine 요구사항과 맞는 Node 22에서 이 검증을 실행합니다.
+`pnpm test:dist`는 `pnpm build` 이후에 실행해야 합니다. 이 명령은 root, core, OpenAPI 엔트리포인트 사이의 strict `createFetcher` identity를 포함해 빌드된 패키지 surface를 검증한 뒤 tarball을 pack하고, 임시 consumer에서 typed HEAD/callable OPTIONS 계약과 HEAD 런타임 동작을 확인합니다. CI는 패키지 engine 요구사항과 맞는 Node 22에서 이 검증을 실행합니다.
 
 ## 현재 한계
 
-- `head`는 v1에서 plain `ky` typing에 남아 있습니다
+- `OPTIONS`는 callable-only이며 `api.options()` shortcut이 없습니다
+- HEAD는 response body를 전제하지 않으므로 `safe.head`를 의도적으로 제공하지 않습니다
 - `params.cookie`는 type-only이며 의도적으로 직렬화되지 않습니다
 - 응답 추론은 `200`, `201`, `204`, `default`만 고려합니다
 - 이 패키지는 자동 auth 또는 cookie 관리를 약속하지 않습니다

--- a/packages/fetcher/README.md
+++ b/packages/fetcher/README.md
@@ -185,9 +185,14 @@ await api('/users/{id}', {
   path: { id: '42' },
   searchParams: { include: 'profile' },
 }).json();
+
+await api('/users/{id}', {
+  method: 'OPTIONS',
+  path: { id: '42' },
+}).json();
 ```
 
-That split is intentional in v1. Shortcut methods use the grouped OSS request contract. The callable surface stays close to plain `ky`.
+That split is intentional in v1. Shortcut methods use the grouped OSS request contract. The callable surface stays close to plain `ky`. OpenAPI `OPTIONS` operations are typed through this callable form; there is intentionally no `api.options()` shortcut.
 
 ## `safe` surface
 
@@ -246,6 +251,8 @@ The runtime stays intentionally small: it prepares OpenAPI-shaped requests and t
 - `create()`, `extend()`, hooks, `prefixUrl`, custom `fetch`, `HTTPError`, timeout behavior, and lazy body parsing keep following ky semantics.
 - Public entrypoint paths stay `@ilokesto/fetcher`, `@ilokesto/fetcher/core`, and `@ilokesto/fetcher/openapi`.
 - Typed shortcut methods use the grouped request contract documented here.
+- `head` adds OpenAPI-aware path, parameter, metadata, and declared response inference while delegating to `ky.head`.
+- `OPTIONS` remains available only through `api(path, { method: 'OPTIONS' })`; `api.options` is not added.
 - Legacy flat shortcut aliases remain runtime-only compatibility for unknown or untyped calls.
 
 ### Path interpolation
@@ -322,6 +329,8 @@ options.context.openapi = {
 };
 ```
 
+Typed `head` requests emit `method: 'head'`. The shortcut returns the normal lazy ky `ResponsePromise`; fetcher does not parse or otherwise assume a HEAD response body.
+
 ## Response inference
 
 `.json()` inference is deterministic.
@@ -355,11 +364,11 @@ createFetcher<Paths>(instance: KyInstance)
 The typed client keeps `ky` behavior while adding:
 
 - typed callable requests
-- typed shortcut methods for `get`, `post`, `put`, `patch`, and `delete`
-- `safe` mirrors for the callable and those shortcut methods
+- typed shortcut methods for `get`, `post`, `put`, `patch`, `delete`, and `head`
+- `safe` mirrors for the callable and body-bearing shortcut methods, excluding `head`
 - typed `create()` and `extend()` return values
 
-`head` intentionally remains on the plain `ky` surface in v1. It is available at runtime, but it does not get the OpenAPI shortcut typing that the other methods have.
+`head` keeps ky-compatible two-argument options for untyped URLs while adding grouped OpenAPI typing for declared HEAD routes. It is intentionally absent from `safe`, because `safe` parses JSON and HEAD does not imply a response body. `OPTIONS` remains typed on the callable surface and does not add an `api.options()` shortcut.
 
 ### Public OpenAPI types
 
@@ -474,11 +483,12 @@ pnpm build
 pnpm test:dist
 ```
 
-`pnpm test:dist` must run after `pnpm build`. It verifies the built package surface, including strict `createFetcher` identity across the root, core, and OpenAPI entrypoints. CI runs these checks on Node 22, which matches the package engine requirement.
+`pnpm test:dist` must run after `pnpm build`. It verifies the built package surface, including strict `createFetcher` identity across the root, core, and OpenAPI entrypoints, then packs a tarball and checks typed HEAD/callable OPTIONS contracts plus HEAD runtime behavior from a temporary consumer. CI runs these checks on Node 22, which matches the package engine requirement.
 
 ## Current limitations
 
-- `head` remains plain `ky` typing in v1
+- `OPTIONS` is callable-only and has no `api.options()` shortcut
+- `safe.head` is intentionally unavailable because HEAD does not imply a response body
 - `params.cookie` is type-only and intentionally not serialized
 - response inference only considers `200`, `201`, `204`, and `default`
 - this package does not claim automatic auth or cookie management

--- a/packages/fetcher/scripts/verify-dist.mjs
+++ b/packages/fetcher/scripts/verify-dist.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { verifyPackedDist } from './verify-packed-dist.mjs';
 
 const root = await import('../dist/index.js');
 const core = await import('../dist/core.js');
@@ -16,7 +17,6 @@ assert.equal(
 );
 
 const seenRequests = [];
-
 const api = root.createFetcher({
   prefixUrl: 'https://example.com/api',
   fetch: async (input) => {
@@ -47,3 +47,5 @@ const payload = await api
 assert.deepEqual(payload, { id: '42', role: 'member' });
 assert.equal(seenRequests[0]?.url, 'https://example.com/api/users/42');
 assert.equal(seenRequests[0]?.method, 'GET');
+
+verifyPackedDist();

--- a/packages/fetcher/scripts/verify-packed-dist.mjs
+++ b/packages/fetcher/scripts/verify-packed-dist.mjs
@@ -1,0 +1,238 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDirectory = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export const verifyPackedDist = () => {
+  const consumerDirectory = mkdtempSync(join(tmpdir(), 'ilokesto-fetcher-dist-'));
+
+  try {
+    execFileSync('pnpm', ['pack', '--pack-destination', consumerDirectory], {
+      cwd: packageDirectory,
+      stdio: 'pipe',
+    });
+
+    const archiveName = readdirSync(consumerDirectory).find((name) => name.endsWith('.tgz'));
+    assert.ok(archiveName, 'pnpm pack must produce a package archive');
+
+    const consumerNodeModules = join(consumerDirectory, 'node_modules');
+    const packedPackageDirectory = join(consumerNodeModules, '@ilokesto/fetcher');
+    mkdirSync(packedPackageDirectory, { recursive: true });
+    execFileSync(
+      'tar',
+      ['-xzf', join(consumerDirectory, archiveName), '-C', packedPackageDirectory, '--strip-components=1'],
+      {
+        cwd: consumerDirectory,
+        stdio: 'pipe',
+      },
+    );
+    symlinkSync(join(packageDirectory, 'node_modules/ky'), join(consumerNodeModules, 'ky'), 'dir');
+    writeFileSync(join(consumerDirectory, 'package.json'), JSON.stringify({ private: true, type: 'module' }));
+
+    execFileSync(process.execPath, ['-e', "import('@ilokesto/fetcher')"], {
+      cwd: consumerDirectory,
+      stdio: 'pipe',
+    });
+
+    writeFileSync(
+      join(consumerDirectory, 'contract.ts'),
+      `import { createFetcher, type Fetcher, type OpenApiRequest } from '@ilokesto/fetcher';
+import type { Options } from 'ky';
+
+export type Paths = {
+  readonly '/resources/{resourceId}': {
+    readonly head: {
+      readonly parameters: {
+        readonly path: { readonly resourceId: string };
+        readonly query: { readonly revision: number };
+        readonly header: { readonly 'x-tenant-id': string };
+        readonly cookie: { readonly session: string };
+      };
+      readonly responses: {
+        readonly 200: {
+          readonly content: {
+            readonly 'application/json': { readonly revision: string };
+          };
+        };
+      };
+    };
+  };
+  readonly '/capabilities/{resourceId}': {
+    readonly options: {
+      readonly parameters: {
+        readonly path: { readonly resourceId: string };
+        readonly query: { readonly verbose: boolean };
+        readonly header: { readonly 'x-capability-token': string };
+        readonly cookie: { readonly session: string };
+      };
+      readonly responses: {
+        readonly 200: {
+          readonly content: {
+            readonly 'application/json': { readonly methods: readonly string[] };
+          };
+        };
+      };
+    };
+  };
+};
+
+type ExpectFalse<Value extends false> = Value;
+type MissingPath = {
+  readonly params: {
+    readonly query: { readonly revision: number };
+    readonly cookie: { readonly session: string };
+  };
+  readonly headers: { readonly 'x-tenant-id': string };
+};
+type HeadRequest = OpenApiRequest<Paths, '/resources/{resourceId}', 'head'>;
+
+const api = createFetcher<Paths>();
+const headResponse = api.head('/resources/{resourceId}', {
+  params: {
+    path: { resourceId: 'resource-1' },
+    query: { revision: 7 },
+    cookie: { session: 'session-1' },
+  },
+  headers: { 'x-tenant-id': 'tenant-1' },
+});
+const optionsResponse = api('/capabilities/{resourceId}', {
+  method: 'OPTIONS',
+  path: { resourceId: 'resource-1' },
+  searchParams: { verbose: true },
+  headers: { 'x-capability-token': 'capability-token' },
+  cookie: { session: 'session-1' },
+});
+
+const headBody: Promise<{ readonly revision: string }> = headResponse.json();
+const optionsBody: Promise<{ readonly methods: readonly string[] }> = optionsResponse.json();
+const missingPathRejected: ExpectFalse<MissingPath extends HeadRequest ? true : false> = false;
+const noOptionsShortcut: ExpectFalse<'options' extends keyof Fetcher<Paths> ? true : false> = false;
+const noSafeHead: ExpectFalse<'head' extends keyof Fetcher<Paths>['safe'] ? true : false> = false;
+
+api.head('/health', {
+  headers: { authorization: 'Bearer token' },
+  searchParams: { probe: 'ready' },
+} satisfies Options);
+
+void [headBody, optionsBody, missingPathRejected, noOptionsShortcut, noSafeHead];
+`,
+    );
+
+    const typecheckArguments = (fileName) => [
+      join(packageDirectory, 'node_modules/typescript/bin/tsc'),
+      '--noEmit',
+      '--strict',
+      '--target',
+      'ESNext',
+      '--module',
+      'NodeNext',
+      '--moduleResolution',
+      'NodeNext',
+      '--skipLibCheck',
+      join(consumerDirectory, fileName),
+    ];
+    const runTypecheck = (fileName) =>
+      execFileSync(process.execPath, typecheckArguments(fileName), {
+        cwd: consumerDirectory,
+        stdio: fileName === 'contract.ts' ? 'inherit' : 'pipe',
+      });
+    const assertTypecheckFails = (fileName) => {
+      const result = spawnSync(process.execPath, typecheckArguments(fileName), {
+        cwd: consumerDirectory,
+        encoding: 'utf8',
+      });
+
+      assert.notEqual(result.status, 0, `${fileName} must fail typechecking`);
+      assert.match(
+        `${result.stdout}${result.stderr}`,
+        /No overload matches this call[\s\S]*NonStringInput/,
+        `${fileName} must fail without reaching the raw string fallback`,
+      );
+    };
+
+    runTypecheck('contract.ts');
+
+    writeFileSync(
+      join(consumerDirectory, 'missing-options-path.ts'),
+      `import { createFetcher } from '@ilokesto/fetcher';
+import type { Paths } from './contract.js';
+
+const api = createFetcher<Paths>();
+api('/capabilities/{resourceId}', {
+  method: 'OPTIONS',
+  searchParams: { verbose: true },
+  headers: { 'x-capability-token': 'capability-token' },
+  cookie: { session: 'session-1' },
+});
+`,
+    );
+    writeFileSync(
+      join(consumerDirectory, 'missing-options-query.ts'),
+      `import { createFetcher } from '@ilokesto/fetcher';
+import type { Paths } from './contract.js';
+
+const api = createFetcher<Paths>();
+api('/capabilities/{resourceId}', {
+  method: 'OPTIONS',
+  path: { resourceId: 'resource-1' },
+  headers: { 'x-capability-token': 'capability-token' },
+  cookie: { session: 'session-1' },
+});
+`,
+    );
+
+    assertTypecheckFails('missing-options-path.ts');
+    assertTypecheckFails('missing-options-query.ts');
+
+    writeFileSync(
+      join(consumerDirectory, 'runtime.mjs'),
+      `import assert from 'node:assert/strict';
+import { createFetcher } from '@ilokesto/fetcher';
+
+const seenRequests = [];
+const seenContexts = [];
+const api = createFetcher({
+  prefixUrl: 'https://example.com/api',
+  hooks: {
+    beforeRequest: [(_request, options) => seenContexts.push(options.context.openapi)],
+  },
+  fetch: async (input) => {
+    const request = input instanceof Request ? input : new Request(input);
+    seenRequests.push({ method: request.method, url: request.url });
+    return new Response(null, { status: 204 });
+  },
+});
+
+const response = await api.head('/resources/{resourceId}', {
+  params: {
+    path: { resourceId: 'resource-1' },
+    query: { revision: 7 },
+    cookie: { session: 'session-1' },
+  },
+  headers: { 'x-tenant-id': 'tenant-1' },
+});
+
+assert.equal(response.status, 204);
+assert.equal(response.bodyUsed, false);
+assert.deepEqual(seenRequests, [
+  { method: 'HEAD', url: 'https://example.com/api/resources/resource-1?revision=7' },
+]);
+assert.deepEqual(seenContexts, [
+  { method: 'head', pathTemplate: '/resources/{resourceId}' },
+]);
+assert.equal('options' in api, false);
+assert.equal('head' in api.safe, false);
+`,
+    );
+    execFileSync(process.execPath, [join(consumerDirectory, 'runtime.mjs')], {
+      cwd: consumerDirectory,
+      stdio: 'pipe',
+    });
+  } finally {
+    rmSync(consumerDirectory, { recursive: true, force: true });
+  }
+};

--- a/packages/fetcher/src/core/createFetcher.ts
+++ b/packages/fetcher/src/core/createFetcher.ts
@@ -9,8 +9,8 @@ import {
 } from '../internal/runtime';
 import type { PathsLike, SafeResult, Fetcher } from '../openapi/types';
 
-type ShortcutMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head';
-type SafeShortcutMethod = Exclude<ShortcutMethod, 'head'>;
+type ShortcutMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
+type SafeShortcutMethod = ShortcutMethod;
 type SafeResponse<Json = unknown> = Awaited<ResponsePromise<Json>>;
 
 const executeKyCall = <Result>(
@@ -175,20 +175,11 @@ const prepareShortcutRequest = ({
   });
 };
 
-const bindShortcutMethod = (instance: KyInstance, method: ShortcutMethod): Fetcher<PathsLike>[ShortcutMethod] => {
+const bindShortcutMethod = <Paths extends PathsLike, Method extends ShortcutMethod>(
+  instance: KyInstance,
+  method: Method,
+): Fetcher<Paths>[Method] => {
   return ((input: Input, request?: unknown, options?: Options) => {
-    if (method === 'head') {
-      const preparedRequest = prepareKyRequest({
-        input,
-        method: 'head',
-        options: request as Options | undefined,
-      });
-
-      return executeKyCall(preparedRequest.input, preparedRequest.options, (nextInput, nextOptions) =>
-        instance.head(nextInput, nextOptions),
-      );
-    }
-
     const preparedRequest = prepareShortcutRequest({
       input,
       method,
@@ -199,7 +190,25 @@ const bindShortcutMethod = (instance: KyInstance, method: ShortcutMethod): Fetch
     return executeKyCall(preparedRequest.input, preparedRequest.options, (nextInput, nextOptions) =>
       instance[method](nextInput, nextOptions),
     );
-  }) as Fetcher<PathsLike>[ShortcutMethod];
+  }) as Fetcher<Paths>[Method];
+};
+
+const bindHeadMethod = <Paths extends PathsLike>(instance: KyInstance): Fetcher<Paths>['head'] => {
+  return ((input: Input, request?: unknown, options?: Options) => {
+    const usesGroupedRequest = isObjectRecord(request) && ('params' in request || options !== undefined);
+    const runtimeOptions = usesGroupedRequest
+      ? normalizeGroupedRequestOptions({ request: toGroupedRequest(request), options })
+      : (request as Options | undefined);
+    const preparedRequest = prepareKyRequest({
+      input,
+      method: 'head',
+      options: runtimeOptions,
+    });
+
+    return executeKyCall(preparedRequest.input, preparedRequest.options, (nextInput, nextOptions) =>
+      instance.head(nextInput, nextOptions),
+    );
+  }) as Fetcher<Paths>['head'];
 };
 
 const bindSafeShortcutMethod = <Paths extends PathsLike, Method extends SafeShortcutMethod>(
@@ -255,12 +264,12 @@ const decorateKyInstance = <Paths extends PathsLike>(instance: KyInstance): Fetc
   fetcher.safe.patch = bindSafeShortcutMethod<Paths, 'patch'>(instance, 'patch');
   fetcher.safe.delete = bindSafeShortcutMethod<Paths, 'delete'>(instance, 'delete');
 
-  fetcher.get = bindShortcutMethod(instance, 'get') as Fetcher<Paths>['get'];
-  fetcher.post = bindShortcutMethod(instance, 'post') as Fetcher<Paths>['post'];
-  fetcher.put = bindShortcutMethod(instance, 'put') as Fetcher<Paths>['put'];
-  fetcher.patch = bindShortcutMethod(instance, 'patch') as Fetcher<Paths>['patch'];
-  fetcher.delete = bindShortcutMethod(instance, 'delete') as Fetcher<Paths>['delete'];
-  fetcher.head = bindShortcutMethod(instance, 'head') as Fetcher<Paths>['head'];
+  fetcher.get = bindShortcutMethod<Paths, 'get'>(instance, 'get');
+  fetcher.post = bindShortcutMethod<Paths, 'post'>(instance, 'post');
+  fetcher.put = bindShortcutMethod<Paths, 'put'>(instance, 'put');
+  fetcher.patch = bindShortcutMethod<Paths, 'patch'>(instance, 'patch');
+  fetcher.delete = bindShortcutMethod<Paths, 'delete'>(instance, 'delete');
+  fetcher.head = bindHeadMethod<Paths>(instance);
   Object.defineProperty(fetcher, 'stop', {
     value: instance.stop,
     enumerable: true,

--- a/packages/fetcher/src/createFetcher.head.test.ts
+++ b/packages/fetcher/src/createFetcher.head.test.ts
@@ -1,0 +1,69 @@
+import ky from 'ky';
+import { describe, expect, it, vi } from 'vitest';
+import { createFetcher } from './openapi';
+import type { HeadPaths } from './test-fixtures/head';
+
+describe('createFetcher HEAD shortcut', () => {
+  it('delegates typed HEAD requests to ky.head with head metadata and no body parsing', async () => {
+    const seenContexts: Array<Record<string, unknown>> = [];
+    const instance = ky.create({
+      prefixUrl: 'https://example.com/api',
+      hooks: {
+        beforeRequest: [
+          (_request, options) => {
+            seenContexts.push(options.context.openapi as Record<string, unknown>);
+          },
+        ],
+      },
+      fetch: async () => new Response(null, { status: 204 }),
+    });
+    const headSpy = vi.spyOn(instance, 'head');
+    const api = createFetcher<HeadPaths>(instance);
+
+    const response = await api.head('/resources/{resourceId}', {
+      params: {
+        path: { resourceId: 'resource-1' },
+        query: { revision: 7 },
+        cookie: { session: 'session-1' },
+      },
+      headers: { 'x-tenant-id': 'tenant-1' },
+    });
+
+    expect(response.status).toBe(204);
+    expect(headSpy).toHaveBeenCalled();
+    expect(seenContexts).toEqual([
+      {
+        method: 'head',
+        pathTemplate: '/resources/{resourceId}',
+      },
+    ]);
+  });
+
+  it('preserves two-argument ky options for untyped HEAD URLs', async () => {
+    const seenRequests: Array<{ readonly url: string; readonly authorization: string | null }> = [];
+    const api = createFetcher<HeadPaths>({
+      prefixUrl: 'https://example.com/api',
+      fetch: async (input) => {
+        const request = input instanceof Request ? input : new Request(input);
+        seenRequests.push({
+          url: request.url,
+          authorization: request.headers.get('authorization'),
+        });
+
+        return new Response(null, { status: 204 });
+      },
+    });
+
+    await api.head('/health', {
+      headers: { authorization: 'Bearer token' },
+      searchParams: { probe: 'ready' },
+    });
+
+    expect(seenRequests).toEqual([
+      {
+        url: 'https://example.com/api/health?probe=ready',
+        authorization: 'Bearer token',
+      },
+    ]);
+  });
+});

--- a/packages/fetcher/src/createFetcher.prefixUrl.test.ts
+++ b/packages/fetcher/src/createFetcher.prefixUrl.test.ts
@@ -157,7 +157,7 @@ describe('createFetcher prefixUrl behavior', () => {
   it('does not retry no-prefix invalid URL behavior', () => {
     const api = createFetcher<ApiPaths>();
 
-    expect(() => api('/posts')).toThrow(/Invalid URL|Failed to parse URL/);
+    expect(() => api('/unknown')).toThrow(/Invalid URL|Failed to parse URL/);
   });
 
   it('does not retry non-string URL or Request inputs with prefixUrl', async () => {
@@ -208,8 +208,8 @@ describe('createFetcher prefixUrl behavior', () => {
     }) as unknown as KyInstance;
     const api = createFetcher<ApiPaths>(throwingInstance);
 
-    expect(() => api('/posts')).toThrow(thrownError);
-    expect(seenInputs).toEqual(['/posts']);
+    expect(() => api('/unknown')).toThrow(thrownError);
+    expect(seenInputs).toEqual(['/unknown']);
   });
 
   it('does not retry absolute URL strings or rewrite normalized relative inputs', async () => {

--- a/packages/fetcher/src/createFetcher.type-contract.test.ts
+++ b/packages/fetcher/src/createFetcher.type-contract.test.ts
@@ -1,8 +1,9 @@
 import { describe, it } from 'vitest';
 import type { Fetcher } from './openapi';
+import { assertTypedHeadAndCallableOptions, type HeadPaths } from './test-fixtures/head';
 import {
   assertBarrelImportContinuity,
-  assertHeadStaysOnPlainKyTyping,
+  assertUntypedHeadKeepsKyTyping,
   assertMergePathsTyping,
   assertNoTypedOptionsShortcut,
   assertReadmeQuickStartSnippet,
@@ -21,10 +22,13 @@ describe('createFetcher type contracts', () => {
       assertTypedShortcutUrlOptionFoundations(api);
       assertUnknownShortcutUrlOptionFallback(api);
       assertNoTypedOptionsShortcut(api);
-      assertHeadStaysOnPlainKyTyping(api);
+      assertUntypedHeadKeepsKyTyping(api);
       assertBarrelImportContinuity();
       assertReadmeQuickStartSnippet();
       assertSafeSurfaceTyping(api);
+
+      const headApi = undefined as unknown as Fetcher<HeadPaths>;
+      assertTypedHeadAndCallableOptions(headApi);
     }
   });
 });

--- a/packages/fetcher/src/internal/runtime.ts
+++ b/packages/fetcher/src/internal/runtime.ts
@@ -13,6 +13,7 @@ type RuntimeContext = Record<string, unknown> & {
 
 type RuntimeOptions = Options & {
   path?: Record<string, PathParameterValue>;
+  cookie?: Record<string, unknown>;
   context?: RuntimeContext;
 };
 
@@ -350,6 +351,7 @@ export const prepareKyRequest = ({
   }
 
   delete runtimeOptions.path;
+  delete runtimeOptions.cookie;
 
   runtimeOptions.context = {
     ...runtimeOptions.context,

--- a/packages/fetcher/src/openapi/fetcher.ts
+++ b/packages/fetcher/src/openapi/fetcher.ts
@@ -156,6 +156,18 @@ export type OpenApiOptions<
       HasMeaningfulKeys<QueryParameters<OperationFor<Paths, Path, Method>>>
     > &
     MaybeProperty<
+      'headers',
+      HeaderParameters<OperationFor<Paths, Path, Method>>,
+      HeaderParametersRequired<OperationFor<Paths, Path, Method>>,
+      HasMeaningfulKeys<HeaderParameters<OperationFor<Paths, Path, Method>>>
+    > &
+    MaybeProperty<
+      'cookie',
+      CookieParameters<OperationFor<Paths, Path, Method>>,
+      CookieParametersRequired<OperationFor<Paths, Path, Method>>,
+      HasMeaningfulKeys<CookieParameters<OperationFor<Paths, Path, Method>>>
+    > &
+    MaybeProperty<
       'json',
       JsonRequestBody<OperationFor<Paths, Path, Method>>,
       JsonRequestBodyRequired<OperationFor<Paths, Path, Method>>,
@@ -188,6 +200,10 @@ type UntypedShortcutPath<
   Url extends string,
 > = Url extends PathKeysWithMethod<Paths, Method> ? never : Url;
 
+type UntypedCallablePath<Paths extends PathsLike, Url extends string> = Url extends PathKey<Paths>
+  ? never
+  : Url;
+
 type WideShortcutMethodArguments<
   Paths extends PathsLike,
   Method extends string,
@@ -197,6 +213,17 @@ type WideShortcutMethodArguments<
   request: WideShortcutRequest,
   options?: ShortcutRequestOptions<Url, Method>,
 ];
+
+type TypedHeadMethod<Paths extends PathsLike> = {
+  <Path extends PathKeysWithMethod<Paths, 'head'>>(
+    ...args: TypedShortcutArguments<Paths, Path, 'head'>
+  ): ResponsePromise<InferJson<Paths, Path, 'head'>>;
+  <Url extends string>(
+    url: UntypedShortcutPath<Paths, 'head', Url>,
+    options?: Options,
+  ): ResponsePromise;
+  (url: NonStringInput, options?: Options): ResponsePromise;
+};
 
 type TypedGetArguments<Paths extends PathsLike, Path extends PathKey<Paths>> = HasRequiredKeys<
   OpenApiOptions<Paths, Path, 'get'>
@@ -226,7 +253,7 @@ type TypedShortcutMethod<Paths extends PathsLike, Method extends ShortcutMethod>
   <Path extends PathKeysWithMethod<Paths, Method>>(
     ...args: TypedShortcutArguments<Paths, Path, Method>
   ): ResponsePromise<InferJson<Paths, Path, Method>>;
-  <Url extends string, Json = unknown>(
+  <const Url extends string, Json = unknown>(
     ...args: WideShortcutMethodArguments<Paths, Method, Url>
   ): ResponsePromise<Json>;
   <Json = unknown>(url: NonStringInput, options?: Options): ResponsePromise<Json>;
@@ -236,7 +263,7 @@ type SafeTypedShortcutMethod<Paths extends PathsLike, Method extends ShortcutMet
   <Path extends PathKeysWithMethod<Paths, Method>>(
     ...args: TypedShortcutArguments<Paths, Path, Method>
   ): Promise<SafeResult<InferJson<Paths, Path, Method>>>;
-  <Url extends string, Json = unknown>(
+  <const Url extends string, Json = unknown>(
     ...args: WideShortcutMethodArguments<Paths, Method, Url>
   ): Promise<SafeResult<Json>>;
   <Json = unknown>(url: NonStringInput, options?: Options): Promise<SafeResult<Json>>;
@@ -249,7 +276,11 @@ type TypedCallable<Paths extends PathsLike> = {
   <Path extends PathKey<Paths>, Method extends MethodKeysForPath<Paths, Path>>(
     ...args: DirectCallArguments<Paths, Path, Method>
   ): ResponsePromise<InferJson<Paths, Path, Method>>;
-  <Json = unknown>(url: Input, options?: Options): ResponsePromise<Json>;
+  <Url extends string, Json = unknown>(
+    url: UntypedCallablePath<Paths, Url>,
+    options?: Options,
+  ): ResponsePromise<Json>;
+  <Json = unknown>(url: NonStringInput, options?: Options): ResponsePromise<Json>;
 };
 
 type SafeTypedCallable<Paths extends PathsLike> = {
@@ -259,7 +290,11 @@ type SafeTypedCallable<Paths extends PathsLike> = {
   <Path extends PathKey<Paths>, Method extends MethodKeysForPath<Paths, Path>>(
     ...args: DirectCallArguments<Paths, Path, Method>
   ): Promise<SafeResult<InferJson<Paths, Path, Method>>>;
-  <Json = unknown>(url: Input, options?: Options): Promise<SafeResult<Json>>;
+  <Url extends string, Json = unknown>(
+    url: UntypedCallablePath<Paths, Url>,
+    options?: Options,
+  ): Promise<SafeResult<Json>>;
+  <Json = unknown>(url: NonStringInput, options?: Options): Promise<SafeResult<Json>>;
 };
 
 type FetcherSafe<Paths extends PathsLike> = SafeTypedCallable<Paths> & {
@@ -271,14 +306,14 @@ type FetcherSafe<Paths extends PathsLike> = SafeTypedCallable<Paths> & {
 };
 
 export type Fetcher<Paths extends PathsLike> = TypedCallable<Paths> &
-  Omit<KyInstance, 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'create' | 'extend'> & {
+  Pick<KyInstance, 'retry' | 'stop'> & {
     safe: FetcherSafe<Paths>;
     get: TypedShortcutMethod<Paths, 'get'>;
     post: TypedShortcutMethod<Paths, 'post'>;
     put: TypedShortcutMethod<Paths, 'put'>;
     patch: TypedShortcutMethod<Paths, 'patch'>;
     delete: TypedShortcutMethod<Paths, 'delete'>;
-    head: KyInstance['head'];
+    head: TypedHeadMethod<Paths>;
     create(defaultOptions?: Options): Fetcher<Paths>;
     extend(defaultOptions: Parameters<KyInstance['extend']>[0]): Fetcher<Paths>;
   };

--- a/packages/fetcher/src/openapi/shared.ts
+++ b/packages/fetcher/src/openapi/shared.ts
@@ -9,8 +9,8 @@ export type OpenApiHttpMethod =
 
 export type PathsLike = Record<string, Partial<Record<OpenApiHttpMethod, unknown>>>;
 
-export type ShortcutMethod = 'get' | 'post' | 'put' | 'patch' | 'delete';
-export type CallableMethod = ShortcutMethod | 'head';
+export type ShortcutMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head';
+export type CallableMethod = ShortcutMethod | 'options';
 export type PathKey<Paths extends PathsLike> = Extract<keyof Paths, string>;
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
 export type DistributiveSimplify<T> = T extends unknown ? Simplify<T> : never;

--- a/packages/fetcher/src/test-fixtures/createFetcher.ts
+++ b/packages/fetcher/src/test-fixtures/createFetcher.ts
@@ -643,7 +643,7 @@ export const assertNoTypedOptionsShortcut = (api: Fetcher<ApiPaths>) => {
   );
 };
 
-export const assertHeadStaysOnPlainKyTyping = (api: Fetcher<ApiPaths>) => {
+export const assertUntypedHeadKeepsKyTyping = (api: Fetcher<ApiPaths>) => {
   api.head('/health', {
     headers: {
       authorization: 'Bearer token',

--- a/packages/fetcher/src/test-fixtures/head.ts
+++ b/packages/fetcher/src/test-fixtures/head.ts
@@ -1,0 +1,144 @@
+import { expectTypeOf } from 'vitest';
+import type { Options } from 'ky';
+import type { Fetcher, OpenApiOptions, OpenApiRequest } from '../openapi';
+
+type HeadResponse = {
+  readonly available: true;
+  readonly revision: string;
+};
+
+export type HeadPaths = {
+  readonly '/resources/{resourceId}': {
+    readonly head: {
+      readonly parameters: {
+        readonly path: {
+          readonly resourceId: string;
+        };
+        readonly query: {
+          readonly revision: number;
+        };
+        readonly header: {
+          readonly 'x-tenant-id': string;
+        };
+        readonly cookie: {
+          readonly session: string;
+        };
+      };
+      readonly responses: {
+        readonly 200: {
+          readonly content: {
+            readonly 'application/json': HeadResponse;
+          };
+        };
+      };
+    };
+  };
+  readonly '/capabilities/{resourceId}': {
+    readonly options: {
+      readonly parameters: {
+        readonly path: {
+          readonly resourceId: string;
+        };
+        readonly query: {
+          readonly verbose: boolean;
+        };
+        readonly header: {
+          readonly 'x-capability-token': string;
+        };
+        readonly cookie: {
+          readonly session: string;
+        };
+      };
+      readonly responses: {
+        readonly 200: {
+          readonly content: {
+            readonly 'application/json': {
+              readonly methods: readonly ['GET', 'HEAD', 'OPTIONS'];
+            };
+          };
+        };
+      };
+    };
+  };
+};
+
+type HeadRequest = OpenApiRequest<HeadPaths, '/resources/{resourceId}', 'head'>;
+type OptionsRequest = OpenApiOptions<HeadPaths, '/capabilities/{resourceId}', 'options'>;
+
+export const assertTypedHeadAndCallableOptions = (api: Fetcher<HeadPaths>) => {
+  const headResponse = api.head('/resources/{resourceId}', {
+    params: {
+      path: { resourceId: 'resource-1' },
+      query: { revision: 7 },
+      cookie: { session: 'session-1' },
+    },
+    headers: { 'x-tenant-id': 'tenant-1' },
+  });
+  const optionsResponse = api('/capabilities/{resourceId}', {
+    method: 'OPTIONS',
+    path: { resourceId: 'resource-1' },
+    searchParams: { verbose: true },
+    headers: { 'x-capability-token': 'capability-token' },
+    cookie: { session: 'session-1' },
+  });
+  const unknownResponse = api('/unknown', {
+    headers: { authorization: 'Bearer token' },
+    searchParams: { probe: 'ready' },
+  });
+
+  expectTypeOf(headResponse.json()).toEqualTypeOf<Promise<HeadResponse>>();
+  expectTypeOf(optionsResponse.json()).toEqualTypeOf<
+    Promise<{ readonly methods: readonly ['GET', 'HEAD', 'OPTIONS'] }>
+  >();
+  expectTypeOf(unknownResponse.json()).toEqualTypeOf<Promise<unknown>>();
+
+  expectTypeOf<{
+    readonly method: 'OPTIONS';
+    readonly searchParams: { readonly verbose: boolean };
+    readonly headers: { readonly 'x-capability-token': string };
+    readonly cookie: { readonly session: string };
+  }>().not.toMatchTypeOf<OptionsRequest>();
+  expectTypeOf<{
+    readonly method: 'OPTIONS';
+    readonly path: { readonly resourceId: string };
+    readonly headers: { readonly 'x-capability-token': string };
+    readonly cookie: { readonly session: string };
+  }>().not.toMatchTypeOf<OptionsRequest>();
+
+  expectTypeOf<{
+    readonly params: {
+      readonly query: { readonly revision: number };
+      readonly cookie: { readonly session: string };
+    };
+    readonly headers: { readonly 'x-tenant-id': string };
+  }>().not.toMatchTypeOf<HeadRequest>();
+  expectTypeOf<{
+    readonly params: {
+      readonly path: { readonly resourceId: string };
+      readonly cookie: { readonly session: string };
+    };
+    readonly headers: { readonly 'x-tenant-id': string };
+  }>().not.toMatchTypeOf<HeadRequest>();
+  expectTypeOf<{
+    readonly params: {
+      readonly path: { readonly resourceId: string };
+      readonly query: { readonly revision: number };
+      readonly cookie: { readonly session: string };
+    };
+  }>().not.toMatchTypeOf<HeadRequest>();
+  expectTypeOf<{
+    readonly params: {
+      readonly path: { readonly resourceId: string };
+      readonly query: { readonly revision: number };
+    };
+    readonly headers: { readonly 'x-tenant-id': string };
+  }>().not.toMatchTypeOf<HeadRequest>();
+
+  api.head('/health', {
+    headers: { authorization: 'Bearer token' },
+    searchParams: { probe: 'ready' },
+  } satisfies Options);
+
+  expectTypeOf<'options' extends keyof Fetcher<HeadPaths> ? true : false>().toEqualTypeOf<false>();
+  expectTypeOf<'head' extends keyof Fetcher<HeadPaths>['safe'] ? true : false>().toEqualTypeOf<false>();
+};


### PR DESCRIPTION
## Summary

- add OpenAPI-aware typed `head` requests that delegate to `ky.head` and emit `head` hook metadata without assuming a response body
- keep OpenAPI `OPTIONS` callable-only while enforcing required path, query, header, and cookie contracts on known paths
- preserve ky-compatible unknown URL fallback and verify packed runtime/type behavior, including negative OPTIONS contracts
- document the English and Korean API contract and add a minor changeset
- exclude generated `packages/fetcher/dist/**` artifacts from the PR

## Verification

- `GIT_MASTER=1 git diff --check origin/main...HEAD`
- `pnpm --filter @ilokesto/fetcher typecheck`
- `pnpm --filter @ilokesto/fetcher test` (6 files, 34 tests passed)
- `pnpm --filter @ilokesto/fetcher build`
- `pnpm --filter @ilokesto/fetcher test:dist`
- `pnpm build`
- `pnpm test:monorepo` (15 tests passed)
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status` (`@ilokesto/fetcher` minor)

Closes #13