### PR TITLE
fix(toast): clear removed Toaster view defaults

### DIFF
--- a/.changeset/toast-view-config-reset-12.md
+++ b/.changeset/toast-view-config-reset-12.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/toast": patch
+---
+
+Clear removed Toaster default options for future toasts while preserving already resolved toast items. Fixes #12.

--- a/packages/toast/src/core/createToastRuntime.ts
+++ b/packages/toast/src/core/createToastRuntime.ts
@@ -227,9 +227,7 @@ export function createToastRuntime(toasterId: ToasterId): ToastRuntimeApi {
 
     view.limit = nextLimit;
     view.position = config.position;
-    if (config.toastOptions !== undefined) {
-      view.toastOptions = config.toastOptions;
-    }
+    view.toastOptions = config.toastOptions;
     notify();
   }
 

--- a/packages/toast/test/Toaster.view-config.test.tsx
+++ b/packages/toast/test/Toaster.view-config.test.tsx
@@ -1,0 +1,66 @@
+import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Toaster } from "../src/components/Toaster";
+import { getRuntime } from "../src/core/registry";
+import { toast } from "../src/core/toast";
+import type { DefaultToastOptions } from "../src/types/toast";
+
+const TOASTER_ID = "view-config-toaster";
+const CONFIGURED_TOAST_OPTIONS = {
+  duration: 60_000,
+  className: "configured-row",
+  ariaProps: {
+    role: "alert",
+    "aria-live": "assertive",
+    "aria-atomic": false,
+  },
+} satisfies DefaultToastOptions;
+
+afterEach(() => {
+  cleanup();
+  expect(getRuntime(TOASTER_ID)).toBeUndefined();
+});
+
+describe("Toaster view configuration", () => {
+  it("clears removed defaults after rerender while preserving the existing accessible toast row", async () => {
+    // Given
+    const view = render(
+      <Toaster
+        toasterId={TOASTER_ID}
+        toastOptions={CONFIGURED_TOAST_OPTIONS}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getRuntime(TOASTER_ID)).toBeDefined();
+    });
+
+    const region = screen.getByRole("region", { name: "Notifications" });
+
+    act(() => {
+      toast("Configured toast", { toasterId: TOASTER_ID });
+    });
+
+    const configuredRow = await within(region).findByRole("alert");
+    expect(configuredRow).toHaveTextContent("Configured toast");
+    expect(configuredRow).toHaveClass("configured-row");
+    expect(configuredRow).toHaveAttribute("aria-live", "assertive");
+    expect(configuredRow).toHaveAttribute("aria-atomic", "false");
+
+    // When
+    view.rerender(<Toaster toasterId={TOASTER_ID} />);
+
+    act(() => {
+      toast("Unconfigured toast", { toasterId: TOASTER_ID });
+    });
+
+    // Then
+    const unconfiguredRow = await within(region).findByRole("status");
+    expect(unconfiguredRow).toHaveTextContent("Unconfigured toast");
+    expect(unconfiguredRow).not.toHaveClass("configured-row");
+    expect(unconfiguredRow).toHaveAttribute("aria-live", "polite");
+    expect(unconfiguredRow).toHaveAttribute("aria-atomic", "true");
+    expect(within(region).getByRole("alert")).toBe(configuredRow);
+    expect(configuredRow).toHaveTextContent("Configured toast");
+  });
+});

--- a/packages/toast/test/createToastRuntime.view-config.test.ts
+++ b/packages/toast/test/createToastRuntime.view-config.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createToastRuntime } from "../src/core/createToastRuntime";
+import type {
+  DefaultToastOptions,
+  ToastRuntimeApi,
+} from "../src/types/toast";
+
+const CONFIGURED_TOAST_OPTIONS = {
+  duration: 12_345,
+  removeDelay: 678,
+  className: "configured-toast",
+  style: { backgroundColor: "rgb(12, 34, 56)" },
+  ariaProps: {
+    role: "alert",
+    "aria-live": "assertive",
+    "aria-atomic": false,
+  },
+} satisfies DefaultToastOptions;
+
+let runtime: ToastRuntimeApi | undefined;
+
+afterEach(() => {
+  runtime?.clear();
+  runtime = undefined;
+  vi.useRealTimers();
+});
+
+describe("createToastRuntime view configuration", () => {
+  it("clears removed toast defaults for future items without changing resolved existing items", () => {
+    // Given
+    vi.useFakeTimers();
+    runtime = createToastRuntime("view-defaults-runtime");
+    runtime.configureView({
+      limit: 10,
+      position: "top-right",
+      toastOptions: CONFIGURED_TOAST_OPTIONS,
+    });
+    runtime.addToast("blank", "Configured toast", { id: "configured" });
+    const configuredItem = runtime.getRawSnapshot()[0];
+
+    expect(configuredItem).toMatchObject({
+      duration: 12_345,
+      removeDelay: 678,
+      className: "configured-toast",
+      style: { backgroundColor: "rgb(12, 34, 56)" },
+      ariaProps: {
+        role: "alert",
+        "aria-live": "assertive",
+        "aria-atomic": false,
+      },
+    });
+
+    // When
+    runtime.configureView({
+      limit: 10,
+      position: "top-right",
+      toastOptions: undefined,
+    });
+    runtime.addToast("blank", "Unconfigured toast", { id: "unconfigured" });
+
+    // Then
+    const [preservedItem, unconfiguredItem] = runtime.getRawSnapshot();
+    expect(preservedItem).toBe(configuredItem);
+    expect(preservedItem).toMatchObject({
+      duration: 12_345,
+      removeDelay: 678,
+      className: "configured-toast",
+      style: { backgroundColor: "rgb(12, 34, 56)" },
+      ariaProps: {
+        role: "alert",
+        "aria-live": "assertive",
+        "aria-atomic": false,
+      },
+    });
+    expect(unconfiguredItem?.className).toBeUndefined();
+    expect(unconfiguredItem?.duration).toBe(4_000);
+    expect(unconfiguredItem?.removeDelay).toBe(1_000);
+    expect(unconfiguredItem?.style).toEqual({});
+    expect(unconfiguredItem?.ariaProps).toEqual({
+      role: "status",
+      "aria-live": "polite",
+      "aria-atomic": true,
+    });
+  });
+
+  it("invalidates the visible snapshot when position changes", () => {
+    // Given
+    runtime = createToastRuntime("position-runtime");
+    runtime.configureView({ limit: 10, position: "top-right" });
+    runtime.addToast("blank", "Top toast", {
+      id: "top",
+      duration: Number.POSITIVE_INFINITY,
+      position: "top-right",
+    });
+    runtime.addToast("blank", "Bottom toast", {
+      id: "bottom",
+      duration: Number.POSITIVE_INFINITY,
+      position: "bottom-left",
+    });
+    const topSnapshot = runtime.getSnapshot();
+
+    // When
+    runtime.configureView({ limit: 10, position: "bottom-left" });
+
+    // Then
+    const bottomSnapshot = runtime.getSnapshot();
+    expect(bottomSnapshot).not.toBe(topSnapshot);
+    expect(bottomSnapshot.map((item) => item.message)).toEqual(["Bottom toast"]);
+  });
+
+  it("invalidates the visible snapshot when limit changes", () => {
+    // Given
+    runtime = createToastRuntime("limit-runtime");
+    runtime.configureView({ limit: 2, position: "top-right" });
+    runtime.addToast("blank", "First toast", {
+      id: "first",
+      duration: Number.POSITIVE_INFINITY,
+    });
+    runtime.addToast("blank", "Second toast", {
+      id: "second",
+      duration: Number.POSITIVE_INFINITY,
+    });
+    const twoItemSnapshot = runtime.getSnapshot();
+
+    // When
+    runtime.configureView({ limit: 1, position: "top-right" });
+
+    // Then
+    const oneItemSnapshot = runtime.getSnapshot();
+    expect(oneItemSnapshot).not.toBe(twoItemSnapshot);
+    expect(oneItemSnapshot.map((item) => item.message)).toEqual(["First toast"]);
+  });
+});


### PR DESCRIPTION
## Summary

- treat each `configureView` payload as the complete current view configuration
- clear removed `toastOptions` for future toasts without mutating already resolved items
- cover direct runtime behavior, mounted `Toaster` rerenders, position/limit snapshots, registry cleanup, and row/region ARIA
- add an `@ilokesto/toast` patch changeset

## Package verifier decision

No `test:pack` or `test:dist` script is added. This patch changes no exports, manifest fields, entrypoints, or distribution shape; source tests, typecheck, build, and the existing monorepo gates cover the changed contract. A package-wide artifact verifier can be considered separately.

## Verification

- `pnpm --filter @ilokesto/toast test` (44 passed)
- `pnpm --filter @ilokesto/toast typecheck`
- `pnpm --filter @ilokesto/toast build`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm test:monorepo` (15 passed)
- `pnpm changeset:status`
- independent built-package RTL/jsdom QA (18 passed)

## Blocker

Do not merge until `@ilokesto/overlay@1.1.1` from release PR #1 is published to npm, as required by issue #12. This PR intentionally does not publish or merge the release PR.

Closes #12