### PR TITLE
fix(utilinent): process initial IntersectionObserver record so Slacker loads when visible on mount

### DIFF
--- a/.changeset/utilinent-intersection-initial-record.md
+++ b/.changeset/utilinent-intersection-initial-record.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/utilinent": patch
+---
+
+Process initially visible IntersectionObserver records so Slacker loads on mount and triggerOnce observers disconnect immediately.

--- a/packages/utilinent/src/hooks/useIntersectionObserver.ts
+++ b/packages/utilinent/src/hooks/useIntersectionObserver.ts
@@ -31,7 +31,6 @@ export function useIntersectionObserver({
   const [entry, setEntry] = useState<IntersectionObserverEntry | undefined>();
 
   const onChangeRef = useRef(onChange);
-  const isFirstCallbackRef = useRef(true);
   const isFrozen = useRef(false);
   const prevIsIntersectingRef = useRef(initialIsIntersecting);
 
@@ -81,12 +80,6 @@ export function useIntersectionObserver({
       setIsIntersecting(isCurrentlyIntersecting);
       setEntry(intersectionEntry);
 
-      // Skip the first callback (initial observation)
-      if (isFirstCallbackRef.current) {
-        isFirstCallbackRef.current = false;
-        return;
-      }
-
       // Call onChange callback
       if (!wasIntersecting && isCurrentlyIntersecting) {
         onChangeRef.current?.(isCurrentlyIntersecting, intersectionEntry);
@@ -112,7 +105,6 @@ export function useIntersectionObserver({
     if (!element) {
       setIsIntersecting(initialIsIntersecting);
       setEntry(undefined);
-      isFirstCallbackRef.current = true;
       prevIsIntersectingRef.current = initialIsIntersecting;
 
       if (!freezeOnceVisible) {

--- a/packages/utilinent/test/controlledIntersectionObserver.ts
+++ b/packages/utilinent/test/controlledIntersectionObserver.ts
@@ -65,11 +65,30 @@ export function installControlledIntersectionObserver() {
   globalThis.IntersectionObserver = ControlledIntersectionObserver;
 }
 
-export async function enterViewport() {
+function getActiveObserver() {
   const observer = [...observers].reverse().find((candidate) => candidate.active);
   if (!observer) {
     throw new Error("Expected an active IntersectionObserver");
   }
+
+  return observer;
+}
+
+export function hasActiveIntersectionObserver() {
+  return observers.some((observer) => observer.active);
+}
+
+export async function emitIntersection(isIntersecting: boolean) {
+  const observer = getActiveObserver();
+
+  await act(async () => {
+    observer.emit(isIntersecting);
+    await Promise.resolve();
+  });
+}
+
+export async function enterViewport() {
+  const observer = getActiveObserver();
 
   await act(async () => {
     observer.emit(false);

--- a/packages/utilinent/test/useIntersectionObserver.test.tsx
+++ b/packages/utilinent/test/useIntersectionObserver.test.tsx
@@ -1,0 +1,78 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Observer } from "../src";
+import { useIntersectionObserver } from "../src/hooks/useIntersectionObserver";
+import {
+  emitIntersection,
+  hasActiveIntersectionObserver,
+  installControlledIntersectionObserver,
+} from "./controlledIntersectionObserver";
+
+type IntersectionChangeHandler = (
+  isIntersecting: boolean,
+  entry: IntersectionObserverEntry,
+) => void;
+
+type IntersectionProbeProps = {
+  readonly onChange: IntersectionChangeHandler;
+};
+
+function IntersectionProbe({ onChange }: IntersectionProbeProps) {
+  const { ref } = useIntersectionObserver({ onChange });
+  return <div ref={ref} />;
+}
+
+describe("useIntersectionObserver", () => {
+  beforeEach(installControlledIntersectionObserver);
+
+  it("notifies when the initial observer record is intersecting", async () => {
+    const onChange = vi.fn<IntersectionChangeHandler>();
+    render(<IntersectionProbe onChange={onChange} />);
+
+    await emitIntersection(true);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ isIntersecting: true, intersectionRatio: 1 }),
+    );
+  });
+
+  it("freezes and disconnects a triggerOnce observer on an initially visible record", async () => {
+    const onIntersect = vi.fn<IntersectionChangeHandler>();
+    const rendered = render(
+      <Observer triggerOnce={true} onIntersect={onIntersect} threshold={0}>
+        visible
+      </Observer>,
+    );
+
+    await emitIntersection(true);
+
+    expect(onIntersect).toHaveBeenCalledTimes(1);
+    expect(hasActiveIntersectionObserver()).toBe(false);
+
+    rendered.rerender(
+      <Observer triggerOnce={true} onIntersect={onIntersect} threshold={0.5}>
+        visible
+      </Observer>,
+    );
+    expect(hasActiveIntersectionObserver()).toBe(false);
+  });
+
+  it("notifies only on later non-intersecting to intersecting transitions", async () => {
+    const onChange = vi.fn<IntersectionChangeHandler>();
+    render(<IntersectionProbe onChange={onChange} />);
+
+    await emitIntersection(false);
+    await emitIntersection(true);
+    await emitIntersection(true);
+    await emitIntersection(false);
+    await emitIntersection(true);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange.mock.calls.map(([isIntersecting]) => isIntersecting)).toEqual([
+      true,
+      true,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- process an initially intersecting IntersectionObserver record through the existing false-to-true transition callback
- apply triggerOnce/freezeOnceVisible freezing and disconnection on that initial visible record
- preserve duplicate-transition suppression and add a patch changeset

## Evidence
- the previous first-callback early return skipped both `onChange` and freeze/disconnect for an initial visible entry
- regression coverage emits only an initial `true` record, verifies callback delivery, and confirms a triggerOnce observer remains disconnected after rerender
- existing non-initial transition behavior remains covered and passing

## Tests
- `pnpm --filter @ilokesto/utilinent test` (28 passed)
- `pnpm --filter @ilokesto/utilinent build`
- `pnpm --filter @ilokesto/utilinent typecheck` (React 18 and React 19)
- changed-file LSP diagnostics (clean)

Fixes #45