### PR TITLE
fix(state): extract cookie value at first separator and encode payload to survive '=' in JSON

### DIFF
--- a/.changeset/state-cookie-payload-encoding.md
+++ b/.changeset/state-cookie-payload-encoding.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Encode cookie persistence payloads so JSON values containing equals signs and cookie delimiters rehydrate without truncation, while continuing to read legacy raw payloads.

--- a/packages/state/src/middleware/persist/persistUtils.ts
+++ b/packages/state/src/middleware/persist/persistUtils.ts
@@ -128,7 +128,18 @@ export function getCookie(name: string) {
   if (typeof document === 'undefined') return null;
   const cookies = document.cookie.split('; ');
   const cookie = cookies.find((c) => c.startsWith(`${name}=`));
-  return cookie ? cookie.split('=')[1] : null;
+  if (!cookie) return null;
+
+  const separatorIndex = cookie.indexOf('=');
+  const rawValue = cookie.slice(separatorIndex + 1);
+
+  try {
+    const decodedValue = decodeURIComponent(rawValue);
+    return encodeURIComponent(decodedValue) === rawValue ? decodedValue : rawValue;
+  } catch (error) {
+    if (error instanceof URIError) return rawValue;
+    throw error;
+  }
 }
 
 export const getSafeStorage = <State>({
@@ -195,7 +206,7 @@ export const setStorage: PersistUtils['setStorage'] = ({
     } else if (storageType === 'session') {
       sessionStorage.setItem(storageKey, encodedState);
     } else if (storageType === 'cookie') {
-      document.cookie = `${storageKey}=${encodedState}`;
+      document.cookie = `${storageKey}=${encodeURIComponent(encodedState)}`;
     }
 
     storageWriteCache.set(cacheKey, encodedState);

--- a/packages/state/test/persist-cookie.test.ts
+++ b/packages/state/test/persist-cookie.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from 'bun:test';
+
+import { persist } from '../src/middleware';
+import { pipe } from '../src/utils/pipe';
+import { withBrowserFakes } from './helpers/browserFakes';
+
+type TokenState = {
+  readonly token: string;
+};
+
+const decodeToken = (value: unknown): TokenState | null => {
+  if (typeof value !== 'object' || value === null || !('token' in value)) return null;
+  return typeof value.token === 'string' ? { token: value.token } : null;
+};
+
+test('Given JSON containing an equals sign, when cookie persistence writes and rehydrates it, then the token survives intact', () => {
+  // Given
+  withBrowserFakes<TokenState>(() => {
+    const storageKey = 'cookie-equals-round-trip';
+    const persistedState = { token: 'abc=' };
+    const writer = pipe
+      .use(persist({ cookie: storageKey, decode: decodeToken }))
+      .create<TokenState>({ token: 'initial' });
+
+    // When
+    writer.setState(persistedState);
+    const reader = pipe
+      .use(persist({ cookie: storageKey, decode: decodeToken }))
+      .create<TokenState>({ token: 'fallback' });
+
+    // Then
+    expect(reader.getState()).toEqual(persistedState);
+  });
+});
+
+test('Given cookie-delimiter-sensitive state, when cookie persistence writes it, then the encoded payload round-trips', () => {
+  // Given
+  withBrowserFakes<TokenState>((_, __, { cookieDocument }) => {
+    const storageKey = 'cookie-delimiter-round-trip';
+    const persistedState = { token: 'semi; comma, space and equals=' };
+    const serializedPayload = JSON.stringify({ state: persistedState, version: 0 });
+    const writer = pipe
+      .use(persist({ cookie: storageKey, decode: decodeToken }))
+      .create<TokenState>({ token: 'initial' });
+
+    // When
+    writer.setState(persistedState);
+    const reader = pipe
+      .use(persist({ cookie: storageKey, decode: decodeToken }))
+      .create<TokenState>({ token: 'fallback' });
+
+    // Then
+    expect(cookieDocument.getItem(storageKey)).toBe(encodeURIComponent(serializedPayload));
+    expect(reader.getState()).toEqual(persistedState);
+  });
+});
+
+test('Given an existing raw cookie payload, when cookie persistence rehydrates it, then legacy JSON remains readable', () => {
+  // Given
+  withBrowserFakes<TokenState>((_, __, { cookieDocument }) => {
+    const storageKey = 'cookie-legacy-raw';
+    const persistedState = { token: 'legacy%20=token' };
+    cookieDocument.cookie = `${storageKey}=${JSON.stringify({ state: persistedState, version: 0 })}`;
+
+    // When
+    const reader = pipe
+      .use(persist({ cookie: storageKey, decode: decodeToken }))
+      .create<TokenState>({ token: 'fallback' });
+
+    // Then
+    expect(reader.getState()).toEqual(persistedState);
+  });
+});


### PR DESCRIPTION
## Summary
- extract cookie payloads at the first `=` separator so JSON values are not truncated
- URI-encode new cookie writes and decode canonical encoded values on read
- preserve existing raw JSON cookies, including payloads containing percent sequences
- add a patch changeset for `@ilokesto/state`

## Evidence
- regression coverage round-trips a token containing `=`
- delimiter-sensitive characters such as semicolons, commas, and spaces are encoded before cookie assignment
- legacy unencoded JSON with `%20` and `=` rehydrates without mutation

## Tests
- `pnpm install`
- `pnpm --filter @ilokesto/store build`
- `pnpm --filter @ilokesto/state build`
- `pnpm --filter @ilokesto/state test` (181 passed)
- `pnpm --filter @ilokesto/state test:typecheck`
- clean TypeScript LSP diagnostics on changed source and test files
- direct runtime driver verified encoded and raw-cookie round-trips

## Issue mapping
The task supplied issue `#44`, but the live repository currently uses `#44` for an unrelated overlay bug. The matching state cookie issue is `#43`, so this PR intentionally closes the correct issue.

Fixes #43