### PR TITLE
fix(form): preserve sibling array arrayKeys when mutating one array

### DIFF
--- a/.changeset/form-preserve-array-keys.md
+++ b/.changeset/form-preserve-array-keys.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/form": patch
+---
+
+Preserve stable render keys for sibling and structurally surviving nested arrays when another array is mutated.

--- a/packages/form/src/core/array/FormArrayRebaser.ts
+++ b/packages/form/src/core/array/FormArrayRebaser.ts
@@ -27,7 +27,7 @@ export class FormArrayRebaser {
    * 2. nextValues를 기준으로 FormState를 새로 초기화한다.
    * 3. 기존 fields를 순회하며 배열 밖 field는 그대로 보존한다.
    * 4. 배열 child field는 mapPreviousIndex로 새 index를 찾아 메타데이터를 옮긴다.
-   * 5. arrayKeys와 submitCount를 새 state에 다시 반영한다.
+   * 5. 살아남은 arrayKeys를 보존하고 변경된 배열의 key와 submitCount를 새 state에 다시 반영한다.
    *
    * @param store - 현재 FormState를 읽을 store.
    * @param fieldPath - 변경된 배열 field path.
@@ -43,13 +43,15 @@ export class FormArrayRebaser {
     nextKeys: readonly string[],
     mapPreviousIndex: IndexMapper,
   ): FormState<TValues> {
+    const previousState = store.getState();
     const fieldPaths = store.getKnownFieldPaths();
     const nextValues = ValueHelper.setValueAtPath(store.getValues(), fieldPath, [...nextArray]);
     const initializedState = FormStateInitializer.initialize(nextValues);
     const arrayKey = FormPath.pathToKey(fieldPath);
     const rebasedFields = { ...initializedState.fields };
+    const rebasedArrayKeys = { ...initializedState.arrayKeys };
 
-    Object.entries(store.getState().fields).forEach(([fieldKey, previousField]) => {
+    Object.entries(previousState.fields).forEach(([fieldKey, previousField]) => {
       const currentFieldPath = fieldPaths[fieldKey];
 
       if (!currentFieldPath) {
@@ -87,17 +89,48 @@ export class FormArrayRebaser {
       };
     });
 
+    Object.entries(previousState.arrayKeys).forEach(([previousArrayKey, previousKeys]) => {
+      if (previousArrayKey === arrayKey) {
+        return;
+      }
+
+      const previousArrayPath = FormPath.keyToPath(previousArrayKey);
+      let nextArrayPath = previousArrayPath;
+
+      if (FormArrayPath.isArrayChildPath(previousArrayPath, fieldPath)) {
+        const previousIndex = previousArrayPath[fieldPath.length];
+
+        if (typeof previousIndex !== 'number') {
+          return;
+        }
+
+        const nextIndex = mapPreviousIndex(previousIndex);
+
+        if (nextIndex === undefined) {
+          return;
+        }
+
+        nextArrayPath = FormArrayPath.replaceArrayIndex(previousArrayPath, fieldPath, nextIndex);
+      }
+
+      const nextArrayKey = FormPath.pathToKey(nextArrayPath);
+      const initializedKeys = initializedState.arrayKeys[nextArrayKey];
+
+      if (initializedKeys?.length === previousKeys.length) {
+        rebasedArrayKeys[nextArrayKey] = [...previousKeys];
+      }
+    });
+
+    rebasedArrayKeys[arrayKey] = [...nextKeys];
+
     return {
       ...initializedState,
       fields: rebasedFields,
-      arrayKeys: {
-        ...initializedState.arrayKeys,
-        [arrayKey]: [...nextKeys],
-      },
-      submitCount: store.getState().submitCount,
-      isSubmitting: store.getState().isSubmitting,
-      isSubmitted: store.getState().isSubmitted,
-      isSubmitSuccessful: store.getState().isSubmitSuccessful,
+      arrayKeys: rebasedArrayKeys,
+      submitCount: previousState.submitCount,
+      isSubmitting: previousState.isSubmitting,
+      isSubmitted: previousState.isSubmitted,
+      isSubmitSuccessful: previousState.isSubmitSuccessful,
     };
   }
 }

--- a/packages/form/test/array-keys.test.ts
+++ b/packages/form/test/array-keys.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from 'vitest';
+
+import { CreateForm } from '../src/index';
+
+test('preserves runtime keys for a sibling array when another array is mutated', () => {
+  const form = new CreateForm({
+    defaultValues: {
+      items: [{ name: 'item-a' }],
+      tags: [{ name: 'tag-a' }],
+    },
+  });
+  const tags = form.array('tags');
+  tags.push({ name: 'tag-b' });
+  const siblingKeys = [...tags.keys()];
+
+  form.array('items').push({ name: 'item-b' });
+
+  expect(tags.keys()).toEqual(siblingKeys);
+});
+
+test('preserves runtime keys for a structurally surviving nested array when its parent moves', () => {
+  const form = new CreateForm({
+    defaultValues: {
+      groups: [
+        { members: [{ name: 'member-a' }] },
+        { members: [{ name: 'member-b' }] },
+      ],
+    },
+  });
+  const movedMembers = form.array(['groups', 1, 'members']);
+  movedMembers.push({ name: 'member-c' });
+  const nestedKeys = [...movedMembers.keys()];
+
+  form.array('groups').move(1, 0);
+
+  expect(form.array(['groups', 0, 'members']).keys()).toEqual(nestedKeys);
+});
+
+test('updates keys for the mutated array in a single-array form', () => {
+  const form = new CreateForm({
+    defaultValues: {
+      items: [{ name: 'item-a' }],
+    },
+  });
+  const items = form.array('items');
+
+  items.push({ name: 'item-b' });
+
+  expect(items.keys()).toEqual(['initial-0', 'item-1']);
+});


### PR DESCRIPTION
## Summary

- Preserve prior `arrayKeys` for sibling arrays that survive an array mutation with the same shape.
- Remap nested array key paths through parent index changes so moved children retain render identity.
- Replace only the directly mutated array key list and add a patch changeset for `@ilokesto/form`.

## Evidence

- Before the fix, runtime `item-1` keys on sibling and nested arrays were rebuilt as `initial-1` during an unrelated rebase.
- The rebaser now carries forward prior keys only when the corresponding initialized array still exists with the same key count.

## Tests

- `pnpm --filter @ilokesto/form test` (19 files, 120 tests passed)
- `pnpm --filter @ilokesto/form typecheck`
- `pnpm --filter @ilokesto/form build`
- Built-package manual QA for sibling, nested-parent-move, and single-array mutation scenarios
- Clean LSP diagnostics for changed TypeScript files

Fixes #37