### PR TITLE
fix(fetcher): relax PathsLike constraint to accept generated interface paths

### DIFF
--- a/.changeset/fetcher-pathslike-interface-constraint.md
+++ b/.changeset/fetcher-pathslike-interface-constraint.md
@@ -1,0 +1,5 @@
+---
+'@ilokesto/fetcher': patch
+---
+
+Relax `PathsLike` constraint from `Record<string, ...>` to `object` so canonical OpenAPI generators (e.g. `openapi-typescript`) that emit `interface paths { '/users': ... }` satisfy the generic constraint. TypeScript interfaces do not have implicit string index signatures, so the previous `Record<string, ...>` constraint rejected them.

--- a/packages/fetcher/src/createFetcher.type-contract.test.ts
+++ b/packages/fetcher/src/createFetcher.type-contract.test.ts
@@ -3,6 +3,7 @@ import type { Fetcher } from './openapi';
 import { assertTypedHeadAndCallableOptions, type HeadPaths } from './test-fixtures/head';
 import {
   assertBarrelImportContinuity,
+  assertInterfacePathsSatisfyPathsLike,
   assertUntypedHeadKeepsKyTyping,
   assertMergePathsTyping,
   assertNoTypedOptionsShortcut,
@@ -26,6 +27,7 @@ describe('createFetcher type contracts', () => {
       assertBarrelImportContinuity();
       assertReadmeQuickStartSnippet();
       assertSafeSurfaceTyping(api);
+      assertInterfacePathsSatisfyPathsLike();
 
       const headApi = undefined as unknown as Fetcher<HeadPaths>;
       assertTypedHeadAndCallableOptions(headApi);

--- a/packages/fetcher/src/openapi/shared.ts
+++ b/packages/fetcher/src/openapi/shared.ts
@@ -7,7 +7,7 @@ export type OpenApiHttpMethod =
   | 'head'
   | 'options';
 
-export type PathsLike = Record<string, Partial<Record<OpenApiHttpMethod, unknown>>>;
+export type PathsLike = object;
 
 export type ShortcutMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head';
 export type CallableMethod = ShortcutMethod | 'options';

--- a/packages/fetcher/src/test-fixtures/createFetcher.ts
+++ b/packages/fetcher/src/test-fixtures/createFetcher.ts
@@ -811,3 +811,48 @@ export const expectHttpError = (error: unknown): HTTPError => {
 
   return error;
 };
+
+interface CanonicalInterfacePaths {
+  '/users/{id}': {
+    get: {
+      parameters: {
+        path: {
+          id: string;
+        };
+      };
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              id: string;
+              role: 'admin' | 'member';
+            };
+          };
+        };
+      };
+    };
+  };
+}
+
+export const assertInterfacePathsSatisfyPathsLike = () => {
+  const api = createFetcher<CanonicalInterfacePaths>({
+    prefixUrl: '/api',
+  });
+
+  expectTypeOf(api).toEqualTypeOf<Fetcher<CanonicalInterfacePaths>>();
+
+  const user = api
+    .get('/users/{id}', {
+      params: {
+        path: { id: '42' },
+      },
+    })
+    .json();
+
+  expectTypeOf(user).toEqualTypeOf<
+    Promise<{
+      id: string;
+      role: 'admin' | 'member';
+    }>
+  >();
+};


### PR DESCRIPTION
## Summary

`PathsLike` required a string index signature (`Record<string, ...>`). Canonical OpenAPI generators (e.g. `openapi-typescript`) export `paths` as an `interface` with literal path properties, which does not satisfy `Record<string, ...>` — TypeScript interfaces do not have implicit string index signatures. `createFetcher<paths>()` therefore failed to type-check.

## Fix

Changed `PathsLike` from `Record<string, Partial<Record<OpenApiHttpMethod, unknown>>>` to `object`. This accepts both type aliases and interfaces, while `PathKey<Paths>` and `Paths[Path]` access still work correctly through generic constraints.

## Evidence

- `packages/fetcher/src/openapi/shared.ts:10` (before: `Record<string, ...>`, after: `object`)

## Type fixture

Added `assertInterfacePathsSatisfyPathsLike` — a compile-time regression test using a canonical `interface CanonicalInterfacePaths` (as `openapi-typescript` generates) that verifies `createFetcher<CanonicalInterfacePaths>()` type-checks and produces correct typed shortcut methods.

## Verification

- `pnpm --filter @ilokesto/fetcher test` — 34/34 passed
- `pnpm --filter @ilokesto/fetcher build` — succeeded
- Changeset added: `.changeset/fetcher-pathslike-interface-constraint.md` (patch)

Fixes #36