### PR TITLE
fix(utilinent): move Slacker retries out of render

### DIFF
--- a/.changeset/utilinent-slacker-effect-retries.md
+++ b/.changeset/utilinent-slacker-effect-retries.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/utilinent": patch
+---
+
+Move Slacker loading and retries out of render with deterministic shared retry ownership and stale-work cancellation.

--- a/packages/utilinent/docs/reference/slacker.ko.mdx
+++ b/packages/utilinent/docs/reference/slacker.ko.mdx
@@ -33,6 +33,12 @@ import { Slacker } from '@ilokesto/utilinent';
 | `maxRetries`, `retryDelay` | optional automatic retry behavior입니다. |
 | `onError` | loader error와 함께 호출됩니다. |
 
+## Retry lifecycle
+
+첫 intersection으로 시작하는 load가 첫 번째 attempt입니다. `maxRetries`는 최초 attempt 이후에 허용할 추가 attempt 수이며, 각 automatic retry 전에 `retryDelay`가 적용됩니다. `errorFallback`이 제공하는 `retry` function은 automatic retry와 같은 retry budget을 사용하고 즉시 시작하며, 대기 중인 automatic retry를 취소합니다.
+
+한 번에 하나의 attempt만 실행되므로 request가 진행 중일 때 반복해서 retry를 눌러도 하나로 합쳐집니다. 활성 상태에서 실패한 각 attempt는 `onError`를 한 번 호출합니다. Load가 성공하거나 `loader` reference가 바뀌거나 component가 unmount되면 예약된 retry가 취소되고 오래된 loader 결과는 무시됩니다.
+
 ## Guidance
 
 Component 안에서 `loader`를 선언한다면 `useCallback`으로 안정적으로 유지하세요. Loader가 매번 바뀌면 작업이 다시 시작될 수 있습니다. Below-the-fold panel, 비싼 recommendation, visible해질 때까지 load하지 않아도 되는 optional UI에 적합합니다.

--- a/packages/utilinent/docs/reference/slacker.mdx
+++ b/packages/utilinent/docs/reference/slacker.mdx
@@ -33,6 +33,12 @@ import { Slacker } from '@ilokesto/utilinent';
 | `maxRetries`, `retryDelay` | Optional automatic retry behavior. |
 | `onError` | Called with loader errors. |
 
+## Retry lifecycle
+
+The load triggered by the first intersection is attempt one. `maxRetries` is the number of additional attempts available after that initial attempt, and `retryDelay` is applied before each automatic retry. The `retry` function from `errorFallback` uses the same retry budget as automatic retries, starts immediately, and cancels any automatic retry that is waiting.
+
+Only one attempt can run at a time, so repeated retry clicks while a request is in flight are coalesced. Each failed active attempt calls `onError` once. A successful load, a new `loader` reference, or unmounting cancels scheduled retries and ignores stale loader results.
+
 ## Guidance
 
 Keep `loader` stable with `useCallback` when it is declared inside a component. A changing loader can cause work to restart. Use `Slacker` for below-the-fold panels, expensive recommendations, or optional UI that should not load until visible.

--- a/packages/utilinent/src/components/Slacker/index.tsx
+++ b/packages/utilinent/src/components/Slacker/index.tsx
@@ -1,6 +1,14 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Observer } from "../Observer";
-import { SlackerProps } from "./types";
+import type { SlackerProps } from "./types";
+
+type LoadState<T> =
+  | { readonly status: "idle" }
+  | { readonly status: "loading" }
+  | { readonly status: "error"; readonly error: Error }
+  | { readonly status: "success"; readonly data: T };
+
+const IDLE_STATE = { status: "idle" } as const;
 
 export function Slacker<T = any>({
   children,
@@ -13,69 +21,156 @@ export function Slacker<T = any>({
   maxRetries = 0,
   retryDelay = 1000,
 }: SlackerProps<T>) {
-  const [loadedData, setLoadedData] = useState<T | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-  const [retryCount, setRetryCount] = useState(0);
+  const [loadState, setLoadState] = useState<LoadState<T>>(IDLE_STATE);
+  const activeRef = useRef(false);
+  const activatedRef = useRef(false);
+  const generationRef = useRef(0);
+  const inFlightRef = useRef(false);
+  const retriesUsedRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loaderRef = useRef(loader);
+  const onErrorRef = useRef(onError);
+  const maxRetriesRef = useRef(maxRetries);
+  const retryDelayRef = useRef(retryDelay);
+  const runAttemptRef = useRef<(() => void) | null>(null);
 
-  const load = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const data = await loader();
-      setLoadedData(data);
-      setRetryCount(0); // 성공 시 재시도 카운트 리셋
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      setError(error);
-      console.error('Slacker loader failed:', error);
-      onError?.(error);
-    } finally {
-      setIsLoading(false);
+  const invalidate = useCallback(() => {
+    generationRef.current += 1;
+    inFlightRef.current = false;
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
     }
-  }, [loader, onError]);
+  }, []);
 
-  const retry = useCallback(async () => {
-    if (retryCount < maxRetries) {
-      setRetryCount(prev => prev + 1);
-      if (retryDelay > 0) {
-        await new Promise(resolve => setTimeout(resolve, retryDelay));
+  const runAttempt = useCallback(() => {
+    runAttemptRef.current?.();
+  }, []);
+
+  const retry = useCallback(() => {
+    if (
+      !activeRef.current ||
+      !activatedRef.current ||
+      inFlightRef.current ||
+      retriesUsedRef.current >= maxRetriesRef.current
+    ) {
+      return;
+    }
+
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    retriesUsedRef.current += 1;
+    runAttempt();
+  }, [runAttempt]);
+
+  useEffect(() => {
+    activeRef.current = true;
+    return () => {
+      activeRef.current = false;
+      invalidate();
+    };
+  }, [invalidate]);
+
+  useEffect(() => {
+    runAttemptRef.current = () => {
+      if (!activeRef.current || inFlightRef.current) {
+        return;
       }
-      await load();
-    }
-  }, [retryCount, maxRetries, retryDelay, load]);
 
-  const handleIntersect = useCallback(async (isIntersecting: boolean) => {
-    if (isIntersecting && !isLoading && loadedData === null) {
-      await load();
-    }
-  }, [isLoading, loadedData, load]);
+      const generation = generationRef.current;
+      inFlightRef.current = true;
+      setLoadState({ status: "loading" });
 
-  // 자동 재시도
-  const shouldAutoRetry = error && maxRetries > 0 && retryCount < maxRetries;
-  
-  if (shouldAutoRetry && !isLoading) {
-    retry();
-  }
+      Promise.resolve()
+        .then(() => loaderRef.current())
+        .then((data) => {
+          if (!activeRef.current || generation !== generationRef.current) {
+            return;
+          }
 
-  // 렌더링할 내용 결정
-  const renderContent = () => {
-    if (loadedData !== null) {
-      return children(loadedData);
+          invalidate();
+          setLoadState({ status: "success", data });
+        })
+        .catch((reason: unknown) => {
+          if (!activeRef.current || generation !== generationRef.current) {
+            return;
+          }
+
+          inFlightRef.current = false;
+          const error = reason instanceof Error ? reason : new Error(String(reason));
+          console.error("Slacker loader failed:", error);
+          onErrorRef.current?.(error);
+          setLoadState({ status: "error", error });
+
+          if (retriesUsedRef.current < maxRetriesRef.current) {
+            const retryGeneration = generationRef.current;
+            retryTimerRef.current = setTimeout(() => {
+              retryTimerRef.current = null;
+              if (activeRef.current && retryGeneration === generationRef.current) {
+                retry();
+              }
+            }, retryDelayRef.current);
+          }
+        });
+    };
+
+    return () => {
+      runAttemptRef.current = null;
+    };
+  }, [invalidate, retry]);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
+
+  useEffect(() => {
+    maxRetriesRef.current = maxRetries;
+  }, [maxRetries]);
+
+  useEffect(() => {
+    retryDelayRef.current = retryDelay;
+  }, [retryDelay]);
+
+  useEffect(() => {
+    if (loaderRef.current === loader) {
+      return;
     }
-    
-    if (error) {
-      return typeof errorFallback === 'function'
-        ? errorFallback({ isLoading, error, retry })
+
+    loaderRef.current = loader;
+    invalidate();
+    retriesUsedRef.current = 0;
+    setLoadState(IDLE_STATE);
+    if (activatedRef.current) {
+      runAttempt();
+    }
+  }, [invalidate, loader, runAttempt]);
+
+  const handleIntersect = useCallback(
+    (isIntersecting: boolean) => {
+      if (!isIntersecting || activatedRef.current) {
+        return;
+      }
+
+      activatedRef.current = true;
+      retriesUsedRef.current = 0;
+      runAttempt();
+    },
+    [runAttempt],
+  );
+
+  let content: React.ReactNode = null;
+  if (loadState.status === "success") {
+    content = children(loadState.data);
+  } else if (loadState.status === "error") {
+    content =
+      typeof errorFallback === "function"
+        ? errorFallback({ isLoading: false, error: loadState.error, retry })
         : errorFallback;
-    }
-    
-    if (isLoading) {
-      return loadingFallback;
-    }
-    
-    return null;
-  };
+  } else if (loadState.status === "loading") {
+    content = loadingFallback;
+  }
 
   return (
     <Observer
@@ -84,7 +179,7 @@ export function Slacker<T = any>({
       triggerOnce={true}
       onIntersect={handleIntersect}
     >
-      {renderContent()}
+      {content}
     </Observer>
   );
 }

--- a/packages/utilinent/src/components/Slacker/index.tsx
+++ b/packages/utilinent/src/components/Slacker/index.tsx
@@ -1,14 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Observer } from "../Observer";
 import type { SlackerProps } from "./types";
 
 type LoadState<T> =
   | { readonly status: "idle" }
   | { readonly status: "loading" }
-  | { readonly status: "error"; readonly error: Error }
+  | { readonly status: "error"; readonly error: Error; readonly generation: number }
   | { readonly status: "success"; readonly data: T };
 
 const IDLE_STATE = { status: "idle" } as const;
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 export function Slacker<T = any>({
   children,
@@ -24,6 +25,7 @@ export function Slacker<T = any>({
   const [loadState, setLoadState] = useState<LoadState<T>>(IDLE_STATE);
   const activeRef = useRef(false);
   const activatedRef = useRef(false);
+  const completedRef = useRef(false);
   const generationRef = useRef(0);
   const inFlightRef = useRef(false);
   const retriesUsedRef = useRef(0);
@@ -47,10 +49,12 @@ export function Slacker<T = any>({
     runAttemptRef.current?.();
   }, []);
 
-  const retry = useCallback(() => {
+  const retry = useCallback((generation: number) => {
     if (
       !activeRef.current ||
       !activatedRef.current ||
+      completedRef.current ||
+      generation !== generationRef.current ||
       inFlightRef.current ||
       retriesUsedRef.current >= maxRetriesRef.current
     ) {
@@ -75,7 +79,7 @@ export function Slacker<T = any>({
 
   useEffect(() => {
     runAttemptRef.current = () => {
-      if (!activeRef.current || inFlightRef.current) {
+      if (!activeRef.current || completedRef.current || inFlightRef.current) {
         return;
       }
 
@@ -90,6 +94,8 @@ export function Slacker<T = any>({
             return;
           }
 
+          retriesUsedRef.current = 0;
+          completedRef.current = true;
           invalidate();
           setLoadState({ status: "success", data });
         })
@@ -102,14 +108,14 @@ export function Slacker<T = any>({
           const error = reason instanceof Error ? reason : new Error(String(reason));
           console.error("Slacker loader failed:", error);
           onErrorRef.current?.(error);
-          setLoadState({ status: "error", error });
+          setLoadState({ status: "error", error, generation });
 
           if (retriesUsedRef.current < maxRetriesRef.current) {
             const retryGeneration = generationRef.current;
             retryTimerRef.current = setTimeout(() => {
               retryTimerRef.current = null;
               if (activeRef.current && retryGeneration === generationRef.current) {
-                retry();
+                retry(retryGeneration);
               }
             }, retryDelayRef.current);
           }
@@ -121,31 +127,23 @@ export function Slacker<T = any>({
     };
   }, [invalidate, retry]);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     onErrorRef.current = onError;
-  }, [onError]);
-
-  useEffect(() => {
     maxRetriesRef.current = maxRetries;
-  }, [maxRetries]);
-
-  useEffect(() => {
     retryDelayRef.current = retryDelay;
-  }, [retryDelay]);
-
-  useEffect(() => {
     if (loaderRef.current === loader) {
       return;
     }
 
     loaderRef.current = loader;
     invalidate();
+    completedRef.current = false;
     retriesUsedRef.current = 0;
     setLoadState(IDLE_STATE);
     if (activatedRef.current) {
       runAttempt();
     }
-  }, [invalidate, loader, runAttempt]);
+  }, [invalidate, loader, maxRetries, onError, retryDelay, runAttempt]);
 
   const handleIntersect = useCallback(
     (isIntersecting: boolean) => {
@@ -166,7 +164,11 @@ export function Slacker<T = any>({
   } else if (loadState.status === "error") {
     content =
       typeof errorFallback === "function"
-        ? errorFallback({ isLoading: false, error: loadState.error, retry })
+        ? errorFallback({
+            isLoading: false,
+            error: loadState.error,
+            retry: () => retry(loadState.generation),
+          })
         : errorFallback;
   } else if (loadState.status === "loading") {
     content = loadingFallback;

--- a/packages/utilinent/test/Slacker.test.tsx
+++ b/packages/utilinent/test/Slacker.test.tsx
@@ -2,83 +2,10 @@ import { StrictMode, type ComponentProps } from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Slacker } from "../src/index";
-
-const observers: ControlledIntersectionObserver[] = [];
-
-class ControlledIntersectionObserver implements IntersectionObserver {
-  readonly root = null;
-  readonly rootMargin: string;
-  readonly thresholds: readonly number[];
-  private target: Element | null = null;
-
-  constructor(
-    private readonly callback: IntersectionObserverCallback,
-    options: IntersectionObserverInit = {},
-  ) {
-    this.rootMargin = options.rootMargin ?? "0px";
-    this.thresholds = Array.isArray(options.threshold)
-      ? options.threshold
-      : [options.threshold ?? 0];
-    observers.push(this);
-  }
-
-  observe(target: Element) {
-    this.target = target;
-  }
-
-  unobserve(target: Element) {
-    if (this.target === target) {
-      this.target = null;
-    }
-  }
-
-  disconnect() {
-    this.target = null;
-  }
-
-  takeRecords(): IntersectionObserverEntry[] {
-    return [];
-  }
-
-  emit(isIntersecting: boolean) {
-    if (!this.target) {
-      return;
-    }
-
-    const rect = new DOMRectReadOnly();
-    const entry: IntersectionObserverEntry = {
-      boundingClientRect: rect,
-      intersectionRatio: isIntersecting ? 1 : 0,
-      intersectionRect: rect,
-      isIntersecting,
-      rootBounds: null,
-      target: this.target,
-      time: 0,
-    };
-    this.callback([entry], this);
-  }
-
-  get active() {
-    return this.target !== null;
-  }
-}
-
-function activeObserver() {
-  const observer = [...observers].reverse().find((candidate) => candidate.active);
-  if (!observer) {
-    throw new Error("Expected an active IntersectionObserver");
-  }
-  return observer;
-}
-
-async function enterViewport() {
-  await act(async () => {
-    const observer = activeObserver();
-    observer.emit(false);
-    observer.emit(true);
-    await Promise.resolve();
-  });
-}
+import {
+  enterViewport,
+  installControlledIntersectionObserver,
+} from "./controlledIntersectionObserver";
 
 async function advanceTimer(milliseconds: number) {
   await act(async () => {
@@ -104,8 +31,7 @@ function stringSlacker(props: StringSlackerProps) {
 
 describe("Slacker retry lifecycle", () => {
   beforeEach(() => {
-    observers.length = 0;
-    globalThis.IntersectionObserver = ControlledIntersectionObserver;
+    installControlledIntersectionObserver();
     vi.useFakeTimers();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
   });
@@ -190,17 +116,21 @@ describe("Slacker retry lifecycle", () => {
   });
 
   it("cancels the automatic retry when a manual retry succeeds", async () => {
+    const retryCallbacks: Array<() => void> = [];
     const loader = vi
       .fn<() => Promise<string>>()
       .mockRejectedValueOnce(new Error("failure"))
       .mockResolvedValue("loaded");
 
-    render(
+    const rendered = render(
       stringSlacker({
         loader,
         maxRetries: 1,
         retryDelay: 1000,
-        errorFallback: ({ retry }) => <button onClick={retry}>Retry</button>,
+        errorFallback: ({ retry }) => {
+          retryCallbacks.push(retry);
+          return <button onClick={retry}>Retry</button>;
+        },
       }),
     );
     await enterViewport();
@@ -211,6 +141,15 @@ describe("Slacker retry lifecycle", () => {
 
     expect(loader).toHaveBeenCalledTimes(2);
     expect(screen.getByText("loaded")).toBeInTheDocument();
+
+    rendered.rerender(stringSlacker({ loader, maxRetries: 2, retryDelay: 1000 }));
+    const staleRetry = retryCallbacks[0];
+    if (!staleRetry) {
+      throw new Error("Expected the error fallback retry callback");
+    }
+    act(() => staleRetry());
+    await act(async () => Promise.resolve());
+    expect(loader).toHaveBeenCalledTimes(2);
   });
 
   it("coalesces rapid manual retries with the in-flight attempt", async () => {
@@ -273,6 +212,41 @@ describe("Slacker retry lifecycle", () => {
     expect(newLoader).toHaveBeenCalledTimes(1);
     expect(screen.getByText("new data")).toBeInTheDocument();
     expect(screen.queryByText("old data")).not.toBeInTheDocument();
+  });
+
+  it("invalidates manual retry callbacks when the loader is replaced", async () => {
+    const retryCallbacks: Array<() => void> = [];
+    const errorFallback = ({ retry }: { retry: () => void }) => {
+      retryCallbacks.push(retry);
+      return <button onClick={retry}>Retry</button>;
+    };
+    const oldLoader = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("old failure"));
+    const newLoader = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("new failure"));
+    const rendered = render(stringSlacker({ loader: oldLoader, maxRetries: 1, errorFallback }));
+    await enterViewport();
+    const staleRetry = retryCallbacks[0];
+
+    rendered.rerender(stringSlacker({ loader: newLoader, maxRetries: 1, errorFallback }));
+    await act(async () => Promise.resolve());
+    if (!staleRetry) {
+      throw new Error("Expected the original retry callback");
+    }
+    act(() => staleRetry());
+    await act(async () => Promise.resolve());
+
+    expect(oldLoader).toHaveBeenCalledTimes(1);
+    expect(newLoader).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels a scheduled retry when unmounted", async () => {
+    const loader = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("failure"));
+    const rendered = render(stringSlacker({ loader, maxRetries: 1, retryDelay: 1000 }));
+    await enterViewport();
+
+    rendered.unmount();
+    await advanceTimer(1000);
+
+    expect(loader).toHaveBeenCalledTimes(1);
   });
 
   it("ignores a failed settlement after unmount", async () => {

--- a/packages/utilinent/test/Slacker.test.tsx
+++ b/packages/utilinent/test/Slacker.test.tsx
@@ -1,0 +1,293 @@
+import { StrictMode, type ComponentProps } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Slacker } from "../src/index";
+
+const observers: ControlledIntersectionObserver[] = [];
+
+class ControlledIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin: string;
+  readonly thresholds: readonly number[];
+  private target: Element | null = null;
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    options: IntersectionObserverInit = {},
+  ) {
+    this.rootMargin = options.rootMargin ?? "0px";
+    this.thresholds = Array.isArray(options.threshold)
+      ? options.threshold
+      : [options.threshold ?? 0];
+    observers.push(this);
+  }
+
+  observe(target: Element) {
+    this.target = target;
+  }
+
+  unobserve(target: Element) {
+    if (this.target === target) {
+      this.target = null;
+    }
+  }
+
+  disconnect() {
+    this.target = null;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  emit(isIntersecting: boolean) {
+    if (!this.target) {
+      return;
+    }
+
+    const rect = new DOMRectReadOnly();
+    const entry: IntersectionObserverEntry = {
+      boundingClientRect: rect,
+      intersectionRatio: isIntersecting ? 1 : 0,
+      intersectionRect: rect,
+      isIntersecting,
+      rootBounds: null,
+      target: this.target,
+      time: 0,
+    };
+    this.callback([entry], this);
+  }
+
+  get active() {
+    return this.target !== null;
+  }
+}
+
+function activeObserver() {
+  const observer = [...observers].reverse().find((candidate) => candidate.active);
+  if (!observer) {
+    throw new Error("Expected an active IntersectionObserver");
+  }
+  return observer;
+}
+
+async function enterViewport() {
+  await act(async () => {
+    const observer = activeObserver();
+    observer.emit(false);
+    observer.emit(true);
+    await Promise.resolve();
+  });
+}
+
+async function advanceTimer(milliseconds: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(milliseconds);
+  });
+}
+
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+type StringSlackerProps = Omit<ComponentProps<typeof Slacker<string>>, "children">;
+
+function stringSlacker(props: StringSlackerProps) {
+  return <Slacker {...props}>{(value) => <p>{value}</p>}</Slacker>;
+}
+
+describe("Slacker retry lifecycle", () => {
+  beforeEach(() => {
+    observers.length = 0;
+    globalThis.IntersectionObserver = ControlledIntersectionObserver;
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts exactly one initial attempt after intersection in StrictMode", async () => {
+    const loader = vi.fn<() => Promise<string>>().mockResolvedValue("loaded");
+
+    render(
+      <StrictMode>
+        {stringSlacker({ loader })}
+      </StrictMode>,
+    );
+    expect(loader).not.toHaveBeenCalled();
+
+    await enterViewport();
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("loaded")).toBeInTheDocument();
+  });
+
+  it("defers a zero-delay retry until the timer boundary", async () => {
+    const loader = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockResolvedValue("loaded");
+
+    render(stringSlacker({ loader, maxRetries: 1, retryDelay: 0 }));
+    await enterViewport();
+
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await advanceTimer(0);
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("loaded")).toBeInTheDocument();
+  });
+
+  it("waits for the complete retry delay", async () => {
+    const loader = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockResolvedValue("loaded");
+
+    render(stringSlacker({ loader, maxRetries: 1, retryDelay: 1000 }));
+    await enterViewport();
+
+    await advanceTimer(999);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await advanceTimer(1);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when maxRetries is zero", async () => {
+    const onError = vi.fn();
+    const loader = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("failure"));
+
+    render(stringSlacker({ loader, maxRetries: 0, onError }));
+    await enterViewport();
+    await advanceTimer(5000);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after the configured additional attempts", async () => {
+    const onError = vi.fn();
+    const loader = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("failure"));
+
+    render(stringSlacker({ loader, maxRetries: 2, retryDelay: 100, onError }));
+    await enterViewport();
+    await advanceTimer(100);
+    await advanceTimer(100);
+    await advanceTimer(1000);
+
+    expect(loader).toHaveBeenCalledTimes(3);
+    expect(onError).toHaveBeenCalledTimes(3);
+  });
+
+  it("cancels the automatic retry when a manual retry succeeds", async () => {
+    const loader = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("failure"))
+      .mockResolvedValue("loaded");
+
+    render(
+      stringSlacker({
+        loader,
+        maxRetries: 1,
+        retryDelay: 1000,
+        errorFallback: ({ retry }) => <button onClick={retry}>Retry</button>,
+      }),
+    );
+    await enterViewport();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await act(async () => Promise.resolve());
+    await advanceTimer(1000);
+
+    expect(loader).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("loaded")).toBeInTheDocument();
+  });
+
+  it("coalesces rapid manual retries with the in-flight attempt", async () => {
+    const retryAttempt = createDeferred<string>();
+    const loader = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error("failure"))
+      .mockImplementation(() => retryAttempt.promise);
+
+    render(
+      stringSlacker({
+        loader,
+        maxRetries: 2,
+        retryDelay: 1000,
+        errorFallback: ({ retry }) => <button onClick={retry}>Retry</button>,
+      }),
+    );
+    await enterViewport();
+    const retryButton = screen.getByRole("button", { name: "Retry" });
+
+    act(() => {
+      retryButton.click();
+      retryButton.click();
+      retryButton.click();
+    });
+    await act(async () => Promise.resolve());
+
+    expect(loader).toHaveBeenCalledTimes(2);
+    retryAttempt.resolve("loaded");
+    await act(async () => Promise.resolve());
+    await advanceTimer(1000);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates pending timers and settlements when the loader is replaced", async () => {
+    const oldAttempt = createDeferred<string>();
+    const oldLoader = vi.fn(() => oldAttempt.promise);
+    const middleLoader = vi.fn<() => Promise<string>>().mockRejectedValue(new Error("failure"));
+    const newLoader = vi.fn<() => Promise<string>>().mockResolvedValue("new data");
+    const rendered = render(
+      stringSlacker({ loader: oldLoader, maxRetries: 1, retryDelay: 1000 }),
+    );
+    await enterViewport();
+
+    rendered.rerender(
+      stringSlacker({ loader: middleLoader, maxRetries: 1, retryDelay: 1000 }),
+    );
+    await act(async () => Promise.resolve());
+    oldAttempt.resolve("old data");
+    await act(async () => Promise.resolve());
+
+    rendered.rerender(
+      stringSlacker({ loader: newLoader, maxRetries: 1, retryDelay: 1000 }),
+    );
+    await act(async () => Promise.resolve());
+    await advanceTimer(1000);
+
+    expect(oldLoader).toHaveBeenCalledTimes(1);
+    expect(middleLoader).toHaveBeenCalledTimes(1);
+    expect(newLoader).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("new data")).toBeInTheDocument();
+    expect(screen.queryByText("old data")).not.toBeInTheDocument();
+  });
+
+  it("ignores a failed settlement after unmount", async () => {
+    const pendingAttempt = createDeferred<string>();
+    const onError = vi.fn();
+    const loader = vi.fn(() => pendingAttempt.promise);
+    const rendered = render(stringSlacker({ loader, maxRetries: 1, onError }));
+    await enterViewport();
+
+    rendered.unmount();
+    pendingAttempt.reject(new Error("late failure"));
+    await act(async () => Promise.resolve());
+    await advanceTimer(1000);
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/utilinent/test/controlledIntersectionObserver.ts
+++ b/packages/utilinent/test/controlledIntersectionObserver.ts
@@ -1,0 +1,79 @@
+import { act } from "@testing-library/react";
+
+const observers: ControlledIntersectionObserver[] = [];
+
+class ControlledIntersectionObserver implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin: string;
+  readonly thresholds: readonly number[];
+  private target: Element | null = null;
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    options: IntersectionObserverInit = {},
+  ) {
+    this.rootMargin = options.rootMargin ?? "0px";
+    this.thresholds = Array.isArray(options.threshold)
+      ? options.threshold
+      : [options.threshold ?? 0];
+    observers.push(this);
+  }
+
+  observe(target: Element) {
+    this.target = target;
+  }
+
+  unobserve(target: Element) {
+    if (this.target === target) {
+      this.target = null;
+    }
+  }
+
+  disconnect() {
+    this.target = null;
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  emit(isIntersecting: boolean) {
+    if (!this.target) {
+      return;
+    }
+
+    const rect = new DOMRectReadOnly();
+    const entry: IntersectionObserverEntry = {
+      boundingClientRect: rect,
+      intersectionRatio: isIntersecting ? 1 : 0,
+      intersectionRect: rect,
+      isIntersecting,
+      rootBounds: null,
+      target: this.target,
+      time: 0,
+    };
+    this.callback([entry], this);
+  }
+
+  get active() {
+    return this.target !== null;
+  }
+}
+
+export function installControlledIntersectionObserver() {
+  observers.length = 0;
+  globalThis.IntersectionObserver = ControlledIntersectionObserver;
+}
+
+export async function enterViewport() {
+  const observer = [...observers].reverse().find((candidate) => candidate.active);
+  if (!observer) {
+    throw new Error("Expected an active IntersectionObserver");
+  }
+
+  await act(async () => {
+    observer.emit(false);
+    observer.emit(true);
+    await Promise.resolve();
+  });
+}


### PR DESCRIPTION
## Summary
- move Slacker loader, timer, retry, and state transitions out of render into an effect-installed lifecycle
- share retry budget and in-flight ownership across automatic/manual retries, with generation invalidation for success, loader replacement, and unmount
- add deterministic StrictMode/fake-timer coverage, English/Korean docs, and a utilinent patch changeset

Closes #15

## Red before / green after

Red before production changes:
- `pnpm --filter @ilokesto/utilinent test -- test/Slacker.test.tsx` failed 4 lifecycle cases: zero-delay retry ran before the timer boundary (2 calls instead of 1), rapid manual retry ownership, loader replacement cancellation, and post-unmount settlement handling.
- Review-driven red regressions also reproduced stale post-success retry (3 calls instead of 2) and stale pre-replacement retry invoking the replacement loader (2 calls instead of 1).

Green after:
- `pnpm --filter @ilokesto/utilinent test` -> 2 files, 13 tests passed.
- Controlled IntersectionObserver plus Vitest fake timers are used throughout; no sleeps.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @ilokesto/utilinent test`
- `pnpm --filter @ilokesto/utilinent build`
- `pnpm exec tsc --noEmit --jsx react-jsx --module ESNext --moduleResolution Bundler --target ESNext --strict --esModuleInterop --types vitest/globals,@testing-library/jest-dom/vitest test/Slacker.test.tsx test/controlledIntersectionObserver.ts`
- `npm pack --dry-run` -> 74 files, package contents limited to README, package metadata, and dist
- `pnpm build`
- `pnpm test:monorepo` -> 15 passed
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status`
- `git diff --check origin/main...HEAD`

## Notes
- Public props/types and rendered output are unchanged.
- Observer, Mount, Suspense behavior, and other utilities are untouched.
- Package docs sync still depends on repository `DOCS_SYNC_TOKEN` configuration; no secrets were changed.