### PR TITLE
fix(overlay): spread item.props before renderProps so runtime-controlled adapter props always win

### DIFF
--- a/.changeset/overlay-runtime-prop-precedence.md
+++ b/.changeset/overlay-runtime-prop-precedence.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/overlay": patch
+---
+
+Prevent consumer item props from overriding runtime-controlled adapter props such as `close`, `remove`, and `isOpen`.

--- a/packages/overlay/src/core/OverlayHost.props.test.tsx
+++ b/packages/overlay/src/core/OverlayHost.props.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { OverlayAdapterComponent } from "../contracts/adapter";
+import { createOverlayContext } from "./createOverlayContext";
+import { createOverlayStore } from "./createOverlayStore";
+
+function renderOverlay(
+  Adapter: OverlayAdapterComponent,
+  props: Record<string, unknown>
+) {
+  const context = createOverlayContext();
+  const store = createOverlayStore();
+  store.open({ id: "runtime-id", type: "test", props });
+
+  render(
+    <context.Provider adapters={{ test: Adapter }} store={store}>
+      {null}
+    </context.Provider>
+  );
+
+  return store;
+}
+
+describe("OverlayHost adapter props", () => {
+  it("uses the runtime close when item props contain close", () => {
+    // Given
+    const consumerClose = vi.fn();
+    const Adapter: OverlayAdapterComponent = ({ close }) => (
+      <button type="button" onClick={() => close("runtime-result")}>
+        Close
+      </button>
+    );
+    const store = renderOverlay(Adapter, { close: consumerClose });
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    // Then
+    expect(consumerClose).not.toHaveBeenCalled();
+    expect(store.getSnapshot()).toEqual([
+      expect.objectContaining({
+        closeResult: "runtime-result",
+        id: "runtime-id",
+        status: "closing",
+      }),
+    ]);
+  });
+
+  it("uses the runtime remove when item props contain remove", () => {
+    // Given
+    const consumerRemove = vi.fn();
+    const Adapter: OverlayAdapterComponent = ({ remove }) => (
+      <button type="button" onClick={remove}>
+        Remove
+      </button>
+    );
+    const store = renderOverlay(Adapter, { remove: consumerRemove });
+
+    // When
+    fireEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    // Then
+    expect(consumerRemove).not.toHaveBeenCalled();
+    expect(store.getSnapshot()).toEqual([]);
+  });
+
+  it("uses the runtime isOpen when item props contain isOpen", () => {
+    // Given
+    const Adapter: OverlayAdapterComponent = ({ isOpen }) => (
+      <output data-testid="open-state">{isOpen ? "open" : "closed"}</output>
+    );
+
+    // When
+    renderOverlay(Adapter, { isOpen: false });
+
+    // Then
+    expect(screen.getByTestId("open-state").textContent).toBe("open");
+  });
+
+  it("forwards legitimate item props to the adapter", () => {
+    // Given
+    const style = { color: "red" };
+    let receivedClassName: unknown;
+    let receivedStyle: unknown;
+    const Adapter: OverlayAdapterComponent = (props) => {
+      receivedClassName = props["className"];
+      receivedStyle = props["style"];
+      return null;
+    };
+
+    // When
+    renderOverlay(Adapter, { className: "notice", style });
+
+    // Then
+    expect(receivedClassName).toBe("notice");
+    expect(receivedStyle).toBe(style);
+  });
+});

--- a/packages/overlay/src/core/OverlayHost.tsx
+++ b/packages/overlay/src/core/OverlayHost.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef } from "react";
 import { useOverlayItems } from "./useOverlayItems";
 import type { OverlayAdapterHooks, OverlayRenderProps } from "../contracts/adapter";
 import type { OverlayId, OverlayItem } from "../contracts/overlay";
-import type { OverlayPlugin } from "../contracts/plugin";
 import type { OverlayContextGetter } from "./useOverlay";
 
 interface OverlayHostProps {
@@ -100,7 +99,7 @@ function OverlayItemRenderer({
     useLifecycle,
   };
 
-  return <Adapter {...renderProps} {...item.props} />;
+  return <Adapter {...item.props} {...renderProps} />;
 }
 
 export function OverlayHost({ useOverlayContext }: OverlayHostProps) {


### PR DESCRIPTION
## Summary
- spread consumer `item.props` before host-generated render props so `close`, `remove`, `isOpen`, `id`, `status`, and `useLifecycle` remain runtime-controlled
- add provider/store/adapter regression coverage for `close`, `remove`, and `isOpen` collisions plus legitimate `className` and `style` forwarding
- add a patch changeset for `@ilokesto/overlay`

## Evidence
The new collision tests failed with the previous spread order because consumer values reached the adapter. With runtime props spread last, adapter actions update/remove the real store item and the open state reflects the runtime lifecycle.

## Tests
- `pnpm install`
- `pnpm --filter @ilokesto/overlay test` (67 passed)
- `pnpm --filter @ilokesto/overlay typecheck`
- `pnpm --filter @ilokesto/overlay build`
- LSP diagnostics: clean on changed TypeScript files

## Issue reference
The supplied issue title and body currently belong to #44; GitHub issue #41 is an unrelated utilinent report.

Fixes #44