### PR TITLE
fix(modal): dismiss only actual top-layer backdrop clicks

### DIFF
--- a/.changeset/modal-top-layer-backdrop-11.md
+++ b/.changeset/modal-top-layer-backdrop-11.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/modal": patch
+---
+
+Dismiss top-layer modals only when a click lands on the native dialog backdrop, not its content or padding. Fixes #11.

--- a/packages/modal/e2e/fixture/src/App.tsx
+++ b/packages/modal/e2e/fixture/src/App.tsx
@@ -39,15 +39,26 @@ function InlineConfirmButton() {
 function TopLayerButton() {
   const { display } = useModal();
   const [result, setResult] = useState('pending');
+  const [dismissCount, setDismissCount] = useState(0);
 
   const open = async () => {
     const saved = await display<boolean>({
       id: 'top-layer-settings',
       transport: 'top-layer',
-      ariaLabel: 'Settings dialog',
+      ariaLabelledBy: 'top-layer-settings-title',
+      ariaDescribedBy: 'top-layer-settings-description',
+      onDismiss: () => setDismissCount((count) => count + 1),
+      style: {
+        boxSizing: 'border-box',
+        width: 320,
+        height: 240,
+        padding: 48,
+      },
       render: (close) => (
-        <section>
-          <h2>Settings</h2>
+        <section aria-label="Settings content">
+          <h2 id="top-layer-settings-title">Settings dialog</h2>
+          <p id="top-layer-settings-description">Configure your modal preferences.</p>
+          <button type="button">Keep settings open</button>
           <button type="button" onClick={() => close(true)}>Save settings</button>
         </section>
       ),
@@ -60,6 +71,7 @@ function TopLayerButton() {
     <section aria-label="Top layer modal demo">
       <button type="button" onClick={open}>Open top-layer settings</button>
       <p>Top-layer result: {result}</p>
+      <p>Top-layer dismiss count: {dismissCount}</p>
     </section>
   );
 }

--- a/packages/modal/e2e/modal.e2e.ts
+++ b/packages/modal/e2e/modal.e2e.ts
@@ -43,6 +43,65 @@ test('top-layer dialog opens and resolves in a real browser', async ({ page }) =
   await expect(page.getByText('Top-layer result: true')).toBeVisible();
 });
 
+test('top-layer descendant and padding clicks keep the dialog open', async ({ page }) => {
+  // Given
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open top-layer settings' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Settings dialog' });
+  await expect(dialog).toHaveAccessibleDescription('Configure your modal preferences.');
+  const dialogBox = await dialog.boundingBox();
+  if (dialogBox === null) {
+    throw new TypeError('Visible top-layer dialog has no bounding box.');
+  }
+  const contentBox = await page.getByRole('region', { name: 'Settings content' }).boundingBox();
+  if (contentBox === null) {
+    throw new TypeError('Visible top-layer content has no bounding box.');
+  }
+  const descendantBox = await page.getByRole('button', { name: 'Keep settings open' }).boundingBox();
+  if (descendantBox === null) {
+    throw new TypeError('Visible top-layer descendant has no bounding box.');
+  }
+  const paddingX = dialogBox.x + 16;
+  const paddingY = dialogBox.y + 16;
+  expect(paddingX).toBeGreaterThan(dialogBox.x);
+  expect(paddingX).toBeLessThan(dialogBox.x + dialogBox.width);
+  expect(paddingY).toBeGreaterThan(dialogBox.y);
+  expect(paddingY).toBeLessThan(dialogBox.y + dialogBox.height);
+  expect(paddingX).toBeLessThan(contentBox.x);
+  expect(paddingY).toBeLessThan(contentBox.y);
+
+  // When
+  await page.mouse.click(
+    descendantBox.x + descendantBox.width / 2,
+    descendantBox.y + descendantBox.height / 2
+  );
+  await page.mouse.click(paddingX, paddingY);
+
+  // Then
+  await expect(dialog).toBeVisible();
+  await expect(page.getByText('Top-layer dismiss count: 0')).toBeVisible();
+  await expect(page.getByText('Top-layer result: pending')).toBeVisible();
+});
+
+test('physical top-layer backdrop click dismisses exactly once', async ({ page }) => {
+  // Given
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Open top-layer settings' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Settings dialog' });
+  const dialogBox = await dialog.boundingBox();
+  if (dialogBox === null) {
+    throw new TypeError('Visible top-layer dialog has no bounding box.');
+  }
+
+  // When
+  await page.mouse.click(dialogBox.x - 16, dialogBox.y + dialogBox.height / 2);
+
+  // Then
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText('Top-layer dismiss count: 1')).toBeVisible();
+  await expect(page.getByText('Top-layer result: undefined')).toBeVisible();
+});
+
 test('reduced motion disables modal animation on first render', async ({ page }) => {
   await page.emulateMedia({ reducedMotion: 'reduce' });
   await page.goto('/');

--- a/packages/modal/src/adapters/ModalAdapterTopLayer.tsx
+++ b/packages/modal/src/adapters/ModalAdapterTopLayer.tsx
@@ -117,14 +117,15 @@ export function ModalAdapterTopLayer<TResult>({
     };
 
     const handleClick = (e: MouseEvent) => {
-      // The native dialog fills the viewport, but clicking its ::backdrop counts as clicking the dialog.
-      // We only close if they click exactly the dialog element (the bounds), which includes the backdrop.
-      // But wait: if the dialog is purely the content, clicking the content is ALSO clicking the dialog,
-      // UNLESS the content is wrapped in a child div. Wait, e.target === dialog works because
-      // if they click the content, e.target is the content element or its children.
       if (isTopModal && dismissible && e.target === dialog && status !== 'closing') {
-        onDismiss?.();
-        close();
+        const { left, right, top, bottom } = dialog.getBoundingClientRect();
+        const isBackdropClick = e.clientX < left || e.clientX > right ||
+          e.clientY < top || e.clientY > bottom;
+
+        if (isBackdropClick) {
+          onDismiss?.();
+          close();
+        }
       }
     };
 

--- a/packages/modal/test/ModalAdapterTopLayer.test.tsx
+++ b/packages/modal/test/ModalAdapterTopLayer.test.tsx
@@ -47,6 +47,132 @@ describe('ModalAdapterTopLayer', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ['interior', 200, 300],
+    ['left edge', 100, 300],
+    ['right edge', 300, 300],
+    ['top edge', 200, 200],
+    ['bottom edge', 200, 400],
+  ])('keeps a click on the dialog %s open', (_location, clientX, clientY) => {
+    // Given
+    const close = vi.fn();
+    const onDismiss = vi.fn();
+    renderWithModalStack(
+      <ModalAdapterTopLayer
+        id="modal-id"
+        isOpen
+        status="open"
+        close={close}
+        remove={vi.fn()}
+        onDismiss={onDismiss}
+        ariaLabel="Bounded dialog"
+        render={() => null}
+      />
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Bounded dialog' });
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue(new DOMRect(100, 200, 200, 200));
+
+    // When
+    fireEvent.click(dialog, { clientX, clientY });
+
+    // Then
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['left', 99, 300],
+    ['right', 301, 300],
+    ['above', 200, 199],
+    ['below', 200, 401],
+  ])('dismisses once for a click strictly %s the dialog border box', (_direction, clientX, clientY) => {
+    // Given
+    const close = vi.fn();
+    const onDismiss = vi.fn();
+    renderWithModalStack(
+      <ModalAdapterTopLayer
+        id="modal-id"
+        isOpen
+        status="open"
+        close={close}
+        remove={vi.fn()}
+        onDismiss={onDismiss}
+        ariaLabel="Backdrop dialog"
+        render={() => null}
+      />
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Backdrop dialog' });
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue(new DOMRect(100, 200, 200, 200));
+
+    // When
+    fireEvent.click(dialog, { clientX, clientY });
+
+    // Then
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a descendant target even when its click coordinates are outside', () => {
+    // Given
+    const close = vi.fn();
+    const onDismiss = vi.fn();
+    renderWithModalStack(
+      <ModalAdapterTopLayer
+        id="modal-id"
+        isOpen
+        status="open"
+        close={close}
+        remove={vi.fn()}
+        onDismiss={onDismiss}
+        ariaLabel="Descendant dialog"
+        render={() => <button type="button">Keep open</button>}
+      />
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Descendant dialog' });
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue(new DOMRect(100, 200, 200, 200));
+
+    // When
+    fireEvent.click(screen.getByRole('button', { name: 'Keep open' }), {
+      clientX: 99,
+      clientY: 300,
+    });
+
+    // Then
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['non-dismissible', false, 'open' as const],
+    ['closing', true, 'closing' as const],
+  ])('ignores an outside click when the dialog is %s', (_condition, dismissible, status) => {
+    // Given
+    const close = vi.fn();
+    const onDismiss = vi.fn();
+    renderWithModalStack(
+      <ModalAdapterTopLayer
+        id="modal-id"
+        isOpen={status === 'open'}
+        status={status}
+        close={close}
+        remove={vi.fn()}
+        dismissible={dismissible}
+        onDismiss={onDismiss}
+        ariaLabel="Guarded dialog"
+        render={() => null}
+      />
+    );
+    const dialog = screen.getByRole('dialog', { name: 'Guarded dialog' });
+    vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue(new DOMRect(100, 200, 200, 200));
+
+    // When
+    fireEvent.click(dialog, { clientX: 99, clientY: 300 });
+
+    // Then
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(close).not.toHaveBeenCalled();
+  });
+
   it('passes scoped close to render content', () => {
     const close = vi.fn();
 

--- a/packages/modal/test/ModalStackBehavior.test.tsx
+++ b/packages/modal/test/ModalStackBehavior.test.tsx
@@ -96,4 +96,68 @@ describe('same-provider modal stack behavior', () => {
 
     expect(outerClose).toHaveBeenCalledTimes(1);
   });
+
+  it('transitions backdrop ownership after the closing top-layer entry unmounts', () => {
+    // Given
+    const outerClose = vi.fn();
+    const outerDismiss = vi.fn();
+    const innerClose = vi.fn();
+    const innerDismiss = vi.fn();
+    const renderStack = (showInner: boolean) => (
+      <>
+        <ModalAdapterTopLayer
+          id="outer-dialog"
+          isOpen
+          status="open"
+          close={outerClose}
+          remove={vi.fn()}
+          onDismiss={outerDismiss}
+          ariaLabel="Outer bounded dialog"
+          render={() => null}
+        />
+        {showInner && (
+          <ModalAdapterTopLayer
+            id="inner-dialog"
+            isOpen={false}
+            status="closing"
+            close={innerClose}
+            remove={vi.fn()}
+            onDismiss={innerDismiss}
+            ariaLabel="Inner closing dialog"
+            render={() => null}
+          />
+        )}
+      </>
+    );
+    const { rerender } = renderWithModalStack(renderStack(true));
+    const outerDialog = screen.getByRole('dialog', { name: 'Outer bounded dialog' });
+    const innerDialog = screen.getByRole('dialog', { name: 'Inner closing dialog' });
+    vi.spyOn(outerDialog, 'getBoundingClientRect').mockReturnValue(new DOMRect(100, 200, 200, 200));
+    vi.spyOn(innerDialog, 'getBoundingClientRect').mockReturnValue(new DOMRect(120, 220, 160, 160));
+
+    // When
+    fireEvent.click(outerDialog, { clientX: 99, clientY: 300 });
+    fireEvent.click(innerDialog, { clientX: 119, clientY: 300 });
+
+    // Then
+    expect(outerDismiss).not.toHaveBeenCalled();
+    expect(outerClose).not.toHaveBeenCalled();
+    expect(innerDismiss).not.toHaveBeenCalled();
+    expect(innerClose).not.toHaveBeenCalled();
+
+    // When
+    rerender(renderStack(false));
+    fireEvent.click(outerDialog, { clientX: 200, clientY: 300 });
+
+    // Then
+    expect(outerDismiss).not.toHaveBeenCalled();
+    expect(outerClose).not.toHaveBeenCalled();
+
+    // When
+    fireEvent.click(outerDialog, { clientX: 99, clientY: 300 });
+
+    // Then
+    expect(outerDismiss).toHaveBeenCalledTimes(1);
+    expect(outerClose).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary
- distinguish native dialog backdrop clicks from padding and empty interior using viewport border-box coordinates
- preserve provider-scoped topness, dismissibility, closing-state, inline, and callback policies
- add deterministic unit/integration and physical Chromium coverage plus a modal patch changeset

## Verification
- `pnpm --filter @ilokesto/modal typecheck`
- `pnpm --filter @ilokesto/modal test`
- `pnpm --filter @ilokesto/modal test:e2e`
- `pnpm --filter @ilokesto/modal test:a11y`
- `pnpm --filter @ilokesto/modal test:pack`
- `pnpm test:monorepo`
- `pnpm typecheck`
- `pnpm test`
- `pnpm changeset:status`

Closes #11