### PR TITLE
fix(form): serialize concurrent submit validation to prevent livelock

### DIFF
--- a/.changeset/form-concurrent-submit-queue.md
+++ b/.changeset/form-concurrent-submit-queue.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/form": patch
+---
+
+Serialize concurrent submit validation and callbacks so every submission settles without validation-token livelock.

--- a/packages/form/src/core/form/FormSubmitter.ts
+++ b/packages/form/src/core/form/FormSubmitter.ts
@@ -10,6 +10,9 @@ import type { FieldState, PathKey } from '../types';
  * 이 흐름을 CreateForm에서 분리해 최상위 controller를 얇게 유지한다.
  */
 export class FormSubmitter<TValues> {
+  private submissionQueue: Promise<void> = Promise.resolve();
+  private pendingSubmissionCount = 0;
+
   /** 같은 store와 validation engine을 공유해야 submitCount와 schema 결과가 같은 snapshot 위에서 동작한다. */
   public constructor(
     private readonly store: FormStateStore<TValues>,
@@ -24,11 +27,27 @@ export class FormSubmitter<TValues> {
    * 3. 실패하면 onInvalid에 현재 fields를 넘기고 undefined를 반환한다.
    * 4. 성공하면 최신 values를 복원해 onValid에 전달한다.
    */
-  public async submit<TResult>(
+  public submit<TResult>(
     onValid: (values: TValues) => TResult | Promise<TResult>,
     onInvalid?: (fields: Readonly<Record<PathKey, FieldState>>) => void,
   ): Promise<TResult | undefined> {
+    this.pendingSubmissionCount += 1;
     this.store.beginSubmit();
+
+    const submission = this.submissionQueue.then(() => this.executeSubmission(onValid, onInvalid));
+    this.submissionQueue = submission.then(
+      () => undefined,
+      () => undefined,
+    );
+
+    return submission;
+  }
+
+  private async executeSubmission<TResult>(
+    onValid: (values: TValues) => TResult | Promise<TResult>,
+    onInvalid?: (fields: Readonly<Record<PathKey, FieldState>>) => void,
+  ): Promise<TResult | undefined> {
+    let successful = false;
 
     try {
       while (true) {
@@ -39,19 +58,20 @@ export class FormSubmitter<TValues> {
             continue;
           case 'invalid':
             onInvalid?.(this.store.getState().fields);
-            this.store.completeSubmit(false);
             return undefined;
           case 'valid': {
             const result = await onValid(this.store.getValues());
 
-            this.store.completeSubmit(true);
+            successful = true;
             return result;
           }
         }
       }
-    } catch (error) {
-      this.store.completeSubmit(false);
-      throw error;
+    } finally {
+      this.pendingSubmissionCount -= 1;
+      if (this.pendingSubmissionCount === 0) {
+        this.store.completeSubmit(successful);
+      }
     }
   }
 }

--- a/packages/form/test/submit-validation-races.test.ts
+++ b/packages/form/test/submit-validation-races.test.ts
@@ -66,3 +66,60 @@ test('Given values change without automatic validation, when pending submit vali
   expect(await submission).toBe('submitted');
   expect(submittedValues).toEqual({ email: 'latest', name: '' });
 });
+
+test('Given concurrent submits with deferred callbacks, when each callback completes, then both submissions settle in sequence', async () => {
+  const validations: Deferred<ValidationResult>[] = [];
+  const form = createControlledForm(validations);
+  const callbackOrder: string[] = [];
+  let resolveFirstCallback: (() => void) | undefined;
+  let resolveSecondCallback: (() => void) | undefined;
+
+  const firstSubmission = form.submit(async () => {
+    callbackOrder.push('first');
+    await new Promise<void>((resolve) => {
+      resolveFirstCallback = resolve;
+    });
+    return 'first result';
+  });
+  const secondSubmission = form.submit(async () => {
+    callbackOrder.push('second');
+    await new Promise<void>((resolve) => {
+      resolveSecondCallback = resolve;
+    });
+    return 'second result';
+  });
+
+  await waitForValidations(validations, 1);
+  expect(form.getState().submitCount).toBe(2);
+  expect(form.getState().isSubmitting).toBe(true);
+
+  getValidation(validations, 0).resolve({ value: { email: '', name: '' } });
+  for (let turn = 0; turn < 10 && resolveFirstCallback === undefined; turn += 1) {
+    await Promise.resolve();
+  }
+
+  expect(callbackOrder).toEqual(['first']);
+  expect(resolveFirstCallback).toBeDefined();
+  expect(validations).toHaveLength(1);
+  expect(form.getState().isSubmitting).toBe(true);
+
+  resolveFirstCallback?.();
+  await waitForValidations(validations, 2);
+  getValidation(validations, 1).resolve({ value: { email: '', name: '' } });
+  for (let turn = 0; turn < 10 && resolveSecondCallback === undefined; turn += 1) {
+    await Promise.resolve();
+  }
+
+  expect(callbackOrder).toEqual(['first', 'second']);
+  expect(resolveSecondCallback).toBeDefined();
+  expect(form.getState().isSubmitting).toBe(true);
+
+  resolveSecondCallback?.();
+  expect(await Promise.all([firstSubmission, secondSubmission])).toEqual([
+    'first result',
+    'second result',
+  ]);
+  expect(form.getState().isSubmitting).toBe(false);
+  expect(form.getState().isSubmitted).toBe(true);
+  expect(form.getState().isSubmitSuccessful).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Serialize each submit validation and callback lifecycle through a FIFO promise queue.
- Keep `isSubmitting` true while any queued submission remains and preserve per-call results/errors.
- Add a regression test covering two concurrent submits with deferred callbacks and sequential settlement.
- Add a patch changeset for `@ilokesto/form`.

## Evidence

Before the fix, the regression started two full validations at once (`Expected 1 validations, received 2`), reproducing the token invalidation race. After the fix, only the active submit owns a full-validation token, both callbacks run in order, both promises settle, and submit state completes only after the queue drains.

## Tests

- `pnpm install`
- `pnpm --filter @ilokesto/form test` (18 files, 118 tests passed)
- `pnpm --filter @ilokesto/form typecheck`
- `pnpm --filter @ilokesto/form build`
- `pnpm --filter @ilokesto/form test:pack`
- Direct ESM consumer driver verified callback order and submit lifecycle
- LSP diagnostics clean for changed TypeScript files

Fixes #35