### PR TITLE
fix(modal): scope stacks to providers

### DIFF
--- a/.changeset/modal-provider-scoped-stack-10.md
+++ b/.changeset/modal-provider-scoped-stack-10.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/modal": patch
+---
+
+Scope modal stack policy to each ModalProvider so providers with distinct stores no longer interfere with inline or top-layer ordering, dismissal, and focus behavior. Fixes #10.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,6 +47,10 @@ All package source lives under `packages/` in one pnpm workspace. Changesets ver
 
 Both `modal` and `toast` are built on `overlay`. This keeps lifecycle, provider scoping, and adapter behavior consistent across layered UI components.
 
+Each `ModalProvider` also owns an internal modal stack runtime. Inline and top-layer adapters share that provider-local runtime for topness, stack indexes, Escape, backdrop, and focus policy while `overlay` continues to own presence lifecycle and the item store. Multiple modal providers are isolated when they receive distinct overlay stores.
+
+The `modal` / `globalModalStore` facade is the backward-compatible exception: providers without an explicit `store` all use the same global store, so applications must mount only one default `ModalProvider`. Applications that need multiple providers must pass a distinct store to each provider.
+
 ### 4. Framework adapters live in consumer packages
 
 `state`, `form`, and future packages provide React/Vue/Solid/Svelte/Angular adapters in their own package directories. The core stays framework-agnostic.

--- a/packages/modal/README.ko.md
+++ b/packages/modal/README.ko.md
@@ -11,6 +11,7 @@ Grunfeld의 awaitable dialog 철학을 유지하면서, 기본 motion을 더 부
 - **Awaitable modal flow** — `display()`가 exit 애니메이션 완료 후 resolve되는 Promise 반환
 - **Hook 기반 API** — `useModal()`로 `display`, `close`, `closeAll`, `reject`, `remove`, `clear` 제공
 - **글로벌 facade** — 모듈 레벨에서 사용할 수 있는 `modal`과 `globalModalStore`
+- **provider-scoped stack 정책** — provider마다 독립적인 topness, z-index, dismiss, focus 정책
 - **inline transport** — 기본 fade/scale motion으로 완전한 제어
 - **top-layer transport** — 네이티브 `<dialog>` + `showModal()`
 - **ESC / backdrop dismiss** — `onDismiss` 콜백과 함께 light dismiss 지원
@@ -143,6 +144,8 @@ modal이 닫힐 때마다 callback이 필요하면 `onModalClose(result)`를 사
 
 모듈 레벨 API를 선호한다면 기본 `ModalProvider`를 한 번 마운트한 뒤 `modal` facade를 사용할 수 있습니다.
 
+`store`가 없는 provider는 하나만 지원합니다. 모든 기본 provider는 `globalModalStore`를 공유하므로 여러 개를 마운트해도 독립적인 facade stack이 만들어지지 않습니다. 여러 provider를 동시에 사용하려면 각 `ModalProvider`에 서로 다른 overlay store를 전달하세요. 그러면 각 provider가 inline 및 top-layer transport의 modal stack 정책을 독립적으로 소유합니다.
+
 ```tsx
 import { ModalProvider, modal } from '@ilokesto/modal';
 
@@ -255,7 +258,7 @@ await display({
 
 ### `ModalProvider`
 
-Context provider. `@ilokesto/overlay`의 `OverlayProvider`를 감싸고, modal adapter를 등록하고, 공유 CSS를 주입합니다. Props: `children`, `store?`.
+Context provider. `@ilokesto/overlay`의 `OverlayProvider`를 감싸고, modal adapter를 등록하고, 공유 CSS를 주입하며, 두 transport가 사용하는 내부 stack runtime을 소유합니다. Props: `children`, `store?`.
 
 ### `useModal()`
 
@@ -313,14 +316,14 @@ src/
 - `ModalAdapterTopLayer.tsx` — 네이티브 `<dialog>`: cancel/backdrop 처리, 위치 지정, scoped backdrop, animation
 
 **`src/components`** — provider:
-- `ModalProvider.tsx` — `OverlayProvider` 감싸기, adapter 등록, CSS 주입, 기본 global store 사용
+- `ModalProvider.tsx` — `OverlayProvider` 감싸기, modal stack 정책 소유, adapter 등록, CSS 주입, 기본 global store 사용
 
 **`src/facade`** — 모듈 레벨 API:
 - `modalFacade.ts` — `modal` facade와 `globalModalStore`
 
 **`src/hooks`** — React 훅:
 - `useModal.ts` — 명령형 API (`display`, `close`, `closeAll`, `reject`, `remove`, `clear`)
-- `useIsTopModal.ts` — z-index 및 focus 관리를 위한 modal stack 추적
+- `useIsTopModal.ts` — z-index, dismiss, focus 관리를 위한 provider-scoped modal stack 추적
 - `usePrefersReducedMotion.ts` — 레거시 fallback 포함 `prefers-reduced-motion` 감지
 
 **`src/shared`** — 내부:

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -11,6 +11,7 @@ A React modal package built on top of `@ilokesto/overlay`, following Grunfeld's 
 - **Awaitable modal flows** — `display()` returns a Promise that resolves after exit animation
 - **Hook-based API** — `useModal()` with `display`, `close`, `closeAll`, `reject`, `remove`, `clear`
 - **Global facade** — `modal` and `globalModalStore` for module-level usage
+- **Provider-scoped stack policy** — independent topness, z-index, dismiss, and focus policy per provider
 - **Inline transport** — default fade/scale motion with full control
 - **Top-layer transport** — native `<dialog>` with `showModal()`
 - **ESC and backdrop dismiss** — light dismiss with `onDismiss` callback
@@ -143,6 +144,8 @@ If you need to distinguish batch-close from individual-close in `onModalClose`, 
 
 If you prefer a module-level API, mount a default `ModalProvider` once and then use the exported `modal` facade.
 
+Only one provider without a `store` is supported. Every default provider shares `globalModalStore`, so mounting more than one does not create independent facade stacks. For multiple simultaneous providers, pass a distinct overlay store to each `ModalProvider`; each provider then owns its own modal stack policy for inline and top-layer transports.
+
 ```tsx
 import { ModalProvider, modal } from '@ilokesto/modal';
 
@@ -255,7 +258,7 @@ That means awaited results resolve after the modal is actually removed, not at t
 
 ### `ModalProvider`
 
-Context provider. Wraps `OverlayProvider` from `@ilokesto/overlay`, registers the modal adapter, injects shared CSS. Props: `children`, `store?`.
+Context provider. Wraps `OverlayProvider` from `@ilokesto/overlay`, registers the modal adapter, injects shared CSS, and owns the internal stack runtime used by both transports. Props: `children`, `store?`.
 
 ### `useModal()`
 
@@ -313,14 +316,14 @@ src/
 - `ModalAdapterTopLayer.tsx` — native `<dialog>`: cancel/backdrop handling, positioning, scoped backdrop, animation
 
 **`src/components`** — provider:
-- `ModalProvider.tsx` — wraps `OverlayProvider`, registers adapter, injects CSS, defaults to global store
+- `ModalProvider.tsx` — wraps `OverlayProvider`, owns modal stack policy, registers adapter, injects CSS, defaults to global store
 
 **`src/facade`** — module-level API:
 - `modalFacade.ts` — `modal` facade and `globalModalStore`
 
 **`src/hooks`** — React hooks:
 - `useModal.ts` — command API (`display`, `close`, `closeAll`, `reject`, `remove`, `clear`)
-- `useIsTopModal.ts` — modal stack tracking for z-index and focus management
+- `useIsTopModal.ts` — provider-scoped modal stack tracking for z-index, dismiss, and focus management
 - `usePrefersReducedMotion.ts` — `prefers-reduced-motion` detection with legacy fallback
 
 **`src/shared`** — internal:

--- a/packages/modal/e2e/fixture/src/App.tsx
+++ b/packages/modal/e2e/fixture/src/App.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { createOverlayStore } from '@ilokesto/overlay';
 import { ModalProvider, useModal } from '../../../src';
+
+const firstProviderStore = createOverlayStore();
+const secondProviderStore = createOverlayStore();
 
 function InlineConfirmButton() {
   const { display } = useModal();
@@ -107,17 +111,81 @@ function StackedButton() {
   );
 }
 
+interface ProviderControlsProps {
+  readonly name: 'First' | 'Second';
+}
+
+function ProviderControls({ name }: ProviderControlsProps) {
+  const { display } = useModal();
+
+  const openInline = () => {
+    void display({
+      id: `${name.toLowerCase()}-provider-inline`,
+      ariaLabel: `${name} provider inline modal`,
+      render: (close) => (
+        <section>
+          <h2>{name} provider inline</h2>
+          <button type="button">{name} start</button>
+          <button type="button" onClick={() => close()}>{name} close inline</button>
+          <button type="button">{name} end</button>
+        </section>
+      ),
+    });
+  };
+
+  const openTopLayer = () => {
+    void display({
+      id: `${name.toLowerCase()}-provider-top-layer`,
+      transport: 'top-layer',
+      ariaLabel: `${name} provider top-layer modal`,
+      render: (close) => (
+        <section>
+          <h2>{name} provider top layer</h2>
+          <button type="button" onClick={() => close()}>{name} close top layer</button>
+        </section>
+      ),
+    });
+  };
+
+  return (
+    <section aria-label={`${name} provider controls`}>
+      <button type="button" onClick={openInline}>Open {name.toLowerCase()} provider inline</button>
+      <button type="button" onClick={openTopLayer}>Open {name.toLowerCase()} provider top layer</button>
+    </section>
+  );
+}
+
+function ProviderIsolationDemo() {
+  return (
+    <section aria-label="Provider isolation demo">
+      <ModalProvider store={firstProviderStore}>
+        <ProviderControls name="First" />
+      </ModalProvider>
+      <ModalProvider store={secondProviderStore}>
+        <ProviderControls name="Second" />
+      </ModalProvider>
+    </section>
+  );
+}
+
 function DemoApp() {
   return (
-    <ModalProvider>
-      <main>
+    <main>
+      <ModalProvider>
         <h1>Modal E2E Fixture</h1>
         <InlineConfirmButton />
         <TopLayerButton />
         <StackedButton />
-      </main>
-    </ModalProvider>
+      </ModalProvider>
+      <ProviderIsolationDemo />
+    </main>
   );
 }
 
-createRoot(document.getElementById('root')!).render(<DemoApp />);
+const rootElement = document.getElementById('root');
+
+if (rootElement === null) {
+  throw new TypeError('Modal E2E fixture root is missing.');
+}
+
+createRoot(rootElement).render(<DemoApp />);

--- a/packages/modal/e2e/modal.a11y.ts
+++ b/packages/modal/e2e/modal.a11y.ts
@@ -5,7 +5,9 @@ test('inline modal has no detectable axe violations', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: 'Open inline confirm' }).click();
 
-  await expect(page.getByRole('dialog', { name: 'Delete item?' })).toBeVisible();
+  const dialog = page.getByRole('dialog', { name: 'Delete item?' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toHaveCSS('opacity', '1');
 
   const results = await new AxeBuilder({ page }).include('body').analyze();
 
@@ -16,7 +18,9 @@ test('top-layer modal has no detectable axe violations', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: 'Open top-layer settings' }).click();
 
-  await expect(page.getByRole('dialog', { name: 'Settings dialog' })).toBeVisible();
+  const dialog = page.getByRole('dialog', { name: 'Settings dialog' });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toHaveCSS('opacity', '1');
 
   const results = await new AxeBuilder({ page }).include('body').analyze();
 

--- a/packages/modal/e2e/modal.e2e.ts
+++ b/packages/modal/e2e/modal.e2e.ts
@@ -55,3 +55,89 @@ test('reduced motion disables modal animation on first render', async ({ page })
 
   expect(animationDuration).toBe('0s');
 });
+
+test('inline backdrop and z-index stay local to each provider', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open first provider inline' }).click();
+  await page.getByRole('button', { name: 'Open second provider inline' }).dispatchEvent('click');
+
+  const firstDialog = page.getByRole('dialog', { name: 'First provider inline modal' });
+  const secondDialog = page.getByRole('dialog', { name: 'Second provider inline modal' });
+  const firstWrapper = page.locator('.ilokesto-modal-inline-wrapper').filter({ has: firstDialog });
+  const secondWrapper = page.locator('.ilokesto-modal-inline-wrapper').filter({ has: secondDialog });
+
+  await expect(firstWrapper).toHaveCSS('z-index', '10000');
+  await expect(secondWrapper).toHaveCSS('z-index', '10000');
+
+  await firstWrapper.getByRole('button', { name: 'Dismiss modal' }).dispatchEvent('click');
+
+  await expect(firstDialog).toBeHidden();
+  await expect(secondDialog).toBeVisible();
+});
+
+test('Escape dismisses the top inline modal in each provider', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open first provider inline' }).click();
+  await page.getByRole('button', { name: 'Open second provider inline' }).dispatchEvent('click');
+
+  const firstDialog = page.getByRole('dialog', { name: 'First provider inline modal' });
+  const secondDialog = page.getByRole('dialog', { name: 'Second provider inline modal' });
+
+  await page.keyboard.press('Escape');
+
+  await expect(firstDialog).toBeHidden();
+  await expect(secondDialog).toBeHidden();
+});
+
+test('focus wrapping remains inside the selected provider modal', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open first provider inline' }).click();
+  await page.getByRole('button', { name: 'Open second provider inline' }).dispatchEvent('click');
+
+  await page.getByRole('button', { name: 'First end' }).focus();
+  await page.keyboard.press('Tab');
+
+  await expect(page.getByRole('button', { name: 'First start' })).toBeFocused();
+});
+
+test('top-layer cancel only dismisses the provider that owns the dialog', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open first provider top layer' }).click();
+  await page.getByRole('button', { name: 'Open second provider top layer' }).dispatchEvent('click');
+
+  const firstDialog = page.getByRole('dialog', { name: 'First provider top-layer modal' });
+  const secondDialog = page.getByRole('dialog', { name: 'Second provider top-layer modal' });
+
+  await firstDialog.dispatchEvent('cancel');
+
+  await expect(firstDialog).toBeHidden();
+  await expect(secondDialog).toBeVisible();
+});
+
+test('physical Escape dismisses first-provider inline and second-provider top-layer modals', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open first provider inline' }).click();
+  await page.getByRole('button', { name: 'Open second provider top layer' }).dispatchEvent('click');
+
+  const inlineDialog = page.getByRole('dialog', { name: 'First provider inline modal' });
+  const topLayerDialog = page.getByRole('dialog', { name: 'Second provider top-layer modal' });
+
+  await page.keyboard.press('Escape');
+
+  await expect(inlineDialog).toBeHidden();
+  await expect(topLayerDialog).toBeHidden();
+});
+
+test('physical Escape dismisses first-provider top-layer and second-provider inline modals', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open first provider top layer' }).click();
+  await page.getByRole('button', { name: 'Open second provider inline' }).dispatchEvent('click');
+
+  const topLayerDialog = page.getByRole('dialog', { name: 'First provider top-layer modal' });
+  const inlineDialog = page.getByRole('dialog', { name: 'Second provider inline modal' });
+
+  await page.keyboard.press('Escape');
+
+  await expect(topLayerDialog).toBeHidden();
+  await expect(inlineDialog).toBeHidden();
+});

--- a/packages/modal/src/adapters/ModalAdapterInline.tsx
+++ b/packages/modal/src/adapters/ModalAdapterInline.tsx
@@ -34,6 +34,7 @@ function getPositionStyles(pos?: ModalPosition): React.CSSProperties {
 }
 
 let scrollLockCount = 0;
+let originalBodyOverflow = '';
 
 export function ModalAdapterInline<TResult>({
   id,
@@ -56,23 +57,24 @@ export function ModalAdapterInline<TResult>({
   autoFocus = true,
   restoreFocus = true,
 }: ModalAdapterProps<TResult>) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
-  const { isTopModal, stackIndex } = useModalStackInfo(id);
+  const { containsTarget, isTopModal, stackIndex } = useModalStackInfo(id, wrapperRef);
   const prefersReducedMotion = usePrefersReducedMotion();
 
   // Body scroll lock
   useEffect(() => {
-    scrollLockCount++;
-    const originalOverflow = document.body.style.overflow;
-    if (scrollLockCount === 1) {
+    if (scrollLockCount === 0) {
+      originalBodyOverflow = document.body.style.overflow;
       document.body.style.overflow = 'hidden';
     }
+    scrollLockCount++;
     
     return () => {
       scrollLockCount--;
       if (scrollLockCount === 0) {
-        document.body.style.overflow = originalOverflow;
+        document.body.style.overflow = originalBodyOverflow;
       }
     };
   }, []);
@@ -105,9 +107,14 @@ export function ModalAdapterInline<TResult>({
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         if (isTopModal && dismissible && status !== 'closing') {
-          e.preventDefault();
+          const targetIsForeignTopLayer = e.target instanceof Element &&
+            e.target.closest('.ilokesto-modal-dialog') !== null &&
+            !containsTarget(e.target);
+
+          if (!targetIsForeignTopLayer) {
+            e.preventDefault();
+          }
           e.stopPropagation();
-          e.stopImmediatePropagation();
           onDismiss?.();
           close();
         }
@@ -134,7 +141,7 @@ export function ModalAdapterInline<TResult>({
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [close, dismissible, isTopModal, onDismiss, status]);
+  }, [close, containsTarget, dismissible, isTopModal, onDismiss, status]);
 
   useEffect(() => {
     const handleFocusIn = (e: FocusEvent) => {
@@ -142,6 +149,11 @@ export function ModalAdapterInline<TResult>({
       const target = e.target instanceof Node ? e.target : null;
 
       if (target && containerRef.current.contains(target)) return;
+      if (
+        target instanceof Element &&
+        target.closest('.ilokesto-modal-inline-wrapper, .ilokesto-modal-dialog') &&
+        !containsTarget(target)
+      ) return;
 
       const focusable = getFocusableElements(containerRef.current)[0] ?? containerRef.current;
       focusable.focus();
@@ -149,7 +161,7 @@ export function ModalAdapterInline<TResult>({
 
     document.addEventListener('focusin', handleFocusIn);
     return () => document.removeEventListener('focusin', handleFocusIn);
-  }, [isTopModal, status]);
+  }, [containsTarget, isTopModal, status]);
 
   const handleBackdropClick = useCallback(
     (e: React.MouseEvent) => {
@@ -180,6 +192,7 @@ export function ModalAdapterInline<TResult>({
 
   return (
     <div
+      ref={wrapperRef}
       className={`ilokesto-modal-inline-wrapper ${isClosing ? 'ilokesto-modal-closing' : 'ilokesto-modal-open'}`}
       style={{
         position: 'fixed',

--- a/packages/modal/src/adapters/ModalAdapterTopLayer.tsx
+++ b/packages/modal/src/adapters/ModalAdapterTopLayer.tsx
@@ -64,7 +64,7 @@ export function ModalAdapterTopLayer<TResult>({
   const dialogRef = useRef<HTMLDialogElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const uniqueId = useId().replace(/:/g, '');
-  const isTopModal = useIsTopModal(id);
+  const isTopModal = useIsTopModal(id, dialogRef);
   const prefersReducedMotion = usePrefersReducedMotion();
 
   // Reduced motion fast-track removal

--- a/packages/modal/src/components/ModalProvider.tsx
+++ b/packages/modal/src/components/ModalProvider.tsx
@@ -4,6 +4,7 @@ import type { OverlayStoreApi } from '@ilokesto/overlay';
 import { ModalAdapter } from '../adapters/ModalAdapter';
 import { globalStyles } from '../shared/styles';
 import { globalModalStore } from '../facade/modalFacade';
+import { createModalStackRuntime, ModalStackRuntimeContext } from '../hooks/useIsTopModal';
 import { createModalLifecycleStore } from '../shared/lifecycle';
 
 export interface ModalProviderProps {
@@ -16,6 +17,7 @@ export function ModalProvider({ children, store }: ModalProviderProps) {
     () => store ? createModalLifecycleStore(store) : globalModalStore,
     [store]
   );
+  const modalStackRuntime = useMemo(createModalStackRuntime, []);
   const adapters = useMemo(() => ({ modal: ModalAdapter }), []);
 
   useEffect(() => {
@@ -30,8 +32,10 @@ export function ModalProvider({ children, store }: ModalProviderProps) {
   }, []);
 
   return (
-    <OverlayProvider store={overlayStore} adapters={adapters}>
-      {children}
-    </OverlayProvider>
+    <ModalStackRuntimeContext.Provider value={modalStackRuntime}>
+      <OverlayProvider store={overlayStore} adapters={adapters}>
+        {children}
+      </OverlayProvider>
+    </ModalStackRuntimeContext.Provider>
   );
 }

--- a/packages/modal/src/hooks/useIsTopModal.ts
+++ b/packages/modal/src/hooks/useIsTopModal.ts
@@ -1,52 +1,87 @@
-import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { createContext, useContext, useEffect, useRef, useSyncExternalStore } from 'react';
+import type { RefObject } from 'react';
 
 interface ModalStackEntry {
-  id: string;
-  token: symbol;
+  readonly id: string;
+  readonly token: symbol;
+  readonly elementRef: RefObject<HTMLElement | null>;
 }
 
-const modalStack: ModalStackEntry[] = [];
-const listeners = new Set<() => void>();
-let stackVersion = 0;
-
-function emitChange() {
-  stackVersion++;
-  listeners.forEach((listener) => {
-    listener();
-  });
+interface ModalStackInfo {
+  readonly isTopModal: boolean;
+  readonly stackIndex: number;
+  readonly containsTarget: (target: Node) => boolean;
 }
 
-function registerModal(entry: ModalStackEntry) {
-  modalStack.push(entry);
-  emitChange();
+export interface ModalStackRuntime {
+  readonly register: (entry: ModalStackEntry) => () => void;
+  readonly subscribe: (listener: () => void) => () => void;
+  readonly getVersion: () => number;
+  readonly getStackInfo: (token: symbol) => ModalStackInfo;
+}
 
-  return () => {
-    const index = modalStack.findIndex((item) => item.token === entry.token);
+export function createModalStackRuntime(): ModalStackRuntime {
+  const entries: ModalStackEntry[] = [];
+  const listeners = new Set<() => void>();
+  let version = 0;
 
-    if (index !== -1) {
-      modalStack.splice(index, 1);
+  const emitChange = () => {
+    version++;
+    listeners.forEach((listener) => {
+      listener();
+    });
+  };
+
+  const containsTarget = (target: Node) => entries.some(
+    (entry) => entry.elementRef.current?.contains(target) ?? false
+  );
+
+  return {
+    register: (entry) => {
+      entries.push(entry);
       emitChange();
-    }
-  };
-}
 
-function subscribe(listener: () => void) {
-  listeners.add(listener);
-  return () => {
-    listeners.delete(listener);
-  };
-}
+      return () => {
+        const index = entries.findIndex((item) => item.token === entry.token);
 
-function getStackVersion() {
-  return stackVersion;
+        if (index !== -1) {
+          entries.splice(index, 1);
+          emitChange();
+        }
+      };
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getVersion: () => version,
+    getStackInfo: (token) => {
+      const stackIndex = entries.findIndex((item) => item.token === token);
+
+      return {
+        isTopModal: stackIndex !== -1 && stackIndex === entries.length - 1,
+        stackIndex: stackIndex === -1 ? 0 : stackIndex,
+        containsTarget,
+      };
+    },
+  };
 }
 
 function getServerSnapshot() {
   return 0;
 }
 
-export function useModalStackInfo(id: string) {
+export const ModalStackRuntimeContext = createContext<ModalStackRuntime | null>(null);
+
+export function useModalStackInfo(id: string, elementRef: RefObject<HTMLElement | null>) {
+  const runtime = useContext(ModalStackRuntimeContext);
   const tokenRef = useRef<symbol | null>(null);
+
+  if (runtime === null) {
+    throw new Error('Modal adapters must be rendered within a ModalProvider.');
+  }
 
   if (!tokenRef.current) {
     tokenRef.current = Symbol(id);
@@ -55,20 +90,14 @@ export function useModalStackInfo(id: string) {
   useEffect(() => {
     if (!tokenRef.current) return;
 
-    return registerModal({ id, token: tokenRef.current });
-  }, [id]);
+    return runtime.register({ id, token: tokenRef.current, elementRef });
+  }, [elementRef, id, runtime]);
 
-  useSyncExternalStore(subscribe, getStackVersion, getServerSnapshot);
+  useSyncExternalStore(runtime.subscribe, runtime.getVersion, getServerSnapshot);
 
-  const stackIndex = modalStack.findIndex((item) => item.token === tokenRef.current);
-  const topIndex = modalStack.length - 1;
-
-  return {
-    isTopModal: stackIndex !== -1 && stackIndex === topIndex,
-    stackIndex: stackIndex === -1 ? 0 : stackIndex,
-  };
+  return runtime.getStackInfo(tokenRef.current);
 }
 
-export function useIsTopModal(id: string) {
-  return useModalStackInfo(id).isTopModal;
+export function useIsTopModal(id: string, elementRef: RefObject<HTMLElement | null>) {
+  return useModalStackInfo(id, elementRef).isTopModal;
 }

--- a/packages/modal/test/ModalAdapterInline.test.tsx
+++ b/packages/modal/test/ModalAdapterInline.test.tsx
@@ -1,15 +1,16 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
 import type { ModalAdapterProps } from '../src/shared/types';
 import { ModalAdapterInline } from '../src/adapters/ModalAdapterInline';
+import { renderWithModalStack } from './modalStackTestUtils';
 
 function renderInline(props: Partial<ModalAdapterProps<unknown>> = {}) {
   const close = vi.fn();
   const remove = vi.fn();
 
-  render(
+  renderWithModalStack(
     <ModalAdapterInline
       id="modal-id"
       isOpen
@@ -56,7 +57,7 @@ describe('ModalAdapterInline', () => {
     document.body.appendChild(opener);
     opener.focus();
 
-    const { unmount } = render(
+    const { unmount } = renderWithModalStack(
       <ModalAdapterInline
         id="modal-id"
         isOpen
@@ -140,7 +141,7 @@ describe('ModalAdapterInline', () => {
     const outerClose = vi.fn();
     const innerClose = vi.fn();
 
-    render(
+    renderWithModalStack(
       <>
         <ModalAdapterInline
           id="outer-modal"
@@ -170,7 +171,7 @@ describe('ModalAdapterInline', () => {
   });
 
   it('stacks nested inline modals above earlier inline modals', () => {
-    render(
+    renderWithModalStack(
       <>
         <ModalAdapterInline
           id="outer-modal"

--- a/packages/modal/test/ModalAdapterTopLayer.test.tsx
+++ b/packages/modal/test/ModalAdapterTopLayer.test.tsx
@@ -1,8 +1,9 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
 import { ModalAdapterTopLayer } from '../src/adapters/ModalAdapterTopLayer';
+import { renderWithModalStack } from './modalStackTestUtils';
 
 describe('ModalAdapterTopLayer', () => {
   afterEach(() => {
@@ -10,7 +11,7 @@ describe('ModalAdapterTopLayer', () => {
   });
 
   it('renders a named native dialog and moves focus inside after showModal', () => {
-    render(
+    renderWithModalStack(
       <ModalAdapterTopLayer
         id="modal-id"
         isOpen
@@ -29,7 +30,7 @@ describe('ModalAdapterTopLayer', () => {
   it('closes on native cancel when dismissible', () => {
     const close = vi.fn();
 
-    render(
+    renderWithModalStack(
       <ModalAdapterTopLayer
         id="modal-id"
         isOpen
@@ -49,7 +50,7 @@ describe('ModalAdapterTopLayer', () => {
   it('passes scoped close to render content', () => {
     const close = vi.fn();
 
-    render(
+    renderWithModalStack(
       <ModalAdapterTopLayer
         id="modal-id"
         isOpen

--- a/packages/modal/test/ModalProvider.test.tsx
+++ b/packages/modal/test/ModalProvider.test.tsx
@@ -1,7 +1,8 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { createOverlayStore } from '@ilokesto/overlay';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { ModalProvider } from '../src/components/ModalProvider';
 
 describe('ModalProvider', () => {
@@ -28,5 +29,39 @@ describe('ModalProvider', () => {
 
     expect(screen.getByText('Updated content')).not.toBeNull();
     expect(document.querySelectorAll('#ilokesto-modal-styles')).toHaveLength(1);
+  });
+
+  it('keeps modal policy independent when two providers use distinct stores', () => {
+    const firstStore = createOverlayStore();
+    const secondStore = createOverlayStore();
+
+    act(() => {
+      firstStore.open({
+        id: 'shared-modal-id',
+        type: 'modal',
+        props: { ariaLabel: 'First provider modal', render: () => null },
+      });
+      secondStore.open({
+        id: 'shared-modal-id',
+        type: 'modal',
+        props: { ariaLabel: 'Second provider modal', render: () => null },
+      });
+    });
+
+    render(
+      <>
+        <ModalProvider store={firstStore}>First provider</ModalProvider>
+        <ModalProvider store={secondStore}>Second provider</ModalProvider>
+      </>
+    );
+
+    const wrappers = document.querySelectorAll<HTMLElement>('.ilokesto-modal-inline-wrapper');
+    expect(wrappers[0]).toHaveStyle({ zIndex: '10000' });
+    expect(wrappers[1]).toHaveStyle({ zIndex: '10000' });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Dismiss modal' })[0]);
+
+    expect(firstStore.getSnapshot()[0]?.status).toBe('closing');
+    expect(secondStore.getSnapshot()[0]?.status).toBe('open');
   });
 });

--- a/packages/modal/test/ModalStackBehavior.test.tsx
+++ b/packages/modal/test/ModalStackBehavior.test.tsx
@@ -1,0 +1,99 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { ModalAdapterInline } from '../src/adapters/ModalAdapterInline';
+import { ModalAdapterTopLayer } from '../src/adapters/ModalAdapterTopLayer';
+import { renderWithModalStack } from './modalStackTestUtils';
+
+describe('same-provider modal stack behavior', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = '';
+  });
+
+  it('keeps duplicate-ID inline entries distinct through the closing phase', () => {
+    const outerClose = vi.fn();
+    const innerClose = vi.fn();
+    const renderStack = (showInner: boolean) => (
+      <>
+        <ModalAdapterInline
+          id="duplicate-id"
+          isOpen
+          status="open"
+          close={outerClose}
+          remove={vi.fn()}
+          ariaLabel="Outer modal"
+          render={() => null}
+        />
+        {showInner && (
+          <ModalAdapterInline
+            id="duplicate-id"
+            isOpen={false}
+            status="closing"
+            close={innerClose}
+            remove={vi.fn()}
+            ariaLabel="Inner modal"
+            render={() => null}
+          />
+        )}
+      </>
+    );
+    const { rerender } = renderWithModalStack(renderStack(true));
+
+    const wrappers = document.querySelectorAll<HTMLElement>('.ilokesto-modal-inline-wrapper');
+    expect(wrappers[0]).toHaveStyle({ zIndex: '10000' });
+    expect(wrappers[1]).toHaveStyle({ zIndex: '10001' });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(outerClose).not.toHaveBeenCalled();
+    expect(innerClose).not.toHaveBeenCalled();
+
+    rerender(renderStack(false));
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(outerClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a closing top-layer entry above its same-provider parent until unmount', () => {
+    const outerClose = vi.fn();
+    const innerClose = vi.fn();
+    const renderStack = (showInner: boolean) => (
+      <>
+        <ModalAdapterTopLayer
+          id="outer-dialog"
+          isOpen
+          status="open"
+          close={outerClose}
+          remove={vi.fn()}
+          ariaLabel="Outer dialog"
+          render={() => null}
+        />
+        {showInner && (
+          <ModalAdapterTopLayer
+            id="inner-dialog"
+            isOpen={false}
+            status="closing"
+            close={innerClose}
+            remove={vi.fn()}
+            ariaLabel="Inner dialog"
+            render={() => null}
+          />
+        )}
+      </>
+    );
+    const { rerender } = renderWithModalStack(renderStack(true));
+
+    fireEvent(screen.getByRole('dialog', { name: 'Outer dialog' }), new Event('cancel'));
+    fireEvent(screen.getByRole('dialog', { name: 'Inner dialog' }), new Event('cancel'));
+
+    expect(outerClose).not.toHaveBeenCalled();
+    expect(innerClose).not.toHaveBeenCalled();
+
+    rerender(renderStack(false));
+    fireEvent(screen.getByRole('dialog', { name: 'Outer dialog' }), new Event('cancel'));
+
+    expect(outerClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/modal/test/ModalStackIsolation.test.tsx
+++ b/packages/modal/test/ModalStackIsolation.test.tsx
@@ -1,0 +1,204 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { StrictMode } from 'react';
+import { createOverlayStore } from '@ilokesto/overlay';
+import type { OverlayStoreApi } from '@ilokesto/overlay';
+import { afterEach, describe, expect, it } from 'vitest';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ModalProvider } from '../src/components/ModalProvider';
+
+interface ModalFixture {
+  readonly id: string;
+  readonly label: string;
+  readonly transport?: 'inline' | 'top-layer';
+  readonly render?: () => React.ReactNode;
+}
+
+function openModal(store: OverlayStoreApi, fixture: ModalFixture) {
+  store.open({
+    id: fixture.id,
+    type: 'modal',
+    props: {
+      ariaLabel: fixture.label,
+      transport: fixture.transport,
+      render: fixture.render ?? (() => null),
+    },
+  });
+}
+
+describe('provider-scoped modal stacks', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = '';
+    document.getElementById('ilokesto-modal-styles')?.remove();
+  });
+
+  it('lets Escape dismiss the top inline modal in each provider', () => {
+    const firstStore = createOverlayStore();
+    const secondStore = createOverlayStore();
+
+    openModal(firstStore, { id: 'first-modal', label: 'First modal' });
+    openModal(secondStore, { id: 'second-modal', label: 'Second modal' });
+
+    render(
+      <>
+        <ModalProvider store={firstStore}>First provider</ModalProvider>
+        <ModalProvider store={secondStore}>Second provider</ModalProvider>
+      </>
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(firstStore.getSnapshot()[0]?.status).toBe('closing');
+    expect(secondStore.getSnapshot()[0]?.status).toBe('closing');
+  });
+
+  it('keeps focus wrapping local to the active provider modal', () => {
+    const firstStore = createOverlayStore();
+    const secondStore = createOverlayStore();
+
+    openModal(firstStore, {
+      id: 'first-modal',
+      label: 'First modal',
+      render: () => (
+        <>
+          <button type="button">First start</button>
+          <button type="button">First end</button>
+        </>
+      ),
+    });
+    openModal(secondStore, {
+      id: 'second-modal',
+      label: 'Second modal',
+      render: () => (
+        <>
+          <button type="button">Second start</button>
+          <button type="button">Second end</button>
+        </>
+      ),
+    });
+
+    render(
+      <>
+        <ModalProvider store={firstStore}>First provider</ModalProvider>
+        <ModalProvider store={secondStore}>Second provider</ModalProvider>
+      </>
+    );
+
+    screen.getByRole('button', { name: 'First end' }).focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+
+    expect(screen.getByRole('button', { name: 'First start' })).toHaveFocus();
+  });
+
+  it('handles top-layer cancel in the provider that owns the dialog', () => {
+    const firstStore = createOverlayStore();
+    const secondStore = createOverlayStore();
+
+    openModal(firstStore, {
+      id: 'first-dialog',
+      label: 'First dialog',
+      transport: 'top-layer',
+    });
+    openModal(secondStore, {
+      id: 'second-dialog',
+      label: 'Second dialog',
+      transport: 'top-layer',
+    });
+
+    render(
+      <>
+        <ModalProvider store={firstStore}>First provider</ModalProvider>
+        <ModalProvider store={secondStore}>Second provider</ModalProvider>
+      </>
+    );
+
+    fireEvent(screen.getByRole('dialog', { name: 'First dialog' }), new Event('cancel'));
+
+    expect(firstStore.getSnapshot()[0]?.status).toBe('closing');
+    expect(secondStore.getSnapshot()[0]?.status).toBe('open');
+  });
+
+  it('removes StrictMode registrations before assigning later stack indexes', () => {
+    const store = createOverlayStore();
+
+    openModal(store, { id: 'first-modal', label: 'First modal' });
+    openModal(store, { id: 'second-modal', label: 'Second modal' });
+
+    render(
+      <StrictMode>
+        <ModalProvider store={store}>Provider</ModalProvider>
+      </StrictMode>
+    );
+
+    let wrappers = document.querySelectorAll<HTMLElement>('.ilokesto-modal-inline-wrapper');
+    expect(wrappers[0]).toHaveStyle({ zIndex: '10000' });
+    expect(wrappers[1]).toHaveStyle({ zIndex: '10001' });
+
+    act(() => {
+      store.remove('second-modal');
+    });
+    act(() => {
+      openModal(store, { id: 'replacement-modal', label: 'Replacement modal' });
+    });
+
+    wrappers = document.querySelectorAll<HTMLElement>('.ilokesto-modal-inline-wrapper');
+    expect(wrappers[0]).toHaveStyle({ zIndex: '10000' });
+    expect(wrappers[1]).toHaveStyle({ zIndex: '10001' });
+  });
+
+  it('keeps a mounted provider isolated when its sibling provider unmounts', () => {
+    const firstStore = createOverlayStore();
+    const secondStore = createOverlayStore();
+
+    openModal(firstStore, { id: 'first-modal', label: 'First modal' });
+    openModal(secondStore, { id: 'second-modal', label: 'Second modal' });
+
+    const providers = (showFirst: boolean) => (
+      <>
+        {showFirst && <ModalProvider store={firstStore}>First provider</ModalProvider>}
+        <ModalProvider store={secondStore}>Second provider</ModalProvider>
+      </>
+    );
+    const { rerender } = render(providers(true));
+
+    rerender(providers(false));
+
+    const wrapper = document.querySelector<HTMLElement>('.ilokesto-modal-inline-wrapper');
+    expect(wrapper).toHaveStyle({ zIndex: '10000' });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss modal' }));
+
+    expect(secondStore.getSnapshot()[0]?.status).toBe('closing');
+  });
+
+  it.each([
+    ['first then second', ['first', 'second']],
+    ['second then first', ['second', 'first']],
+  ] as const)('restores body overflow after providers close %s', (_name, closeOrder) => {
+    const firstStore = createOverlayStore();
+    const secondStore = createOverlayStore();
+    const stores = { first: firstStore, second: secondStore };
+    const labels = { first: 'First modal', second: 'Second modal' };
+    document.body.style.overflow = 'clip';
+
+    openModal(firstStore, { id: 'first-modal', label: labels.first });
+    openModal(secondStore, { id: 'second-modal', label: labels.second });
+
+    render(
+      <>
+        <ModalProvider store={firstStore}>First provider</ModalProvider>
+        <ModalProvider store={secondStore}>Second provider</ModalProvider>
+      </>
+    );
+
+    for (const provider of closeOrder) {
+      act(() => {
+        stores[provider].close(`${provider}-modal`);
+      });
+      fireEvent.animationEnd(screen.getByRole('dialog', { name: labels[provider] }));
+    }
+
+    expect(document.body.style.overflow).toBe('clip');
+  });
+});

--- a/packages/modal/test/modalStackTestUtils.tsx
+++ b/packages/modal/test/modalStackTestUtils.tsx
@@ -1,0 +1,21 @@
+import { useMemo } from 'react';
+import type { ReactElement, ReactNode } from 'react';
+import { render } from '@testing-library/react';
+import {
+  createModalStackRuntime,
+  ModalStackRuntimeContext,
+} from '../src/hooks/useIsTopModal';
+
+function ModalStackTestProvider({ children }: { readonly children: ReactNode }) {
+  const runtime = useMemo(createModalStackRuntime, []);
+
+  return (
+    <ModalStackRuntimeContext.Provider value={runtime}>
+      {children}
+    </ModalStackRuntimeContext.Provider>
+  );
+}
+
+export function renderWithModalStack(element: ReactElement) {
+  return render(element, { wrapper: ModalStackTestProvider });
+}


### PR DESCRIPTION
## Summary
- give each `ModalProvider` an independent stack runtime for inline and top-layer policy
- preserve provider-local Escape, backdrop, focus, z-index, and scroll-lock behavior across distinct stores
- add unit, real Chromium, accessibility, architecture, bilingual docs, and patch changeset coverage

## Verification
- `pnpm --filter @ilokesto/modal typecheck`
- `pnpm --filter @ilokesto/modal test:ci`
- `pnpm test:monorepo`
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status`

Closes #10