### PR TITLE
test(utilinent): lock Mount async and proxy contract

### DIFF
--- a/.changeset/utilinent-mount-factory-async-types.md
+++ b/.changeset/utilinent-mount-factory-async-types.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/utilinent": patch
+---
+
+Reject direct Promise-like Mount children with React 19 types while preserving factory-only asynchronous children.

--- a/packages/utilinent/README.md
+++ b/packages/utilinent/README.md
@@ -91,6 +91,22 @@ export default UserListAfter;
 
 &nbsp;
 
+## Mount async contract
+
+`Mount` accepts direct non-Promise React nodes. Asynchronous work must be passed as a factory, so the contract remains the same with React 18 and React 19 types.
+
+```tsx
+import { Mount } from '@ilokesto/utilinent';
+
+<Mount fallback={<p>Loading preview...</p>} onError={reportError}>
+  {() => loadPreview().then((preview) => <Preview data={preview} />)}
+</Mount>
+```
+
+Direct `Promise` and `PromiseLike` children are intentionally rejected. A factory may return either a node synchronously or a `Promise` of a node.
+
+&nbsp;
+
 ## Custom proxy components
 
 If you want to build your own `Show`-style component (for example, `Clickable`),

--- a/packages/utilinent/docs/core-concepts.ko.mdx
+++ b/packages/utilinent/docs/core-concepts.ko.mdx
@@ -82,7 +82,7 @@ PluginManager.register({ show: { Link } });
 - `For`: list 또는 empty state.
 - `Repeat`: fixed count 또는 fallback.
 - `Switch` + `Match`: 처음 matching되는 branch.
-- `Mount`: promise를 포함한 node-producing function resolve.
+- `Mount`: Promise를 반환할 수 있는 node factory를 resolve합니다. React type version과 관계없이 직접 Promise-like child는 지원하지 않습니다.
 - `Observer`: element가 viewport와 intersect할 때 render.
 - `Slacker`: visible해질 때 data를 lazy load.
 - `Slot`: child component에 prop merge.

--- a/packages/utilinent/docs/core-concepts.mdx
+++ b/packages/utilinent/docs/core-concepts.mdx
@@ -82,7 +82,7 @@ Each component should describe one rendering responsibility:
 - `For`: list or empty state.
 - `Repeat`: fixed count or fallback.
 - `Switch` + `Match`: first matching branch.
-- `Mount`: resolve a node-producing function, including promises.
+- `Mount`: resolve a node factory that may return a Promise; direct Promise-like children are unsupported across React type versions.
 - `Observer`: render when an element intersects the viewport.
 - `Slacker`: load data lazily when visible.
 - `Slot`: merge props into a child component.

--- a/packages/utilinent/docs/reference/mount.ko.mdx
+++ b/packages/utilinent/docs/reference/mount.ko.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Mount"
-description: "직접 children, synchronous function, promise 기반 children을 fallback과 error handling으로 resolve합니다."
+description: "직접 node를 렌더링하거나 동기 및 비동기 node factory를 resolve합니다."
 ---
 
 # Mount
 
-`Mount`는 직접 children을 즉시 렌더링합니다. `children`이 function이면 mount 후 function을 호출하고 결과가 resolve될 때까지 `fallback`을 렌더링합니다.
+`Mount`는 직접 전달한 React node를 즉시 렌더링합니다. 비동기 작업은 Promise를 반환하는 factory로 전달해야 합니다. 직접 `Promise` 및 `PromiseLike` child는 React 18과 React 19 type 모두에서 지원하지 않습니다.
 
 ```tsx lineNumbers
 import { Mount } from '@ilokesto/utilinent';
@@ -19,9 +19,30 @@ import { Mount } from '@ilokesto/utilinent';
 
 | Prop | Type | 설명 |
 | --- | --- | --- |
-| `children` | `ReactNode`; `() => ReactNode`; `Promise<ReactNode>` | 직접 node 또는 node-producing function입니다. |
-| `fallback` | `ReactNode` | Function child가 pending이거나 error 이후 렌더링됩니다. |
-| `onError` | `(error) => void` | Child function이 throw/reject하면 호출됩니다. |
+| `children` | `MountNode \| (() => ReactNode \| Promise<ReactNode>)` | 직접 node 또는 동기/비동기 node factory입니다. `MountNode`는 `PromiseLike` 값을 제외한 `ReactNode`입니다. |
+| `fallback` | `ReactNode` | Factory의 초기 출력이며 Promise가 pending인 동안과 error 이후에 유지됩니다. 기본값은 `null`입니다. |
+| `onError` | `(error: unknown) => void` | 현재 factory가 throw 또는 reject하면 원래 error를 받습니다. |
+
+## Factory로만 비동기 작업 전달하기
+
+비동기 작업은 child factory 안에서 호출하세요.
+
+```tsx lineNumbers
+<Mount fallback={<Spinner />} onError={reportError}>
+  {() => loadPreview().then((preview) => <Preview data={preview} />)}
+</Mount>
+```
+
+Render 중에 작업을 시작하고 그 Promise를 `children`으로 직접 전달하지 마세요. React 19가 promise를 `ReactNode`에 포함하더라도 직접 `Promise<ReactElement>`, `Promise<string>`, 기타 `PromiseLike` child는 public type과 runtime contract 모두에서 의도적으로 지원하지 않습니다.
+
+## Timing, fallback, error
+
+- 직접 node는 초기 출력이며 `fallback`을 사용하지 않습니다.
+- Function child는 `fallback`으로 시작합니다. `Mount`는 commit 이후 layout effect에서 function을 호출합니다.
+- 동기 결과는 해당 effect에서 fallback을 교체하며, 일반적으로 browser paint 전에 반영됩니다.
+- Promise 결과가 pending인 동안에는 fallback이 계속 보입니다.
+- 동기 throw 또는 현재 Promise의 rejection은 fallback을 유지하고, 기존 console error를 기록하며, 실패한 invocation에 대해 `onError`를 한 번 호출합니다.
+- React Strict Mode는 development에서 effect를 다시 실행할 수 있으므로 factory는 여러 번 호출되어도 안전해야 합니다.
 
 ## Tag form
 
@@ -33,4 +54,6 @@ import { Mount } from '@ilokesto/utilinent';
 
 ## Race safety
 
-`Mount`는 call id를 추적해서 cleanup 이후나 더 최신 call 이후 도착한 stale async result를 무시합니다. 불필요한 재시작을 피하려면 `children`과 `onError` function을 가능하면 안정적으로 유지하세요.
+`children`이 바뀌면 더 최신 call이 시작됩니다. 이전 call의 fulfillment 또는 rejection은 무시되므로 현재 출력을 교체할 수 없고 `onError`도 호출하지 않습니다. Unmount 이후 settlement도 같은 방식으로 무시합니다. Pending 비동기 작업을 직접 node로 교체하면 해당 node를 즉시 표시합니다.
+
+불필요하게 effect를 다시 시작하지 않도록 `children`과 `onError` function을 가능하면 안정적으로 유지하세요.

--- a/packages/utilinent/docs/reference/mount.mdx
+++ b/packages/utilinent/docs/reference/mount.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Mount"
-description: "Resolve direct, synchronous, or promise-based children with fallback and error handling."
+description: "Render direct nodes or resolve synchronous and asynchronous node factories."
 ---
 
 # Mount
 
-`Mount` renders direct children immediately. If `children` is a function, it calls the function after mount and renders `fallback` until the result is resolved.
+`Mount` renders a direct React node immediately. To perform asynchronous work, pass a factory that returns a Promise. Direct `Promise` and `PromiseLike` children are unsupported with both React 18 and React 19 types.
 
 ```tsx lineNumbers
 import { Mount } from '@ilokesto/utilinent';
@@ -19,9 +19,30 @@ import { Mount } from '@ilokesto/utilinent';
 
 | Prop | Type | Description |
 | --- | --- | --- |
-| `children` | `ReactNode`; `() => ReactNode`; `Promise<ReactNode>` | Direct node or node-producing function. |
-| `fallback` | `ReactNode` | Rendered while a function child is pending or after an error. |
-| `onError` | `(error) => void` | Called when the child function throws or rejects. |
+| `children` | `MountNode \| (() => ReactNode \| Promise<ReactNode>)` | Direct node or a synchronous/asynchronous node factory. `MountNode` is `ReactNode` without `PromiseLike` values. |
+| `fallback` | `ReactNode` | Initial output for a factory, retained while its Promise is pending and after an error. Defaults to `null`. |
+| `onError` | `(error: unknown) => void` | Receives the original error when the current factory throws or rejects. |
+
+## Factory-only async work
+
+Call the asynchronous operation inside the child factory:
+
+```tsx lineNumbers
+<Mount fallback={<Spinner />} onError={reportError}>
+  {() => loadPreview().then((preview) => <Preview data={preview} />)}
+</Mount>
+```
+
+Do not start the operation during render and pass its Promise as `children`. Direct `Promise<ReactElement>`, `Promise<string>`, and other `PromiseLike` children are intentionally unsupported by both the public type and runtime contract, even though React 19 includes promises in `ReactNode`.
+
+## Timing, fallback, and errors
+
+- A direct node is the initial output and does not use `fallback`.
+- A function child starts with `fallback`. `Mount` invokes the function in a layout effect after commit.
+- A synchronous result replaces the fallback in that effect, normally before the browser paints.
+- A Promise result keeps the fallback visible until fulfillment.
+- A synchronous throw or active Promise rejection keeps the fallback visible, writes the existing console error, and calls `onError` once for that failed invocation.
+- React Strict Mode can replay effects in development, so factories must be safe to invoke more than once.
 
 ## Tag form
 
@@ -33,4 +54,6 @@ import { Mount } from '@ilokesto/utilinent';
 
 ## Race safety
 
-`Mount` tracks calls and ignores stale async results after cleanup or a newer call. Keep the `children` and `onError` functions stable when possible so work is not restarted unnecessarily.
+Changing `children` starts a newer call. Fulfillment or rejection from an older call is ignored: it cannot replace the current output and does not call `onError`. Settlements after unmount are ignored in the same way. Replacing pending async work with a direct node displays that node immediately.
+
+Keep the `children` and `onError` functions stable when possible so effects are not restarted unnecessarily.

--- a/packages/utilinent/package.json
+++ b/packages/utilinent/package.json
@@ -3,7 +3,9 @@
   "version": "1.1.4",
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p test/tsconfig.json && pnpm typecheck:react19",
+    "typecheck:react19": "pnpm build && tsc --noEmit -p test/react19/tsconfig.json"
   },
   "repository": {
     "type": "git",
@@ -44,6 +46,7 @@
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.31",
     "@types/react-dom": "^18.3.7",
+    "@types/react19": "npm:@types/react@19.2.18",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/packages/utilinent/src/components/Mount/types.ts
+++ b/packages/utilinent/src/components/Mount/types.ts
@@ -1,7 +1,9 @@
 import type { BaseTypeHelperFn, Fallback, ProxyType } from "../../types";
 
+type MountNode<Node = React.ReactNode> = Node extends PromiseLike<unknown> ? never : Node;
+
 export interface MountProps extends Fallback {
-  children: React.ReactNode | (() => React.ReactNode | Promise<React.ReactNode>);
+  children: MountNode | (() => React.ReactNode | Promise<React.ReactNode>);
   onError?: (error: unknown) => void;
 }
 

--- a/packages/utilinent/test/Mount.test.tsx
+++ b/packages/utilinent/test/Mount.test.tsx
@@ -1,0 +1,217 @@
+import { StrictMode, createRef, type ReactNode } from "react";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Mount } from "../src/index";
+
+function createDeferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+async function settle(settlement: () => void) {
+  await act(async () => {
+    settlement();
+    await Promise.resolve();
+  });
+}
+
+describe("Mount async contract", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders a direct React node immediately", () => {
+    render(<Mount fallback="loading">ready</Mount>);
+
+    expect(screen.getByText("ready")).toBeInTheDocument();
+    expect(screen.queryByText("loading")).not.toBeInTheDocument();
+  });
+
+  it("replaces the initial fallback with a synchronous factory result", () => {
+    const factory = vi.fn(() => <p>sync result</p>);
+
+    render(<Mount fallback="loading">{factory}</Mount>);
+
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("sync result")).toBeInTheDocument();
+    expect(screen.queryByText("loading")).not.toBeInTheDocument();
+  });
+
+  it("shows fallback until an async factory fulfills", async () => {
+    const deferred = createDeferred<ReactNode>();
+    render(<Mount fallback="loading">{() => deferred.promise}</Mount>);
+
+    expect(screen.getByText("loading")).toBeInTheDocument();
+
+    await settle(() => deferred.resolve(<p>async result</p>));
+
+    expect(screen.getByText("async result")).toBeInTheDocument();
+  });
+
+  it("keeps fallback and reports a synchronous factory throw once", () => {
+    const failure = new Error("sync failure");
+    const onError = vi.fn();
+    const factory = vi.fn((): ReactNode => {
+      throw failure;
+    });
+
+    render(
+      <Mount fallback="failed" onError={onError}>
+        {factory}
+      </Mount>,
+    );
+
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it("keeps fallback and reports an active rejection once", async () => {
+    const deferred = createDeferred<ReactNode>();
+    const failure = new Error("async failure");
+    const onError = vi.fn();
+    render(
+      <Mount fallback="failed" onError={onError}>
+        {() => deferred.promise}
+      </Mount>,
+    );
+
+    await settle(() => deferred.reject(failure));
+
+    expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it("ignores stale fulfillment after a newer async child resolves", async () => {
+    const stale = createDeferred<ReactNode>();
+    const current = createDeferred<ReactNode>();
+    const rendered = render(<Mount fallback="loading">{() => stale.promise}</Mount>);
+
+    rendered.rerender(<Mount fallback="loading">{() => current.promise}</Mount>);
+    await settle(() => current.resolve("current result"));
+    await settle(() => stale.resolve("stale result"));
+
+    expect(screen.getByText("current result")).toBeInTheDocument();
+    expect(screen.queryByText("stale result")).not.toBeInTheDocument();
+  });
+
+  it("ignores stale rejection after children are replaced", async () => {
+    const deferred = createDeferred<ReactNode>();
+    const onError = vi.fn();
+    const rendered = render(
+      <Mount fallback="loading" onError={onError}>
+        {() => deferred.promise}
+      </Mount>,
+    );
+
+    rendered.rerender(<Mount onError={onError}>replacement</Mount>);
+    await settle(() => deferred.reject(new Error("stale failure")));
+
+    expect(screen.getByText("replacement")).toBeInTheDocument();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("ignores fulfillment and rejection after unmount", async () => {
+    const fulfillment = createDeferred<ReactNode>();
+    const rejection = createDeferred<ReactNode>();
+    const onError = vi.fn();
+    const rendered = render(
+      <>
+        <Mount onError={onError}>{() => fulfillment.promise}</Mount>
+        <Mount onError={onError}>{() => rejection.promise}</Mount>
+      </>,
+    );
+
+    rendered.unmount();
+    await settle(() => fulfillment.resolve("late result"));
+    await settle(() => rejection.reject(new Error("late failure")));
+
+    expect(onError).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("replaces pending async work with a synchronous child", async () => {
+    const deferred = createDeferred<ReactNode>();
+    const rendered = render(<Mount fallback="loading">{() => deferred.promise}</Mount>);
+
+    rendered.rerender(<Mount>sync replacement</Mount>);
+    await settle(() => deferred.resolve("stale result"));
+
+    expect(screen.getByText("sync replacement")).toBeInTheDocument();
+    expect(screen.queryByText("stale result")).not.toBeInTheDocument();
+  });
+
+  it("accepts only the latest StrictMode factory settlement", async () => {
+    const attempts: Array<ReturnType<typeof createDeferred<ReactNode>>> = [];
+    const factory = vi.fn(() => {
+      const attempt = createDeferred<ReactNode>();
+      attempts.push(attempt);
+      return attempt.promise;
+    });
+    render(
+      <StrictMode>
+        <Mount fallback="loading">{factory}</Mount>
+      </StrictMode>,
+    );
+    const [stale, current] = attempts;
+    if (!stale || !current) {
+      throw new Error("Expected StrictMode to invoke the factory twice");
+    }
+
+    await settle(() => stale.resolve("stale result"));
+    expect(screen.getByText("loading")).toBeInTheDocument();
+
+    await settle(() => current.resolve("current result"));
+    expect(screen.getByText("current result")).toBeInTheDocument();
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Mount proxy contract", () => {
+  it("renders Mount.div content and forwards common host props and its ref", () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Mount.div
+        ref={ref}
+        className="preview"
+        data-state="ready"
+        aria-label="Preview"
+        data-testid="mount-div"
+      >
+        content
+      </Mount.div>,
+    );
+
+    const element = screen.getByTestId("mount-div");
+    expect(element.tagName).toBe("DIV");
+    expect(element).toHaveTextContent("content");
+    expect(element).toHaveClass("preview");
+    expect(element).toHaveAttribute("data-state", "ready");
+    expect(element).toHaveAccessibleName("Preview");
+    expect(ref.current).toBe(element);
+  });
+
+  it("forwards element-specific props and a concrete DOM ref", () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(
+      <Mount.button ref={ref} type="submit">
+        Submit
+      </Mount.button>,
+    );
+
+    const button = screen.getByRole("button", { name: "Submit" });
+    expect(button).toBeInstanceOf(HTMLButtonElement);
+    expect(button).toHaveAttribute("type", "submit");
+    expect(ref.current).toBe(button);
+  });
+});

--- a/packages/utilinent/test/react19/Mount.test-d.ts
+++ b/packages/utilinent/test/react19/Mount.test-d.ts
@@ -1,0 +1,46 @@
+import type { ReactElement, ReactNode } from "react";
+import { Mount } from "@ilokesto/utilinent";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends
+  (<Value>() => Value extends Right ? 1 : 2)
+    ? (<Value>() => Value extends Right ? 1 : 2) extends
+        (<Value>() => Value extends Left ? 1 : 2)
+      ? true
+      : false
+    : false;
+
+type IsAssignable<From, To> = [From] extends [To] ? true : false;
+type Assert<Condition extends true> = Condition;
+
+type MountChildren = Parameters<typeof Mount>[0]["children"];
+type React19IncludesElementPromise = Assert<
+  IsAssignable<Promise<ReactElement>, ReactNode>
+>;
+type DirectElementPromiseIsRejected = Assert<
+  Equal<IsAssignable<Promise<ReactElement>, MountChildren>, false>
+>;
+type DirectStringPromiseIsRejected = Assert<
+  Equal<IsAssignable<Promise<string>, MountChildren>, false>
+>;
+type DirectPromiseLikeValuesAreExcluded = Assert<
+  Equal<Extract<MountChildren, PromiseLike<unknown>>, never>
+>;
+type AsyncElementFactoryIsAccepted = Assert<
+  IsAssignable<() => Promise<ReactElement>, MountChildren>
+>;
+type AsyncNodeFactoryIsAccepted = Assert<
+  IsAssignable<() => Promise<ReactNode>, MountChildren>
+>;
+type AsyncStringFactoryIsAccepted = Assert<
+  IsAssignable<() => Promise<string>, MountChildren>
+>;
+
+export type MountReact19TypeContract =
+  | React19IncludesElementPromise
+  | DirectElementPromiseIsRejected
+  | DirectStringPromiseIsRejected
+  | DirectPromiseLikeValuesAreExcluded
+  | AsyncElementFactoryIsAccepted
+  | AsyncNodeFactoryIsAccepted
+  | AsyncStringFactoryIsAccepted;

--- a/packages/utilinent/test/react19/tsconfig.json
+++ b/packages/utilinent/test/react19/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "baseUrl": "../..",
+    "checkJs": false,
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "paths": {
+      "@ilokesto/utilinent": ["dist/index.d.ts"],
+      "react": ["node_modules/@types/react19"],
+      "react/*": ["node_modules/@types/react19/*"]
+    },
+    "types": ["@types/react19"]
+  },
+  "include": ["./Mount.test-d.ts"]
+}

--- a/packages/utilinent/test/tsconfig.json
+++ b/packages/utilinent/test/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "moduleResolution": "Bundler",
+    "noEmit": true
+  },
+  "include": ["../src", "./**/*.ts", "./**/*.tsx"],
+  "exclude": ["./react19"]
+}

--- a/packages/utilinent/test/types/Mount.test-d.tsx
+++ b/packages/utilinent/test/types/Mount.test-d.tsx
@@ -1,0 +1,135 @@
+import {
+  forwardRef,
+  type ComponentRef,
+  type ReactElement,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { Mount } from "../../src/index";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends
+  (<Value>() => Value extends Right ? 1 : 2)
+    ? (<Value>() => Value extends Right ? 1 : 2) extends
+        (<Value>() => Value extends Left ? 1 : 2)
+      ? true
+      : false
+    : false;
+
+type IsAssignable<From, To> = [From] extends [To] ? true : false;
+type Assert<Condition extends true> = Condition;
+type NonPromiseNode<Node> = Node extends PromiseLike<unknown> ? never : Node;
+
+type MountChildren = Parameters<typeof Mount>[0]["children"];
+type ExpectedMountNode = NonPromiseNode<ReactNode>;
+type ExpectedMountChildren =
+  | ExpectedMountNode
+  | (() => ReactNode | Promise<ReactNode>);
+
+type MountChildrenRemainExact = Assert<Equal<MountChildren, ExpectedMountChildren>>;
+type DirectNodeIsAccepted = Assert<IsAssignable<ReactNode, MountChildren>>;
+type SyncFactoryIsAccepted = Assert<IsAssignable<() => ReactNode, MountChildren>>;
+type AsyncFactoryIsAccepted = Assert<
+  IsAssignable<() => Promise<ReactNode>, MountChildren>
+>;
+type DirectElementPromiseIsRejected = Assert<
+  Equal<IsAssignable<Promise<ReactElement>, MountChildren>, false>
+>;
+type DirectStringPromiseIsRejected = Assert<
+  Equal<IsAssignable<Promise<string>, MountChildren>, false>
+>;
+type DirectPromiseLikeValuesAreExcluded = Assert<
+  Equal<Extract<MountChildren, PromiseLike<unknown>>, never>
+>;
+
+type DivProps = Parameters<typeof Mount.div>[0];
+type DivHostPropsAreAccepted = Assert<
+  IsAssignable<
+    {
+      readonly children: ReactNode;
+      readonly className: string;
+      readonly "aria-label": string;
+      readonly ref: RefObject<HTMLDivElement>;
+    },
+    DivProps
+  >
+>;
+type DivRefIsConcrete = Assert<Equal<ComponentRef<typeof Mount.div>, HTMLDivElement>>;
+
+type ButtonProps = Parameters<typeof Mount.button>[0];
+type ButtonSpecificPropsAreAccepted = Assert<
+  IsAssignable<
+    {
+      readonly children: ReactNode;
+      readonly type: "submit";
+      readonly ref: RefObject<HTMLButtonElement>;
+    },
+    ButtonProps
+  >
+>;
+type ButtonRejectsWrongRef = Assert<
+  Equal<
+    IsAssignable<
+      {
+        readonly children: ReactNode;
+        readonly ref: RefObject<HTMLAnchorElement>;
+      },
+      ButtonProps
+    >,
+    false
+  >
+>;
+
+type CustomTargetProps = {
+  readonly children?: ReactNode;
+  readonly destination: string;
+};
+
+const CustomTarget = forwardRef<HTMLAnchorElement, CustomTargetProps>(function CustomTarget(
+  { children, destination },
+  ref,
+) {
+  return (
+    <a ref={ref} href={destination}>
+      {children}
+    </a>
+  );
+});
+
+declare module "../../src/types/register" {
+  interface UtilinentRegister {
+    readonly mount: {
+      readonly CustomTarget: typeof CustomTarget;
+    };
+  }
+}
+
+type CustomMountProps = Parameters<typeof Mount.CustomTarget>[0];
+type CustomMountPropsAreAccepted = Assert<
+  IsAssignable<
+    {
+      readonly children: () => Promise<ReactNode>;
+      readonly destination: string;
+      readonly ref: RefObject<HTMLAnchorElement>;
+    },
+    CustomMountProps
+  >
+>;
+type CustomMountRefIsConcrete = Assert<
+  Equal<ComponentRef<typeof Mount.CustomTarget>, HTMLAnchorElement>
+>;
+
+export type MountTypeContract =
+  | MountChildrenRemainExact
+  | DirectNodeIsAccepted
+  | SyncFactoryIsAccepted
+  | AsyncFactoryIsAccepted
+  | DirectElementPromiseIsRejected
+  | DirectStringPromiseIsRejected
+  | DirectPromiseLikeValuesAreExcluded
+  | DivHostPropsAreAccepted
+  | DivRefIsConcrete
+  | ButtonSpecificPropsAreAccepted
+  | ButtonRejectsWrongRef
+  | CustomMountPropsAreAccepted
+  | CustomMountRefIsConcrete;

--- a/packages/utilinent/tsconfig.json
+++ b/packages/utilinent/tsconfig.json
@@ -12,6 +12,7 @@
     "allowJs": true,
     "checkJs": true,
     "esModuleInterop": true,
+    "types": ["react"]
   },
   "include": ["src", "src/index.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,6 +435,9 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.7
         version: 18.3.7(@types/react@18.3.31)
+      '@types/react19':
+        specifier: npm:@types/react@19.2.18
+        version: '@types/react@19.2.18'
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.7.1
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)


### PR DESCRIPTION
## Summary
- lock synchronous, asynchronous, error, race, unmount, Strict Mode, proxy prop, and ref behavior for `Mount`
- reject direct Promise-like children while preserving async factories across React 18 and React 19 declarations
- align README and bilingual reference documentation with the factory-only async contract

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @ilokesto/utilinent test`
- `pnpm --filter @ilokesto/utilinent typecheck`
- `pnpm test:monorepo`
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status`

Closes #16