### PR TITLE
fix(state): distinguish function-valued initial state from reducer across all adapters

### DIFF
--- a/.changeset/state-function-valued-initial-state.md
+++ b/.changeset/state-function-valued-initial-state.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Preserve function-valued plain initial state across the React, Vue, Angular, Svelte, and Solid adapters while retaining reducer creation for two-argument calls, including an explicit `undefined` initial state.

--- a/packages/state/src/core/Angular/index.ts
+++ b/packages/state/src/core/Angular/index.ts
@@ -18,5 +18,8 @@ export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,
 ) {
-  return createFrameworkAdapter(createUseSignal<T, Action>, firstArg, secondArg);
+  return createFrameworkAdapter(
+    createUseSignal<T, Action>,
+    { firstArg, secondArg, isReduce: arguments.length === 2 },
+  );
 }

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -16,5 +16,8 @@ export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,
 ) {
-  return createFrameworkAdapter(createUseState<T, Action>, firstArg, secondArg);
+  return createFrameworkAdapter(
+    createUseState<T, Action>,
+    { firstArg, secondArg, isReduce: arguments.length === 2 },
+  );
 }

--- a/packages/state/src/core/Solid/index.ts
+++ b/packages/state/src/core/Solid/index.ts
@@ -18,5 +18,8 @@ export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,
 ) {
-  return createFrameworkAdapter(createUseAccessor<T, Action>, firstArg, secondArg);
+  return createFrameworkAdapter(
+    createUseAccessor<T, Action>,
+    { firstArg, secondArg, isReduce: arguments.length === 2 },
+  );
 }

--- a/packages/state/src/core/Svelte/index.ts
+++ b/packages/state/src/core/Svelte/index.ts
@@ -18,5 +18,8 @@ export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,
 ) {
-  return createFrameworkAdapter(createStore<T, Action>, firstArg, secondArg);
+  return createFrameworkAdapter(
+    createStore<T, Action>,
+    { firstArg, secondArg, isReduce: arguments.length === 2 },
+  );
 }

--- a/packages/state/src/core/Vue/index.ts
+++ b/packages/state/src/core/Vue/index.ts
@@ -18,5 +18,8 @@ export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,
 ) {
-  return createFrameworkAdapter(createUseComposable<T, Action>, firstArg, secondArg);
+  return createFrameworkAdapter(
+    createUseComposable<T, Action>,
+    { firstArg, secondArg, isReduce: arguments.length === 2 },
+  );
 }

--- a/packages/state/src/core/shared/createFrameworkAdapter.ts
+++ b/packages/state/src/core/shared/createFrameworkAdapter.ts
@@ -4,19 +4,18 @@ import { getStore } from '../../lib/getStore.js';
 import type { ReduceFn, ReducerAction } from '../../types/ReduceFn.js';
 import { getInitialState } from './getInitialState.js';
 
-const isReduceFn = <T, Action extends ReducerAction>(
-  value: Store<T> | T | ReduceFn<T, Action>,
-): value is ReduceFn<T, Action> => {
-  return typeof value === 'function';
-};
+type FrameworkAdapterArguments<T, Action extends ReducerAction> = Readonly<{
+  firstArg: Store<T> | T | ReduceFn<T, Action>;
+  secondArg: T | Store<T> | undefined;
+  isReduce: boolean;
+}>;
 
 export function createFrameworkAdapter<T, Action extends ReducerAction, Adapter>(
   createAdapter: (store: Store<T>, isReduce: boolean) => Adapter,
-  firstArg: Store<T> | T | ReduceFn<T, Action>,
-  secondArg?: T | Store<T>,
+  { firstArg, secondArg, isReduce }: FrameworkAdapterArguments<T, Action>,
 ): Adapter {
-  const { initialState, isReduce } = getInitialState(firstArg, secondArg);
-  const reduceFn = isReduceFn(firstArg) ? firstArg : undefined;
+  const initialState = getInitialState(firstArg, secondArg, isReduce).initialState;
+  const reduceFn = isReduce ? (firstArg as ReduceFn<T, Action>) : undefined;
 
   return createAdapter(getStore(initialState, reduceFn), isReduce);
 }

--- a/packages/state/src/core/shared/getInitialState.ts
+++ b/packages/state/src/core/shared/getInitialState.ts
@@ -4,11 +4,12 @@ import type { ReduceFn, ReducerAction } from '../../types/ReduceFn.js';
 
 export function getInitialState<T, Action extends ReducerAction>(
   firstArg: T | Store<T> | ReduceFn<T, Action>,
-  secondArg?: T | Store<T>,
+  secondArg: T | Store<T> | undefined,
+  isReduce: boolean,
 ): { initialState: T | Store<T>; isReduce: boolean } {
-  if (typeof firstArg === 'function') {
+  if (isReduce) {
     return { initialState: secondArg as T | Store<T>, isReduce: true };
   }
 
-  return { initialState: firstArg, isReduce: false };
+  return { initialState: firstArg as T | Store<T>, isReduce: false };
 }

--- a/packages/state/test/framework-create-overloads.test.ts
+++ b/packages/state/test/framework-create-overloads.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+import type { Store } from '@ilokesto/store';
+
+import { create as createAngular } from '../src/core/Angular';
+import { create as createReact } from '../src/core/React';
+import { create as createSolid } from '../src/core/Solid';
+import { create as createSvelte } from '../src/core/Svelte';
+import { create as createVue } from '../src/core/Vue';
+import type { ReducerAction } from '../src/types/ReduceFn';
+
+type StateAdapter<State> = Readonly<{
+  readOnly: () => State;
+}>;
+
+type ReducerAdapter<State, Action> = Readonly<{
+  readOnly: () => State;
+  writeOnly: () => (action: Action) => void;
+}>;
+
+type FrameworkAdapter = Readonly<{
+  name: string;
+  createState: <State>(initialState: State | Store<State>) => StateAdapter<State>;
+  createReducer: <State, Action extends ReducerAction>(
+    reducer: (state: State, action: Action) => State,
+    initialState: State | Store<State>,
+  ) => ReducerAdapter<State, Action>;
+}>;
+
+type IncrementAction = Readonly<{ type: 'increment' }>;
+
+const frameworkAdapters = [
+  {
+    name: 'React',
+    createState: <State>(initialState: State | Store<State>) => createReact(initialState),
+    createReducer: <State, Action extends ReducerAction>(
+      reducer: (state: State, action: Action) => State,
+      initialState: State | Store<State>,
+    ) => createReact(reducer, initialState),
+  },
+  {
+    name: 'Vue',
+    createState: <State>(initialState: State | Store<State>) => createVue(initialState),
+    createReducer: <State, Action extends ReducerAction>(
+      reducer: (state: State, action: Action) => State,
+      initialState: State | Store<State>,
+    ) => createVue(reducer, initialState),
+  },
+  {
+    name: 'Angular',
+    createState: <State>(initialState: State | Store<State>) => createAngular(initialState),
+    createReducer: <State, Action extends ReducerAction>(
+      reducer: (state: State, action: Action) => State,
+      initialState: State | Store<State>,
+    ) => createAngular(reducer, initialState),
+  },
+  {
+    name: 'Svelte',
+    createState: <State>(initialState: State | Store<State>) => createSvelte(initialState),
+    createReducer: <State, Action extends ReducerAction>(
+      reducer: (state: State, action: Action) => State,
+      initialState: State | Store<State>,
+    ) => createSvelte(reducer, initialState),
+  },
+  {
+    name: 'Solid',
+    createState: <State>(initialState: State | Store<State>) => createSolid(initialState),
+    createReducer: <State, Action extends ReducerAction>(
+      reducer: (state: State, action: Action) => State,
+      initialState: State | Store<State>,
+    ) => createSolid(reducer, initialState),
+  },
+] satisfies readonly FrameworkAdapter[];
+
+describe('framework create() overload detection', () => {
+  for (const framework of frameworkAdapters) {
+    describe(framework.name, () => {
+      test('Given function-valued plain state, When create receives one argument, Then it stores the function without invoking it as a reducer', () => {
+        // Given
+        const initialState = (): number => 1;
+
+        // When
+        const adapter = framework.createState(initialState);
+
+        // Then
+        expect(adapter.readOnly()).toBe(initialState);
+        expect(adapter.readOnly()()).toBe(1);
+      });
+
+      test('Given a reducer and initial state, When create receives two arguments, Then dispatch uses the reducer', () => {
+        // Given
+        const reducer = (state: number, _action: IncrementAction): number => state + 1;
+        const adapter = framework.createReducer(reducer, 1);
+
+        // When
+        adapter.writeOnly()({ type: 'increment' });
+
+        // Then
+        expect(adapter.readOnly()).toBe(2);
+      });
+
+      test('Given a reducer with explicit undefined initial state, When create receives two arguments, Then dispatch still uses the reducer', () => {
+        // Given
+        const reducer = (state: number | undefined, _action: IncrementAction): number =>
+          (state ?? 0) + 1;
+        const adapter = framework.createReducer<number | undefined, IncrementAction>(
+          reducer,
+          undefined,
+        );
+
+        // When
+        adapter.writeOnly()({ type: 'increment' });
+
+        // Then
+        expect(adapter.readOnly()).toBe(1);
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

A function supplied as plain initial state was always misclassified as a reducer because `getInitialState` used `typeof firstArg === 'function'` to detect the reducer overload. `create<() => number>(() => 1)` therefore created a reducer store with `undefined` initial state instead of storing the function. This affected all 5 framework adapters (React, Vue, Solid, Svelte, Angular).

## Fix

Pass an explicit `isReduce` discriminator from each framework adapter's `create()` entry point (based on argument count) to the shared `getInitialState` helper, instead of using `typeof firstArg === 'function'`. This preserves function-valued plain initial state while keeping reducer creation when two arguments are supplied.

## Evidence

- `packages/state/src/core/shared/getInitialState.ts:9-11` (before: `typeof firstArg === 'function'`, after: explicit `isReduce` parameter)
- `packages/state/src/core/shared/createFrameworkAdapter.ts:18-21`
- `packages/state/src/core/{React,Vue,Solid,Svelte,Angular}/index.ts`

## Test coverage

Added `packages/state/test/framework-create-overloads.test.ts` covering all 5 adapters:
- `create<() => number>(() => 1)` stores the function as initial state
- `create(initialState, reducer)` still creates a reducer store correctly
- `create(initialState, reducer, undefined)` works with explicit undefined initial state

## Verification

- `pnpm --filter @ilokesto/state test` — 193/193 passed
- Changeset added: `.changeset/state-function-valued-initial-state.md` (patch)

Fixes #48
