### PR TITLE
fix(overlay): diagnose missing adapters

### DIFF
--- a/.changeset/overlay-missing-adapter-diagnostics.md
+++ b/.changeset/overlay-missing-adapter-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/overlay": patch
+---
+
+Report missing overlay adapters once per mounted item in development while keeping production and item lifecycle behavior unchanged.

--- a/packages/overlay/docs/core-concepts.ko.mdx
+++ b/packages/overlay/docs/core-concepts.ko.mdx
@@ -17,7 +17,7 @@ description: "provider 범위, overlay item, 어댑터, close/remove lifecycle�
 
 ## 어댑터 registry와 host
 
-`OverlayHost`는 `useOverlayItems()`로 현재 item 목록을 구독하고, 각 item을 `adapters[item.type]`으로 렌더링합니다. 어댑터가 없으면 해당 item은 렌더링되지 않습니다. 따라서 어댑터 등록은 애플리케이션 경계입니다. 런타임은 어떤 overlay 계열도 host할 수 있지만, 각 계열은 자신의 렌더링과 동작을 제공해야 합니다.
+`OverlayHost`는 `useOverlayItems()`로 현재 item 목록을 구독하고, 각 item을 `adapters[item.type]`으로 렌더링합니다. 어댑터가 없으면 해당 item은 렌더링되지 않습니다. 개발 환경에서는 마운트된 item identity마다 `id`와 `type`을 포함한 오류 진단을 한 번 출력하고, production에서는 아무 진단도 출력하지 않습니다. host가 item을 자동으로 resolve, reject, remove하지 않으므로 item은 store에 남고 promise도 pending 상태를 유지합니다. 따라서 어댑터 등록은 애플리케이션 경계입니다. 런타임은 어떤 overlay 계열도 host할 수 있지만, 각 계열은 자신의 렌더링과 동작을 제공해야 합니다.
 
 ## close와 remove
 

--- a/packages/overlay/docs/core-concepts.mdx
+++ b/packages/overlay/docs/core-concepts.mdx
@@ -17,7 +17,7 @@ Each `OverlayItem` has `id`, `type`, `props`, `status`, `createdAt`, and an opti
 
 ## Adapter registry and host
 
-`OverlayHost` subscribes to the current items through `useOverlayItems()` and renders each item with `adapters[item.type]`. If an adapter is missing, the item renders nothing. That makes adapter registration an application boundary: the runtime can host any overlay family, but each family must provide its own rendering and behavior.
+`OverlayHost` subscribes to the current items through `useOverlayItems()` and renders each item with `adapters[item.type]`. If an adapter is missing, the item renders nothing. Development emits one error diagnostic per mounted item identity with its `id` and `type`, while production remains silent. The item stays in the store and its promise remains pending because the host does not settle or remove it automatically. That makes adapter registration an application boundary: the runtime can host any overlay family, but each family must provide its own rendering and behavior.
 
 ## close vs remove
 

--- a/packages/overlay/docs/reference/overlay-host.ko.mdx
+++ b/packages/overlay/docs/reference/overlay-host.ko.mdx
@@ -19,7 +19,7 @@ const renderProps = {
 return <Adapter {...renderProps} {...item.props} />;
 ```
 
-보통 `OverlayProvider`가 host를 포함하므로 직접 마운트할 필요는 없습니다. custom provider shell을 만들거나 알 수 없는 type의 item이 왜 아무것도 렌더링하지 않는지 이해해야 할 때 이 문서를 보세요. 등록되지 않은 어댑터는 앱 전체를 깨뜨리지 않도록 렌더링 시점에 의도적으로 무시됩니다.
+보통 `OverlayProvider`가 host를 포함하므로 직접 마운트할 필요는 없습니다. custom provider shell을 만들거나 알 수 없는 type의 item이 왜 아무것도 렌더링하지 않는지 이해해야 할 때 이 문서를 보세요. 어댑터가 없으면 `null`을 렌더링합니다. 개발 환경에서는 마운트된 item identity마다 item의 `id`와 `type`을 포함한 오류 진단을 한 번 출력하고, production에서는 아무 진단도 출력하지 않습니다. host는 item을 자동으로 resolve, reject, remove하지 않으므로 애플리케이션 코드가 명시적으로 remove 또는 clear할 때까지 item은 store에 남고 `display()` promise도 pending 상태를 유지합니다.
 
 ## 실무 메모
 

--- a/packages/overlay/docs/reference/overlay-host.mdx
+++ b/packages/overlay/docs/reference/overlay-host.mdx
@@ -19,7 +19,7 @@ const renderProps = {
 return <Adapter {...renderProps} {...item.props} />;
 ```
 
-You usually do not mount `OverlayHost` yourself because `OverlayProvider` includes it. Read this page when you build a custom provider shell or need to understand why an item with an unknown type renders nothing. Missing adapters are intentionally ignored at render time rather than crashing the whole app.
+You usually do not mount `OverlayHost` yourself because `OverlayProvider` includes it. Read this page when you build a custom provider shell or need to understand why an item with an unknown type renders nothing. A missing adapter renders `null`. In development, the host emits one error diagnostic per mounted item identity with the item's `id` and `type`; production stays silent. The host does not resolve, reject, or remove the item automatically, so it remains in the store and a `display()` promise remains pending until application code explicitly removes or clears it.
 
 ## Practical note
 

--- a/packages/overlay/docs/troubleshooting.ko.mdx
+++ b/packages/overlay/docs/troubleshooting.ko.mdx
@@ -11,7 +11,7 @@ description: "provider, 어댑터, lifecycle, 비동기 결과에서 자주 생�
 
 ## `display()` 후 아무것도 렌더링되지 않음
 
-`display` 또는 `open`에 넘긴 `type`을 확인하세요. `OverlayHost`는 `adapters[item.type]`을 찾습니다. 그 key에 맞는 어댑터가 없으면 item은 아무것도 렌더링하지 않습니다. `OverlayProvider`가 기대한 adapter map을 받고 있는지도 확인하세요.
+`display` 또는 `open`에 넘긴 `type`을 확인하세요. `OverlayHost`는 `adapters[item.type]`을 찾습니다. 그 key에 맞는 어댑터가 없으면 item은 아무것도 렌더링하지 않고, 개발 환경에서는 마운트된 해당 item의 `id`와 `type`을 포함한 오류 진단을 한 번 출력합니다. production에서는 아무 진단도 출력하지 않습니다. host는 어댑터가 없는 item을 자동으로 resolve, reject, remove하지 않으므로 item은 store에 남고 `display()` promise도 pending 상태를 유지합니다. `OverlayProvider`가 기대한 adapter map을 받고 있는지도 확인하세요.
 
 ## promise가 끝나지 않음
 

--- a/packages/overlay/docs/troubleshooting.mdx
+++ b/packages/overlay/docs/troubleshooting.mdx
@@ -11,7 +11,7 @@ description: "Common mistakes around providers, adapters, lifecycle, and async r
 
 ## Nothing renders after `display()`
 
-Check the `type` passed to `display` or `open`. `OverlayHost` looks up `adapters[item.type]`. If no adapter exists for that key, the item renders nothing. Also confirm that `OverlayProvider` receives the adapter map you expect.
+Check the `type` passed to `display` or `open`. `OverlayHost` looks up `adapters[item.type]`. If no adapter exists for that key, the item renders nothing and development emits one error diagnostic for that mounted item with its `id` and `type`. Production stays silent. The item remains in the store and any `display()` promise stays pending because the host never resolves, rejects, or removes missing-adapter items automatically. Also confirm that `OverlayProvider` receives the adapter map you expect.
 
 ## The promise never resolves
 

--- a/packages/overlay/src/core/OverlayHost.missing-adapter.test.tsx
+++ b/packages/overlay/src/core/OverlayHost.missing-adapter.test.tsx
@@ -1,0 +1,134 @@
+import { StrictMode } from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createOverlayContext } from "./createOverlayContext";
+import { createOverlayStore } from "./createOverlayStore";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("missing overlay adapters", () => {
+  it("reports a development diagnostic once per mounted item identity", () => {
+    // Given
+    vi.stubEnv("NODE_ENV", "development");
+    const diagnostic = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const context = createOverlayContext();
+    const store = createOverlayStore();
+    store.open({ id: "missing-item", type: "missing-type" });
+
+    // When
+    const view = render(
+      <StrictMode>
+        <context.Provider adapters={{}} store={store}>
+          <div />
+        </context.Provider>
+      </StrictMode>
+    );
+    view.rerender(
+      <StrictMode>
+        <context.Provider adapters={{}} store={store}>
+          <div />
+        </context.Provider>
+      </StrictMode>
+    );
+    act(() => {
+      store.close("missing-item");
+    });
+
+    // Then
+    expect(diagnostic).toHaveBeenCalledTimes(1);
+    expect(diagnostic.mock.calls[0]?.[1]).toEqual({
+      id: "missing-item",
+      type: "missing-type",
+    });
+  });
+
+  it("reports each new missing item", () => {
+    // Given
+    vi.stubEnv("NODE_ENV", "development");
+    const diagnostic = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const context = createOverlayContext();
+    const store = createOverlayStore();
+    render(<context.Provider adapters={{}} store={store}>{null}</context.Provider>);
+
+    // When
+    act(() => {
+      store.open({ id: "first-item", type: "first-type" });
+    });
+    act(() => {
+      store.open({ id: "second-item", type: "second-type" });
+    });
+
+    // Then
+    expect(diagnostic).toHaveBeenCalledTimes(2);
+    expect(diagnostic.mock.calls.map((call) => call[1])).toEqual([
+      { id: "first-item", type: "first-type" },
+      { id: "second-item", type: "second-type" },
+    ]);
+  });
+
+  it("reports an item again when the same id is removed and remounted", () => {
+    // Given
+    vi.stubEnv("NODE_ENV", "development");
+    const diagnostic = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const context = createOverlayContext();
+    const store = createOverlayStore();
+    render(<context.Provider adapters={{}} store={store}>{null}</context.Provider>);
+
+    // When
+    act(() => {
+      store.open({ id: "reused-item", type: "missing-type" });
+    });
+    act(() => {
+      store.remove("reused-item");
+    });
+    act(() => {
+      store.open({ id: "reused-item", type: "missing-type" });
+    });
+
+    // Then
+    expect(diagnostic).toHaveBeenCalledTimes(2);
+    expect(diagnostic.mock.calls.map((call) => call[1])).toEqual([
+      { id: "reused-item", type: "missing-type" },
+      { id: "reused-item", type: "missing-type" },
+    ]);
+  });
+
+  it.each(["production", "staging"])(
+    "stays silent and leaves a missing item pending in %s",
+    async (nodeEnv) => {
+      // Given
+      vi.stubEnv("NODE_ENV", nodeEnv);
+      const diagnostic = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const resolved = vi.fn();
+      const rejected = vi.fn();
+      const context = createOverlayContext();
+      const store = createOverlayStore();
+      const request = store.open({ id: "production-item", type: "missing-type" });
+      void request.promise.then(resolved, rejected);
+
+      // When
+      const { container } = render(
+        <context.Provider adapters={{}} store={store}>{null}</context.Provider>
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Then
+      expect(diagnostic).not.toHaveBeenCalled();
+      expect(container).toBeEmptyDOMElement();
+      expect(store.getSnapshot()).toEqual([
+        expect.objectContaining({
+          id: "production-item",
+          status: "open",
+          type: "missing-type",
+        }),
+      ]);
+      expect(resolved).not.toHaveBeenCalled();
+      expect(rejected).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/packages/overlay/src/core/OverlayHost.tsx
+++ b/packages/overlay/src/core/OverlayHost.tsx
@@ -20,6 +20,7 @@ function OverlayItemRenderer({
   const Adapter = adapters[item.type];
   const hooksRef = useRef<OverlayAdapterHooks | null>(null);
   const prevStatusRef = useRef<"open" | "closing" | "mounted">("mounted");
+  const missingAdapterReportedRef = useRef(false);
 
   const close = useCallback(
     (result?: unknown) => {
@@ -68,6 +69,23 @@ function OverlayItemRenderer({
       runPhase("onUnmount", item.id, item);
     };
   }, [item.id]);
+
+  useEffect(() => {
+    if (
+      typeof process === "undefined" ||
+      process.env.NODE_ENV !== "development" ||
+      Adapter ||
+      missingAdapterReportedRef.current
+    ) {
+      return;
+    }
+
+    missingAdapterReportedRef.current = true;
+    console.error("[@ilokesto/overlay] Missing adapter", {
+      id: item.id,
+      type: item.type,
+    });
+  }, [Adapter, item.id, item.type]);
 
   if (!Adapter) {
     return null;


### PR DESCRIPTION
## Summary

- emit one effect-driven missing-adapter diagnostic per mounted overlay item identity in development
- keep production and other non-development environments silent without changing null rendering or lifecycle settlement
- document the contract in English and Korean and add an `@ilokesto/overlay` patch changeset

## Behavior

The diagnostic uses the existing `console.error` channel and includes structured `id` and `type` fields. A renderer-local ref deduplicates StrictMode effect replay, provider rerenders, and status transitions. Removing and remounting an item, including reuse of the same id, creates a new identity and reports again. Missing items remain rendered as `null`, stay in the store, and leave `display()` promises pending until application code explicitly removes or clears them. Registered adapter lifecycle and plugin ordering are unchanged.

## TDD evidence

### Red before runtime change

`pnpm --filter @ilokesto/overlay exec vitest run src/core/OverlayHost.missing-adapter.test.tsx`

- 2 failed, 1 passed
- both development cases failed because `console.error` was called 0 times

A follow-up staging case also failed red before tightening the environment guard:

- 1 failed, 4 passed
- staging incorrectly emitted one diagnostic

### Green after runtime change

- focused missing-adapter suite: 5 passed
- host lifecycle/plugin/context regression set: 20 passed
- complete overlay suite: 63 passed
- public package-surface driver: passed StrictMode dedupe, structured id/type, null render, closing item retention, and pending promise assertions

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter @ilokesto/overlay typecheck`
- `pnpm --filter @ilokesto/overlay test`
- `pnpm --filter @ilokesto/overlay build`
- `pnpm build`
- `pnpm test:monorepo` (15 passed)
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status`
- `GIT_MASTER=1 git diff --check origin/main...HEAD`

All gates exited 0. The overlay suite emits the existing expected outside-provider error output from its assertion test, without failures.

## Release and docs note

Release PR #1 remains open and untouched. `DOCS_SYNC_TOKEN` is absent in this environment, so the future overlay docs-sync workflow may fail until that repository secret is available; this PR does not configure or modify secrets.

Closes #9