### PR TITLE
fix(utilinent): propagate React 19 callback-ref cleanup functions in Slot and Observer composeRefs

### DIFF
--- a/.changeset/utilinent-react19-ref-cleanup.md
+++ b/.changeset/utilinent-react19-ref-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/utilinent": patch
+---
+
+Propagate React 19 callback-ref cleanup functions through Slot and Observer while preserving composed object refs.

--- a/packages/utilinent/package.json
+++ b/packages/utilinent/package.json
@@ -53,8 +53,8 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
     "jsdom": "^29.1.1",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
+    "react": "19.2.8",
+    "react-dom": "19.2.8",
     "typescript": "^5.4.5",
     "vite": "^7.3.6",
     "vitest": "^4.1.10"

--- a/packages/utilinent/src/components/Observer/index.tsx
+++ b/packages/utilinent/src/components/Observer/index.tsx
@@ -1,7 +1,9 @@
-import { ComponentPropsWithRef, forwardRef, useCallback } from "react";
+import { forwardRef, useMemo } from "react";
+import type { ComponentPropsWithRef } from "react";
 import { useIntersectionObserver } from "../../hooks/useIntersectionObserver";
 import { Show } from "../Show";
-import { ObserverProps } from "./types";
+import { composeRefs } from "../Slot/composeRefs";
+import type { ObserverProps } from "./types";
 
 export const Observer = forwardRef<HTMLDivElement, ObserverProps & Omit<ComponentPropsWithRef<'div'>, 'ref'>>(
   function Observer(
@@ -24,18 +26,8 @@ export const Observer = forwardRef<HTMLDivElement, ObserverProps & Omit<Componen
       onChange,
     });
 
-    const mergedRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        // Set observer ref
-        observerRef(node);
-
-        // Handle forwarded ref
-        if (typeof forwardedRef === "function") {
-          forwardedRef(node);
-        } else if (forwardedRef) {
-          forwardedRef.current = node;
-        }
-      },
+    const mergedRef = useMemo(
+      () => composeRefs(observerRef, forwardedRef),
       [observerRef, forwardedRef]
     );
 

--- a/packages/utilinent/src/components/Slot/composeRefs.ts
+++ b/packages/utilinent/src/components/Slot/composeRefs.ts
@@ -1,13 +1,43 @@
-import { Ref } from "react";
+import type { MutableRefObject, Ref } from "react";
 
-export function composeRefs<T>(...refs: Ref<T>[]) {
-    return (node: T) => {
-      for (const ref of refs) {
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref != null) {
-          (ref as React.MutableRefObject<T>).current = node;
-        }
-      }
-    };
+type RefCleanup = () => void;
+type ComposableRef<T> =
+  | Ref<T>
+  | ((node: T | null) => RefCleanup | undefined)
+  | undefined;
+
+function setRef<T>(ref: ComposableRef<T>, node: T | null): RefCleanup | void {
+  if (typeof ref === "function") {
+    return ref(node);
   }
+
+  if (ref != null) {
+    const mutableRef: MutableRefObject<T | null> = ref;
+    mutableRef.current = node;
+  }
+}
+
+export function composeRefs<T>(...refs: ComposableRef<T>[]) {
+  return (node: T | null) => {
+    let hasCleanup = false;
+    const cleanups = refs.map((ref) => {
+      const cleanup = setRef(ref, node);
+      if (typeof cleanup === "function") {
+        hasCleanup = true;
+      }
+      return cleanup;
+    });
+
+    if (hasCleanup) {
+      return () => {
+        cleanups.forEach((cleanup, index) => {
+          if (typeof cleanup === "function") {
+            cleanup();
+          } else {
+            setRef(refs[index], null);
+          }
+        });
+      };
+    }
+  };
+}

--- a/packages/utilinent/test/Refs.test.tsx
+++ b/packages/utilinent/test/Refs.test.tsx
@@ -1,0 +1,71 @@
+import { createRef } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Observer, Slot } from "../src/index";
+
+function refWithCleanup<T>(cleanup: () => void) {
+  return (node: T | null) => (node ? cleanup : undefined);
+}
+
+describe("React 19 callback ref cleanup", () => {
+  it("runs a Slot callback ref cleanup on unmount", () => {
+    const cleanup = vi.fn();
+    const rendered = render(
+      <Slot ref={refWithCleanup<HTMLElement>(cleanup)}>
+        <button type="button">Open</button>
+      </Slot>,
+    );
+
+    rendered.unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs an Observer callback ref cleanup on unmount", () => {
+    const cleanup = vi.fn();
+    const rendered = render(
+      <Observer ref={refWithCleanup<HTMLDivElement>(cleanup)}>Observed</Observer>,
+    );
+
+    rendered.unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs every cleanup from composed Slot callback refs", () => {
+    const slotCleanup = vi.fn();
+    const childCleanup = vi.fn();
+    const rendered = render(
+      <Slot ref={refWithCleanup<HTMLElement>(slotCleanup)}>
+        <button ref={refWithCleanup<HTMLButtonElement>(childCleanup)} type="button">
+          Open
+        </button>
+      </Slot>,
+    );
+
+    rendered.unmount();
+
+    expect(slotCleanup).toHaveBeenCalledTimes(1);
+    expect(childCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("assigns and clears an object ref composed with a cleanup ref", () => {
+    const objectRef = createRef<HTMLElement>();
+    const rendered = render(
+      <Slot ref={objectRef}>
+        <button
+          ref={refWithCleanup<HTMLButtonElement>(vi.fn())}
+          type="button"
+        >
+          Open
+        </button>
+      </Slot>,
+    );
+
+    expect(objectRef.current).toBe(screen.getByRole("button", { name: "Open" }));
+
+    rendered.unmount();
+
+    expect(objectRef.current).toBeNull();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,7 +425,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.2
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^22.9.0
         version: 22.20.1
@@ -457,11 +457,11 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1
       react:
-        specifier: 18.3.1
-        version: 18.3.1
+        specifier: 19.2.8
+        version: 19.2.8
       react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: 19.2.8
+        version: 19.2.8(react@19.2.8)
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
@@ -4922,6 +4922,16 @@ snapshots:
       '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.31
+      '@types/react-dom': 18.3.7(@types/react@18.3.31)
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
       '@types/react': 18.3.31
       '@types/react-dom': 18.3.7(@types/react@18.3.31)


### PR DESCRIPTION
## Summary
- propagate React 19 callback-ref cleanup functions through the shared `composeRefs` helper used by Slot and Observer
- preserve mixed callback/object-ref teardown by invoking returned cleanups and resetting refs that rely on legacy null semantics
- run utilinent runtime regressions on React 19 while retaining React 18 type compilation and the `react >=18` peer contract
- add a patch changeset for `@ilokesto/utilinent`

## Evidence
- before the fix, the new Slot, Observer, and multiple-ref cleanup cases all failed because cleanup callbacks were discarded
- the object-ref regression exercises the React 19 cleanup path and verifies `.current` is cleared after unmount

## Tests
- `pnpm --filter @ilokesto/utilinent test` (29 passed)
- `pnpm --filter @ilokesto/utilinent typecheck`
- `pnpm --filter @ilokesto/utilinent build`
- `pnpm exec vitest run test/Refs.test.tsx --reporter=verbose` (4 lifecycle scenarios passed)

## Issue mapping
The implementation request referenced #46, but the current remote #46 is an unrelated modal issue. The matching utilinent issue is #41.

Fixes #41