### PR TITLE
fix(toast): resolve toast position to configured view position instead of DEFAULT_POSITION

### DIFF
--- a/.changeset/toast-configured-view-position-49.md
+++ b/.changeset/toast-configured-view-position-49.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/toast": patch
+---
+
+Resolve facade-created toasts without an explicit position to the mounted Toaster's configured position. Fixes #49.

--- a/packages/toast/src/core/createToastRuntime.ts
+++ b/packages/toast/src/core/createToastRuntime.ts
@@ -192,7 +192,7 @@ export function createToastRuntime(toasterId: ToasterId): ToastRuntimeApi {
       createdAt: now,
       toasterId,
       duration: mergedOptions.duration ?? DEFAULT_DURATION[type],
-      position: mergedOptions.position ?? current?.position ?? DEFAULT_POSITION,
+      position: mergedOptions.position ?? current?.position ?? view.position,
       height: current?.height ?? null,
       pauseDuration: 0,
       pausedAt,

--- a/packages/toast/test/Toaster.view-config.test.tsx
+++ b/packages/toast/test/Toaster.view-config.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom/vitest";
 import { act, cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { Toaster } from "../src/components/Toaster";
@@ -22,6 +23,92 @@ afterEach(() => {
 });
 
 describe("Toaster view configuration", () => {
+  it("renders a facade-created toast at the Toaster bottom-left position", async () => {
+    // Given
+    render(<Toaster toasterId={TOASTER_ID} position="bottom-left" />);
+
+    await waitFor(() => {
+      expect(getRuntime(TOASTER_ID)).toBeDefined();
+    });
+
+    const region = screen.getByRole("region", { name: "Notifications" });
+
+    // When
+    act(() => {
+      toast("Bottom-left toast", { toasterId: TOASTER_ID });
+    });
+
+    // Then
+    expect(await within(region).findByText("Bottom-left toast")).toBeVisible();
+    expect(getRuntime(TOASTER_ID)?.getRawSnapshot()[0]?.position).toBe("bottom-left");
+  });
+
+  it("renders a facade-created toast at the Toaster bottom-center position", async () => {
+    // Given
+    render(<Toaster toasterId={TOASTER_ID} position="bottom-center" />);
+
+    await waitFor(() => {
+      expect(getRuntime(TOASTER_ID)).toBeDefined();
+    });
+
+    const region = screen.getByRole("region", { name: "Notifications" });
+
+    // When
+    act(() => {
+      toast("Bottom-center toast", { toasterId: TOASTER_ID });
+    });
+
+    // Then
+    expect(await within(region).findByText("Bottom-center toast")).toBeVisible();
+    expect(getRuntime(TOASTER_ID)?.getRawSnapshot()[0]?.position).toBe("bottom-center");
+  });
+
+  it("keeps an explicit per-toast position ahead of the Toaster position", async () => {
+    // Given
+    render(<Toaster toasterId={TOASTER_ID} position="bottom-left" />);
+
+    await waitFor(() => {
+      expect(getRuntime(TOASTER_ID)).toBeDefined();
+    });
+
+    // When
+    act(() => {
+      toast("Explicit toast", {
+        toasterId: TOASTER_ID,
+        position: "top-center",
+      });
+    });
+
+    // Then
+    expect(getRuntime(TOASTER_ID)?.getRawSnapshot()[0]?.position).toBe("top-center");
+  });
+
+  it("keeps toastOptions.position ahead of the Toaster position", async () => {
+    // Given
+    render(
+      <Toaster
+        toasterId={TOASTER_ID}
+        position="bottom-left"
+        toastOptions={{ position: "bottom-center" }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getRuntime(TOASTER_ID)).toBeDefined();
+    });
+
+    const region = screen.getByRole("region", { name: "Notifications" });
+
+    // When
+    act(() => {
+      toast("Toast options position", { toasterId: TOASTER_ID });
+    });
+
+    // Then
+    expect(await within(region).findByText("Toast options position")).toBeVisible();
+    expect(getRuntime(TOASTER_ID)?.getRawSnapshot()[0]?.position).toBe("bottom-center");
+  });
+
   it("clears removed defaults after rerender while preserving the existing accessible toast row", async () => {
     // Given
     const view = render(


### PR DESCRIPTION
## Summary
- Resolve facade-created toasts without an explicit position to the mounted `Toaster` view position.
- Preserve explicit per-toast and `toastOptions.position` precedence.
- Add regression coverage and a patch changeset for `@ilokesto/toast`.

## Evidence
- The regression tests failed before the runtime change because bottom-left and bottom-center toasts were stored at top-right and filtered from the configured view.
- Chromium manual QA rendered a facade-created toast in a fixed bottom-left container (`bottom: 0px`, `left: 0px`).

## Tests
- `pnpm --filter @ilokesto/toast test` (48 passed)
- `pnpm --filter @ilokesto/toast typecheck`
- `pnpm --filter @ilokesto/toast build`
- `pnpm exec changeset status`
- LSP diagnostics clean for changed TypeScript files

Fixes #49