### PR TITLE
fix(overlay): tie onUnmount to store item removal rather than effect cleanup

### DIFF
--- a/.changeset/overlay-onunmount-store-removal.md
+++ b/.changeset/overlay-onunmount-store-removal.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/overlay": patch
+---
+
+Tie `onUnmount` lifecycle hooks to overlay store removal so provider teardown does not end a still-pending item lifecycle.

--- a/packages/overlay/src/core/OverlayHost.lifecycle.test.tsx
+++ b/packages/overlay/src/core/OverlayHost.lifecycle.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, act } from "@testing-library/react";
 import { createOverlayContext } from "./createOverlayContext";
+import { createOverlayStore } from "./createOverlayStore";
 import type { OverlayAdapterComponent, OverlayAdapterHooks } from "../contracts/adapter";
 
 function createTrackingAdapter(): {
@@ -75,32 +76,48 @@ describe("adapter lifecycle hooks", () => {
     expect(calls.filter((c) => c.phase === "onClosing")).toHaveLength(1);
   });
 
-  it("calls onUnmount when the item is removed", () => {
+  it("does not call onUnmount when the provider unmounts while the item remains in the supplied store", async () => {
     const ctx = createOverlayContext();
     const { Adapter, calls } = createTrackingAdapter();
-
-    let overlayApi: ReturnType<typeof ctx.useOverlay> | undefined;
-    function App() {
-      overlayApi = ctx.useOverlay();
-      return null;
-    }
+    const store = createOverlayStore();
+    const settled = vi.fn();
+    const request = store.open({ id: "test", type: "modal" });
+    void request.promise.then(settled, settled);
 
     const { unmount } = render(
-      <ctx.Provider adapters={{ modal: Adapter }}>
-        <App />
+      <ctx.Provider adapters={{ modal: Adapter }} store={store}>
+        {null}
+      </ctx.Provider>
+    );
+
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+    });
+
+    expect(calls.filter((call) => call.phase === "onUnmount")).toHaveLength(0);
+    expect(store.getSnapshot().map((item) => item.id)).toEqual(["test"]);
+    expect(settled).not.toHaveBeenCalled();
+  });
+
+  it("calls onUnmount once when the supplied store explicitly removes the item", () => {
+    const ctx = createOverlayContext();
+    const { Adapter, calls } = createTrackingAdapter();
+    const store = createOverlayStore();
+    store.open({ id: "test", type: "modal" });
+
+    const { unmount } = render(
+      <ctx.Provider adapters={{ modal: Adapter }} store={store}>
+        {null}
       </ctx.Provider>
     );
 
     act(() => {
-      overlayApi!.open({ id: "test", type: "modal" });
-    });
-
-    act(() => {
-      overlayApi!.remove("test");
+      store.remove("test");
     });
 
     expect(calls).toContainEqual({ phase: "onUnmount", id: "test" });
-    expect(calls.filter((c) => c.phase === "onUnmount")).toHaveLength(1);
+    expect(calls.filter((call) => call.phase === "onUnmount")).toHaveLength(1);
 
     unmount();
   });
@@ -138,7 +155,7 @@ describe("adapter lifecycle hooks", () => {
     expect(calls.filter((c) => c.phase === "onOpen").length).toBe(openCountAfterOpen);
   });
 
-  it("calls hooks in order: onOpen → onClosing → onUnmount", () => {
+  it("calls onUnmount once after removal in the normal close then remove flow", () => {
     const ctx = createOverlayContext();
     const { Adapter, calls } = createTrackingAdapter();
 
@@ -162,6 +179,8 @@ describe("adapter lifecycle hooks", () => {
       overlayApi!.close("test", "done");
     });
 
+    expect(calls.filter((call) => call.phase === "onUnmount")).toHaveLength(0);
+
     act(() => {
       overlayApi!.remove("test");
     });
@@ -179,10 +198,7 @@ describe("adapter lifecycle hooks", () => {
     const ctx = createOverlayContext();
     const calls: string[] = [];
 
-    const Adapter: OverlayAdapterComponent = ({ useLifecycle }) => {
-      // deliberately not calling useLifecycle
-      return null;
-    };
+    const Adapter: OverlayAdapterComponent = () => null;
 
     let overlayApi: ReturnType<typeof ctx.useOverlay> | undefined;
     function App() {

--- a/packages/overlay/src/core/OverlayHost.tsx
+++ b/packages/overlay/src/core/OverlayHost.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef } from "react";
 import { useOverlayItems } from "./useOverlayItems";
 import type { OverlayAdapterHooks, OverlayRenderProps } from "../contracts/adapter";
 import type { OverlayId, OverlayItem } from "../contracts/overlay";
-import type { OverlayPlugin } from "../contracts/plugin";
 import type { OverlayContextGetter } from "./useOverlay";
 
 interface OverlayHostProps {
@@ -37,20 +36,23 @@ function OverlayItemRenderer({
     hooksRef.current = hooks;
   };
 
-  function runPhase(
-    phase: "onOpen" | "onClosing" | "onUnmount",
-    id: OverlayId,
-    item: OverlayItem
-  ): void {
-    const adapterHook = hooksRef.current?.[phase];
-    if (adapterHook) {
-      adapterHook(id, item);
-      return;
-    }
-    for (const plugin of plugins) {
-      plugin[phase]?.(id, item);
-    }
-  }
+  const runPhase = useCallback(
+    (
+      phase: "onOpen" | "onClosing" | "onUnmount",
+      id: OverlayId,
+      item: OverlayItem
+    ): void => {
+      const adapterHook = hooksRef.current?.[phase];
+      if (adapterHook) {
+        adapterHook(id, item);
+        return;
+      }
+      for (const plugin of plugins) {
+        plugin[phase]?.(id, item);
+      }
+    },
+    [plugins]
+  );
 
   useEffect(() => {
     if (prevStatusRef.current === "mounted" && item.status === "open") {
@@ -62,13 +64,20 @@ function OverlayItemRenderer({
       runPhase("onClosing", item.id, item);
     }
     prevStatusRef.current = item.status;
-  }, [item.status, item.id]);
+  }, [item, runPhase]);
 
   useEffect(() => {
     return () => {
+      const itemRemainsInStore = store
+        .getSnapshot()
+        .some((storedItem) => storedItem.id === item.id);
+      if (itemRemainsInStore) {
+        return;
+      }
+
       runPhase("onUnmount", item.id, item);
     };
-  }, [item.id]);
+  }, [item, runPhase, store]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Summary
- gate `onUnmount` lifecycle cleanup on the item no longer existing in the owning overlay store
- preserve pending items and promises when a provider using a supplied store unmounts
- cover provider teardown, explicit removal, and close-to-remove ordering, with a patch changeset

## Evidence
- before the fix, the new provider-teardown regression observed one `onUnmount` call while the item remained in the supplied store
- after the fix, provider teardown leaves the item and promise pending; removal fires `onUnmount` exactly once
- existing missing-adapter diagnostics and plugin lifecycle tests remain green

## Tests
- `pnpm install`
- `pnpm --filter @ilokesto/store build`
- `pnpm --filter @ilokesto/overlay test` (64 passed)
- `pnpm --filter @ilokesto/overlay typecheck`
- `pnpm --filter @ilokesto/overlay build`
- compiled-package React/jsdom lifecycle drive
- LSP diagnostics clean on changed TypeScript files

Fixes #40