### PR TITLE
fix(state): safely reuse reducer Stores

### DIFF
--- a/.changeset/state-existing-store-reducer-5.md
+++ b/.changeset/state-existing-store-reducer-5.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Safely reuse an existing Store across reducer adapters by installing one reducer middleware for the same reducer identity and rejecting conflicting reducer registrations before mutation.

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -187,6 +187,12 @@ const counter = create<CounterState, CounterAction>(
 
 React는 튜플을 반환하고, Vue는 `{ state, dispatch }`, Angular는 `{ state, dispatch }`, Svelte는 `dispatch`가 포함된 readable store를 반환하며, Solid는 `{ state, dispatch }`를 반환합니다.
 
+### 기존 Store 재사용
+
+두 번째 인자로 기존 `Store`를 전달하면 프레임워크 어댑터와 직접 Store 쓰기가 하나의 상태 스냅샷을 공유합니다. 같은 Store를 정확히 동일한 reducer 함수 참조와 함께 다시 사용해도 안전합니다. `@ilokesto/state`는 reducer middleware를 한 번만 설치하며, dispatch마다 reducer를 한 번 호출한 결과를 모든 어댑터가 관찰합니다.
+
+하나의 Store에는 하나의 reducer 식별자만 등록할 수 있습니다. 같은 Store에 다른 reducer 함수를 등록하면 middleware나 상태를 변경하기 전에 `TypeError: Cannot register a different reducer for the same Store.`를 동기적으로 throw합니다. 직접 호출한 `store.setState(...)`는 기존과 동일하게 일반 Store 업데이트로 동작하며 reducer를 호출하지 않습니다.
+
 ## 프레임워크 생명주기 밖에서 읽기 및 쓰기
 
 ```ts

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -189,6 +189,12 @@ const counter = create<CounterState, CounterAction>(
 
 React returns tuples, Vue returns `{ state, dispatch }`, Angular returns `{ state, dispatch }`, Svelte returns a readable store with `dispatch`, and Solid returns `{ state, dispatch }`.
 
+### Reusing an Existing Store
+
+Pass an existing `Store` as the second argument to share one state snapshot across framework adapters and direct Store writes. Reusing that Store with the exact same reducer function reference is idempotent: `@ilokesto/state` installs reducer middleware once, and every adapter observes the result of one reducer call per dispatch.
+
+A Store can have only one reducer identity. Registering a different reducer function on the same Store throws synchronously with `TypeError: Cannot register a different reducer for the same Store.` before middleware or state is changed. Direct `store.setState(...)` writes remain plain Store updates and do not invoke the reducer.
+
 ## Read and Write Outside Framework Lifecycles
 
 ```ts

--- a/packages/state/src/lib/getStore.ts
+++ b/packages/state/src/lib/getStore.ts
@@ -4,6 +4,8 @@ import type { ReduceFn, ReducerAction } from '../types/ReduceFn.js';
 
 type StoreSetStateAction<T> = Parameters<Store<T>['setState']>[0];
 
+const reducerByStore = new WeakMap<object, object>();
+
 const isStore = <T>(initialValue: T | Store<T>): initialValue is Store<T> => {
   return initialValue instanceof Store;
 };
@@ -22,6 +24,16 @@ export const getStore = <T, Action extends ReducerAction>(
   const store = isStore(initState) ? initState : new Store(initState);
 
   if (reduceFn) {
+    const registeredReducer = reducerByStore.get(store);
+
+    if (registeredReducer !== undefined) {
+      if (registeredReducer !== reduceFn) {
+        throw new TypeError('Cannot register a different reducer for the same Store.');
+      }
+
+      return store;
+    }
+
     store.unshiftMiddleware((nextState: StoreSetStateAction<T>, next) => {
       if (!isStoreAction<T, Action>(store, nextState)) {
         next(nextState);
@@ -31,6 +43,7 @@ export const getStore = <T, Action extends ReducerAction>(
       const currentState = store.getState();
       next(reduceFn(currentState, nextState));
     });
+    reducerByStore.set(store, reduceFn);
   }
 
   return store;

--- a/packages/state/test/framework-adapters.test.ts
+++ b/packages/state/test/framework-adapters.test.ts
@@ -185,6 +185,27 @@ describe('framework create() lifecycle-free contracts', () => {
         expect(store.getState()).toEqual({ count: 8, label: 'external' });
         expect(adapter.readOnly()).toBe(store.getState());
       });
+
+      test('Given one Store and reducer identity, When two adapters reuse them and one dispatches, Then both observe one reducer result', () => {
+        // Given
+        const store = new Store<CounterState>(initialState);
+        let reducerCalls = 0;
+        const reducer = (state: CounterState, action: CounterAction): CounterState => {
+          reducerCalls += 1;
+          return counterReducer(state, action);
+        };
+        const firstAdapter = framework.createReducer(reducer, store);
+        const secondAdapter = framework.createReducer(reducer, store);
+
+        // When
+        secondAdapter.writeOnly()({ type: 'increment' });
+
+        // Then
+        expect(reducerCalls).toBe(1);
+        expect(store.getState()).toEqual({ count: 2, label: 'initial' });
+        expect(firstAdapter.readOnly()).toBe(store.getState());
+        expect(secondAdapter.readOnly()).toBe(store.getState());
+      });
     });
   }
 });

--- a/packages/state/test/get-store.test.ts
+++ b/packages/state/test/get-store.test.ts
@@ -1,7 +1,8 @@
-import { expect, test } from 'bun:test';
+import { expect, spyOn, test } from 'bun:test';
 import { Store } from '@ilokesto/store';
 
 import { create as createSvelteStore } from '../src/core/Svelte';
+import { dispatchStoreAction } from '../src/lib/actionMetadata';
 import { getStore } from '../src/lib/getStore';
 import type { ReduceFn } from '../src/types/ReduceFn';
 
@@ -73,4 +74,58 @@ test('Given reducer-backed state with a string type field, when it is replaced d
   // Then
   expect(store.getState()).toEqual(replacement);
   expect(reducerActions).toEqual([]);
+});
+
+test('Given one Store and one reducer identity, when getStore registers it twice and dispatches once, then the reducer runs once', () => {
+  // Given
+  type IdentityStateAction = Readonly<{ type: 'increment'; count: number }>;
+  const store = new Store<IdentityStateAction>({ type: 'increment', count: 1 });
+  const middlewareSpy = spyOn(store, 'unshiftMiddleware');
+  let reducerCalls = 0;
+  const reducer: ReduceFn<IdentityStateAction, IdentityStateAction> = (_state, action) => {
+    reducerCalls += 1;
+    return action;
+  };
+  getStore(store, reducer);
+  getStore(store, reducer);
+
+  // When
+  dispatchStoreAction(store, { type: 'increment', count: 3 });
+
+  // Then
+  expect(reducerCalls).toBe(1);
+  expect(middlewareSpy).toHaveBeenCalledTimes(1);
+  expect(store.getState()).toEqual({ type: 'increment', count: 3 });
+  middlewareSpy.mockRestore();
+});
+
+test('Given a Store with a reducer, when a different reducer identity is registered, then it throws before changing reducer behavior or state', () => {
+  // Given
+  const initialState: TypedState = { type: 'ready', count: 1 };
+  const store = new Store<TypedState>(initialState);
+  let firstReducerCalls = 0;
+  let conflictingReducerCalls = 0;
+  const firstReducer: ReduceFn<TypedState, IncrementAction> = (state, action) => {
+    firstReducerCalls += 1;
+    return { ...state, count: state.count + action.amount };
+  };
+  const conflictingReducer: ReduceFn<TypedState, IncrementAction> = (state, action) => {
+    conflictingReducerCalls += 1;
+    return { ...state, count: state.count + action.amount * 10 };
+  };
+  getStore(store, firstReducer);
+
+  // When
+  const registerConflictingReducer = () => getStore(store, conflictingReducer);
+
+  // Then
+  expect(registerConflictingReducer).toThrow(
+    new TypeError('Cannot register a different reducer for the same Store.'),
+  );
+  expect(store.getState()).toBe(initialState);
+
+  dispatchStoreAction(store, { type: 'increment', amount: 2 });
+  expect(firstReducerCalls).toBe(1);
+  expect(conflictingReducerCalls).toBe(0);
+  expect(store.getState()).toEqual({ type: 'ready', count: 3 });
 });


### PR DESCRIPTION
## Summary

- keep reducer registration private to `@ilokesto/state` with a Store-keyed `WeakMap`
- make repeated registration of the same reducer function identity idempotent
- reject a different reducer identity synchronously with the stable `TypeError: Cannot register a different reducer for the same Store.` contract before middleware or state mutation
- preserve direct Store writes, action metadata, plain/fresh adapters, and shared behavior across React, Vue, Angular, Solid, and Svelte
- document the contract in English and Korean and add an `@ilokesto/state` patch changeset

Closes #5

## Red Before

```text
$ bun test test/get-store.test.ts test/framework-adapters.test.ts
22 pass, 2 fail

Expected reducer calls: 1
Received: 2

Expected: TypeError("Cannot register a different reducer for the same Store.")
Received: function did not throw
```

The duplicate-execution fixture intentionally returns the dispatched action object, proving that stacked reducer middleware can invoke the same reducer twice.

## Green After

```text
$ bun test test/get-store.test.ts test/framework-adapters.test.ts
24 pass, 0 fail, 92 expect() calls

$ pnpm --filter @ilokesto/state test
178 pass, 0 fail, 869 expect() calls
```

The five-framework matrix creates two reducer adapters over one Store and reducer identity, dispatches once, and verifies one reducer call plus one shared result for every adapter.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @ilokesto/state typecheck`
- `pnpm --filter @ilokesto/state test`
- `pnpm --filter @ilokesto/state test:typecheck`
- `pnpm --filter @ilokesto/state build`
- built-module driver: shared reuse, exact conflict rejection, and direct Store writes passed
- `pnpm build`
- `pnpm test:monorepo` (15 passed)
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status`
- `git diff --check origin/main...HEAD`

All commands completed successfully. Root `pnpm test` was run in isolation after the monorepo verification command to avoid concurrent build-artifact cleanup.

## Release

- `.changeset/state-existing-store-reducer-5.md`
- `@ilokesto/state`: patch
