### PR TITLE
docs(state): align pipe and persist documentation with builder-only API in EN and KO

### DIFF
--- a/.changeset/state-builder-only-docs.md
+++ b/.changeset/state-builder-only-docs.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Correct the English and Korean middleware documentation to use the builder-only `pipe` API and safe `persist` configuration.

--- a/packages/state/docs/advanced/persist-migrations.ko.mdx
+++ b/packages/state/docs/advanced/persist-migrations.ko.mdx
@@ -18,13 +18,34 @@ description: "persist의 storage type, versioning, migration caveat입니다."
 migration function은 stored version index부터 최신 migration까지 실행됩니다. 결과는 새 version과 함께 다시 저장됩니다.
 
 ```ts lineNumbers
-persist({ theme: 'light', count: 0 }, {
-  local: 'settings',
-  migrate: [
-    (old) => ({ theme: String(old), count: 0 }),
-    (old) => ({ ...old, count: Number(old.count ?? 0) }),
-  ],
+import { persist } from '@ilokesto/state/middleware';
+import type { PersistMigration } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
+
+type SettingsV1 = { theme: string };
+type SettingsState = { theme: string; count: number };
+
+const toV1: PersistMigration<unknown, SettingsV1> = (old) => ({
+  theme: typeof old === 'string' ? old : 'light',
 });
+const toCurrent: PersistMigration<SettingsV1, SettingsState> = (old) => ({
+  ...old,
+  count: 0,
+});
+const decodeSettings = (value: unknown): SettingsState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('theme' in value) || typeof value.theme !== 'string') return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { theme: value.theme, count: value.count };
+};
+
+const settingsStore = pipe
+  .use(persist({
+    local: 'settings',
+    migrate: [toV1, toCurrent],
+    decode: decodeSettings,
+  }))
+  .create<SettingsState>({ theme: 'light', count: 0 });
 ```
 
 ## 주의할 점

--- a/packages/state/docs/advanced/persist-migrations.mdx
+++ b/packages/state/docs/advanced/persist-migrations.mdx
@@ -18,13 +18,34 @@ description: "Storage types, versioning, and migration caveats for persist."
 Migration functions run from the stored version index until the latest migration. The result is written back with the new version.
 
 ```ts lineNumbers
-persist({ theme: 'light', count: 0 }, {
-  local: 'settings',
-  migrate: [
-    (old) => ({ theme: String(old), count: 0 }),
-    (old) => ({ ...old, count: Number(old.count ?? 0) }),
-  ],
+import { persist } from '@ilokesto/state/middleware';
+import type { PersistMigration } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
+
+type SettingsV1 = { theme: string };
+type SettingsState = { theme: string; count: number };
+
+const toV1: PersistMigration<unknown, SettingsV1> = (old) => ({
+  theme: typeof old === 'string' ? old : 'light',
 });
+const toCurrent: PersistMigration<SettingsV1, SettingsState> = (old) => ({
+  ...old,
+  count: 0,
+});
+const decodeSettings = (value: unknown): SettingsState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('theme' in value) || typeof value.theme !== 'string') return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { theme: value.theme, count: value.count };
+};
+
+const settingsStore = pipe
+  .use(persist({
+    local: 'settings',
+    migrate: [toV1, toCurrent],
+    decode: decodeSettings,
+  }))
+  .create<SettingsState>({ theme: 'light', count: 0 });
 ```
 
 ## Caveats

--- a/packages/state/docs/guides/plain-state.ko.mdx
+++ b/packages/state/docs/guides/plain-state.ko.mdx
@@ -131,11 +131,19 @@ import { create } from '@ilokesto/state/react';
 import { logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const searchStore = pipe(
-  initialSearchState,
-  persist({ local: 'search-state' }),
-  logger({ collapsed: true }),
-);
+const decodeSearch = (value: unknown): SearchState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('query' in value) || typeof value.query !== 'string') return null;
+  if (!('page' in value) || typeof value.page !== 'number') return null;
+  if (!('pageSize' in value) || typeof value.pageSize !== 'number') return null;
+  if (!('sort' in value) || (value.sort !== 'relevance' && value.sort !== 'newest')) return null;
+  return { query: value.query, page: value.page, pageSize: value.pageSize, sort: value.sort };
+};
+
+const searchStore = pipe
+  .use(persist({ local: 'search-state', decode: decodeSearch }))
+  .use(logger({ collapsed: true }))
+  .create<SearchState>(initialSearchState);
 
 export const useSearch = create<SearchState>(searchStore);
 ```

--- a/packages/state/docs/guides/plain-state.mdx
+++ b/packages/state/docs/guides/plain-state.mdx
@@ -131,11 +131,19 @@ import { create } from '@ilokesto/state/react';
 import { logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const searchStore = pipe(
-  initialSearchState,
-  persist({ local: 'search-state' }),
-  logger({ collapsed: true }),
-);
+const decodeSearch = (value: unknown): SearchState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('query' in value) || typeof value.query !== 'string') return null;
+  if (!('page' in value) || typeof value.page !== 'number') return null;
+  if (!('pageSize' in value) || typeof value.pageSize !== 'number') return null;
+  if (!('sort' in value) || (value.sort !== 'relevance' && value.sort !== 'newest')) return null;
+  return { query: value.query, page: value.page, pageSize: value.pageSize, sort: value.sort };
+};
+
+const searchStore = pipe
+  .use(persist({ local: 'search-state', decode: decodeSearch }))
+  .use(logger({ collapsed: true }))
+  .create<SearchState>(initialSearchState);
 
 export const useSearch = create<SearchState>(searchStore);
 ```

--- a/packages/state/docs/guides/reducer-state.ko.mdx
+++ b/packages/state/docs/guides/reducer-state.ko.mdx
@@ -150,12 +150,24 @@ import { create } from '@ilokesto/state/react';
 import { devtools, logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const cartStore = pipe(
-  initialCartState,
-  persist({ local: 'cart' }),
-  logger({ collapsed: true, diff: true }),
-  devtools('cart'),
-);
+const isCartItem = (value: unknown): value is CartItem => {
+  return typeof value === 'object' && value !== null
+    && 'id' in value && typeof value.id === 'string'
+    && 'quantity' in value && typeof value.quantity === 'number';
+};
+
+const decodeCart = (value: unknown): CartState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('items' in value) || !Array.isArray(value.items) || !value.items.every(isCartItem)) return null;
+  if (!('coupon' in value) || (value.coupon !== null && typeof value.coupon !== 'string')) return null;
+  return { items: value.items, coupon: value.coupon };
+};
+
+const cartStore = pipe
+  .use(persist({ local: 'cart', decode: decodeCart }))
+  .use(logger({ collapsed: true, diff: true }))
+  .use(devtools('cart'))
+  .create<CartState>(initialCartState);
 
 export const useCart = create<CartState, CartAction>(reduceCart, cartStore);
 ```

--- a/packages/state/docs/guides/reducer-state.mdx
+++ b/packages/state/docs/guides/reducer-state.mdx
@@ -150,12 +150,24 @@ import { create } from '@ilokesto/state/react';
 import { devtools, logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const cartStore = pipe(
-  initialCartState,
-  persist({ local: 'cart' }),
-  logger({ collapsed: true, diff: true }),
-  devtools('cart'),
-);
+const isCartItem = (value: unknown): value is CartItem => {
+  return typeof value === 'object' && value !== null
+    && 'id' in value && typeof value.id === 'string'
+    && 'quantity' in value && typeof value.quantity === 'number';
+};
+
+const decodeCart = (value: unknown): CartState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('items' in value) || !Array.isArray(value.items) || !value.items.every(isCartItem)) return null;
+  if (!('coupon' in value) || (value.coupon !== null && typeof value.coupon !== 'string')) return null;
+  return { items: value.items, coupon: value.coupon };
+};
+
+const cartStore = pipe
+  .use(persist({ local: 'cart', decode: decodeCart }))
+  .use(logger({ collapsed: true, diff: true }))
+  .use(devtools('cart'))
+  .create<CartState>(initialCartState);
 
 export const useCart = create<CartState, CartAction>(reduceCart, cartStore);
 ```

--- a/packages/state/docs/middleware/debounce.ko.mdx
+++ b/packages/state/docs/middleware/debounce.ko.mdx
@@ -10,16 +10,18 @@ description: "빠른 update를 지연하고 누적된 최신 state를 적용합�
 ## Signature
 
 ```ts lineNumbers
-debounce<T>(initialState: T | Store<T>, wait: number | undefined): Store<T>
-debounce(wait?: number): <T>(initialState: T | Store<T>) => Store<T>
+debounce(wait?: number): PipeAnyMiddleware
 ```
 
 ## 예제
 
 ```ts lineNumbers
 import { debounce } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
-const store = debounce({ query: '' }, 250);
+const store = pipe
+  .use(debounce(250))
+  .create({ query: '' });
 
 store.setState({ query: 'i' });
 store.setState({ query: 'il' });

--- a/packages/state/docs/middleware/debounce.mdx
+++ b/packages/state/docs/middleware/debounce.mdx
@@ -10,16 +10,18 @@ description: "Delay rapid updates and apply the latest accumulated state."
 ## Signature
 
 ```ts lineNumbers
-debounce<T>(initialState: T | Store<T>, wait: number | undefined): Store<T>
-debounce(wait?: number): <T>(initialState: T | Store<T>) => Store<T>
+debounce(wait?: number): PipeAnyMiddleware
 ```
 
 ## Example
 
 ```ts lineNumbers
 import { debounce } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
-const store = debounce({ query: '' }, 250);
+const store = pipe
+  .use(debounce(250))
+  .create({ query: '' });
 
 store.setState({ query: 'i' });
 store.setState({ query: 'il' });

--- a/packages/state/docs/middleware/devtools.ko.mdx
+++ b/packages/state/docs/middleware/devtools.ko.mdx
@@ -10,8 +10,7 @@ description: "개발 환경에서 state update를 Redux DevTools extension에 �
 ## Signature
 
 ```ts lineNumbers
-devtools<T>(initialState: T | Store<T>, name: string): Store<T>
-devtools(name: string): <T>(initialState: T | Store<T>) => Store<T>
+devtools(name: string): PipeAnyMiddleware
 ```
 
 ## 예제
@@ -20,7 +19,10 @@ devtools(name: string): <T>(initialState: T | Store<T>) => Store<T>
 import { devtools, logger } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const store = pipe({ count: 0 }, devtools('counter'), logger());
+const store = pipe
+  .use(devtools('counter'))
+  .use(logger())
+  .create({ count: 0 });
 ```
 
 ## 지원하는 DevTools action

--- a/packages/state/docs/middleware/devtools.mdx
+++ b/packages/state/docs/middleware/devtools.mdx
@@ -10,8 +10,7 @@ description: "Connect state updates to the Redux DevTools extension in developme
 ## Signature
 
 ```ts lineNumbers
-devtools<T>(initialState: T | Store<T>, name: string): Store<T>
-devtools(name: string): <T>(initialState: T | Store<T>) => Store<T>
+devtools(name: string): PipeAnyMiddleware
 ```
 
 ## Example
@@ -20,7 +19,10 @@ devtools(name: string): <T>(initialState: T | Store<T>) => Store<T>
 import { devtools, logger } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const store = pipe({ count: 0 }, devtools('counter'), logger());
+const store = pipe
+  .use(devtools('counter'))
+  .use(logger())
+  .create({ count: 0 });
 ```
 
 ## Supported DevTools actions

--- a/packages/state/docs/middleware/index.ko.mdx
+++ b/packages/state/docs/middleware/index.ko.mdx
@@ -5,10 +5,9 @@ description: "@ilokesto/state middleware를 조합하는 방식과 각 helper를
 
 # 미들웨어 소개
 
-`@ilokesto/state/middleware`는 `@ilokesto/store` middleware를 더 쉽게 붙이기 위한 작은 helper 모음입니다. 각 helper는 두 방식으로 사용할 수 있습니다.
+`@ilokesto/state/middleware`는 `@ilokesto/store` middleware를 더 쉽게 붙이기 위한 작은 helper 모음입니다. 각 helper는 등록된 pipe middleware를 반환합니다. 반환값을 `pipe.use(...)`에 넘기고, middleware가 더 있으면 `.use()`를 이어 붙인 뒤 `.create(initialState)`로 plain state에서 store를 만드세요.
 
-- 즉시 적용: `initialState` 또는 기존 `Store<T>`를 먼저 넘기고 `Store<T>`를 받습니다.
-- curried 방식: option을 먼저 넘기고 `pipe`에서 조합할 수 있는 함수를 받습니다.
+Public composition API는 builder-only입니다. `pipe`는 호출할 수 없으며 middleware helper는 `initialState`나 기존 `Store<T>`를 즉시 받는 생성 mode를 제공하지 않습니다.
 
 ## 미들웨어가 실행되는 시점
 
@@ -32,12 +31,16 @@ const schema = {
   },
 } as const;
 
-const store = pipe(
-  { count: 0 },
-  validate(schema),
-  logger({ collapsed: true, diff: true }),
-  persist({ local: 'counter' }),
-);
+const decodeCounter = (value: unknown): { count: number } | null => {
+  const result = schema['~standard'].validate(value);
+  return 'value' in result ? result.value : null;
+};
+
+const store = pipe
+  .use(validate(schema))
+  .use(logger({ collapsed: true, diff: true }))
+  .use(persist({ local: 'counter', decode: decodeCounter }))
+  .create({ count: 0 });
 ```
 
 ## 제공되는 미들웨어

--- a/packages/state/docs/middleware/index.mdx
+++ b/packages/state/docs/middleware/index.mdx
@@ -5,10 +5,9 @@ description: "How @ilokesto/state middleware is composed and when each helper fi
 
 # Middleware introduction
 
-`@ilokesto/state/middleware` provides small wrappers around `@ilokesto/store` middleware. Each helper can be used in two styles:
+`@ilokesto/state/middleware` provides small wrappers around `@ilokesto/store` middleware. Each helper returns registered pipe middleware. Pass that value to `pipe.use(...)`, add more middleware with additional `.use()` calls, then create a store from plain state with `.create(initialState)`.
 
-- immediate style: pass `initialState` or an existing `Store<T>` first and get a `Store<T>` back,
-- curried style: pass options first and get a function that can be composed with `pipe`.
+The public composition API is builder-only. `pipe` is not callable, and middleware helpers do not expose an immediate `initialState` or existing-`Store<T>` construction mode.
 
 ## When middleware runs
 
@@ -32,12 +31,16 @@ const schema = {
   },
 } as const;
 
-const store = pipe(
-  { count: 0 },
-  validate(schema),
-  logger({ collapsed: true, diff: true }),
-  persist({ local: 'counter' }),
-);
+const decodeCounter = (value: unknown): { count: number } | null => {
+  const result = schema['~standard'].validate(value);
+  return 'value' in result ? result.value : null;
+};
+
+const store = pipe
+  .use(validate(schema))
+  .use(logger({ collapsed: true, diff: true }))
+  .use(persist({ local: 'counter', decode: decodeCounter }))
+  .create({ count: 0 });
 ```
 
 ## Available middleware

--- a/packages/state/docs/middleware/logger.ko.mdx
+++ b/packages/state/docs/middleware/logger.ko.mdx
@@ -10,8 +10,7 @@ description: "개발 중 state update를 로그로 확인합니다."
 ## Signature
 
 ```ts lineNumbers
-logger<T>(initialState: T | Store<T>, options?: LoggerOptions): Store<T>
-logger(options?: LoggerOptions): <T>(initialState: T | Store<T>) => Store<T>
+logger(options?: LoggerOptions): PipeAnyMiddleware
 
 type LoggerOptions = {
   collapsed?: boolean;
@@ -24,8 +23,11 @@ type LoggerOptions = {
 
 ```ts lineNumbers
 import { logger } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
-const store = logger({ count: 0 }, { collapsed: true, diff: true, timestamp: true });
+const store = pipe
+  .use(logger({ collapsed: true, diff: true, timestamp: true }))
+  .create({ count: 0 });
 
 store.setState((state) => ({ count: state.count + 1 }));
 ```

--- a/packages/state/docs/middleware/logger.mdx
+++ b/packages/state/docs/middleware/logger.mdx
@@ -10,8 +10,7 @@ description: "Log state updates during development."
 ## Signature
 
 ```ts lineNumbers
-logger<T>(initialState: T | Store<T>, options?: LoggerOptions): Store<T>
-logger(options?: LoggerOptions): <T>(initialState: T | Store<T>) => Store<T>
+logger(options?: LoggerOptions): PipeAnyMiddleware
 
 type LoggerOptions = {
   collapsed?: boolean;
@@ -24,8 +23,11 @@ type LoggerOptions = {
 
 ```ts lineNumbers
 import { logger } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
-const store = logger({ count: 0 }, { collapsed: true, diff: true, timestamp: true });
+const store = pipe
+  .use(logger({ collapsed: true, diff: true, timestamp: true }))
+  .create({ count: 0 });
 
 store.setState((state) => ({ count: state.count + 1 }));
 ```

--- a/packages/state/docs/middleware/persist.ko.mdx
+++ b/packages/state/docs/middleware/persist.ko.mdx
@@ -10,41 +10,86 @@ description: "store state를 localStorage, sessionStorage, cookie에 저장합�
 ## Signature
 
 ```ts lineNumbers
-persist<T, P extends Array<MigrationFn>>(
-  initialState: T | Store<T>,
-  options: PersistConfig<T, P>,
-): Store<T>
-persist(options): <T>(initialState: T | Store<T>) => Store<T>
+persist<DecodedState, const Steps extends readonly MigrationFn[]>(
+  options: SafePersistConfig<DecodedState, Steps>,
+): PipeMiddleware<DecodedState>
 ```
+
+`persist(options)`는 `pipe.use(...)`에 등록할 middleware를 반환합니다. 등록한 뒤 `.create(initialState)`로 store를 만드세요. Storage에서 읽은 값을 live state로 사용하기 전에 검증하도록 `decode`가 필수입니다.
 
 ## Local storage 예제
 
 ```ts lineNumbers
 import { persist } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
-const store = persist({ theme: 'light' as 'light' | 'dark' }, { local: 'theme' });
+type ThemeState = { theme: 'light' | 'dark' };
+
+const decodeTheme = (value: unknown): ThemeState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('theme' in value) || (value.theme !== 'light' && value.theme !== 'dark')) return null;
+  return { theme: value.theme };
+};
+
+const store = pipe
+  .use(persist({ local: 'theme', decode: decodeTheme }))
+  .create<ThemeState>({ theme: 'light' });
 ```
 
 ## Session과 cookie storage
 
 ```ts lineNumbers
-const sessionStore = persist({ token: null as string | null }, { session: 'session' });
-const cookieStore = persist({ accepted: false }, { cookie: 'cookie-consent' });
+type SessionState = { token: string | null };
+type ConsentState = { accepted: boolean };
+
+const decodeSession = (value: unknown): SessionState | null => {
+  if (typeof value !== 'object' || value === null || !('token' in value)) return null;
+  return typeof value.token === 'string' || value.token === null ? { token: value.token } : null;
+};
+
+const decodeConsent = (value: unknown): ConsentState | null => {
+  if (typeof value !== 'object' || value === null || !('accepted' in value)) return null;
+  return typeof value.accepted === 'boolean' ? { accepted: value.accepted } : null;
+};
+
+const sessionStore = pipe
+  .use(persist({ session: 'session', decode: decodeSession }))
+  .create<SessionState>({ token: null });
+
+const cookieStore = pipe
+  .use(persist({ cookie: 'cookie-consent', decode: decodeConsent }))
+  .create<ConsentState>({ accepted: false });
 ```
 
 ## Migration 예제
 
 ```ts lineNumbers
-const settings = persist(
-  { theme: 'light', count: 0 },
-  {
+import type { PersistMigration } from '@ilokesto/state/middleware';
+
+type SettingsV1 = { theme: string };
+type SettingsState = { theme: string; count: number };
+
+const toV1: PersistMigration<unknown, SettingsV1> = (old) => ({
+  theme: typeof old === 'string' ? old : 'light',
+});
+const toCurrent: PersistMigration<SettingsV1, SettingsState> = (old) => ({
+  ...old,
+  count: 0,
+});
+const decodeSettings = (value: unknown): SettingsState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('theme' in value) || typeof value.theme !== 'string') return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { theme: value.theme, count: value.count };
+};
+
+const settings = pipe
+  .use(persist({
     local: 'settings',
-    migrate: [
-      (old) => ({ theme: String(old), count: 0 }),
-      (old) => ({ ...old, count: Number(old.count ?? 0) }),
-    ],
-  },
-);
+    migrate: [toV1, toCurrent],
+    decode: decodeSettings,
+  }))
+  .create<SettingsState>({ theme: 'light', count: 0 });
 ```
 
 ## Storage format과 주의점
@@ -69,9 +114,17 @@ const settings = persist(
 import { persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
+type CounterState = { count: number };
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { count: value.count };
+};
+
 const counterStore = pipe
   .use(persist({ local: 'counter', decode: decodeCounter, skipHydration: true }))
-  .create({ count: 0 });
+  .create<CounterState>({ count: 0 });
 
 // React client component에서:
 useEffect(() => {
@@ -94,16 +147,18 @@ const hydrated = counterStore.persist.hasHydrated();
 성공 시 callback은 hydrated state와 `undefined`를 받습니다. storage가 비어 있는 경우도 성공이며 hydration 직전의 live state를 유지합니다. storage read, parsing, migration, decoding 실패 시에도 live state를 유지하고 callback에는 `undefined`와 원래 error가 전달됩니다. post callback 안에서는 `store.persist.hasHydrated()`가 이미 `true`입니다. post callback 자체가 throw하면 그 exception은 그대로 전파되며 같은 callback의 error 인자로 다시 전달되지 않습니다.
 
 ```ts lineNumbers
-persist({
-  local: 'theme',
-  decode: decodeTheme,
-  skipHydration: true,
-  onRehydrateStorage: (state) => (rehydratedState, error) => {
-    if (error) {
-      console.error('Rehydration failed', error);
-      return;
-    }
-    console.log('Rehydrated from', state, 'to', rehydratedState);
-  },
-});
+const themeStore = pipe
+  .use(persist({
+    local: 'theme',
+    decode: decodeTheme,
+    skipHydration: true,
+    onRehydrateStorage: (state) => (rehydratedState, error) => {
+      if (error) {
+        console.error('Rehydration failed', error);
+        return;
+      }
+      console.log('Rehydrated from', state, 'to', rehydratedState);
+    },
+  }))
+  .create<ThemeState>({ theme: 'light' });
 ```

--- a/packages/state/docs/middleware/persist.mdx
+++ b/packages/state/docs/middleware/persist.mdx
@@ -10,41 +10,86 @@ description: "Persist store state to localStorage, sessionStorage, or cookies."
 ## Signature
 
 ```ts lineNumbers
-persist<T, P extends Array<MigrationFn>>(
-  initialState: T | Store<T>,
-  options: PersistConfig<T, P>,
-): Store<T>
-persist(options): <T>(initialState: T | Store<T>) => Store<T>
+persist<DecodedState, const Steps extends readonly MigrationFn[]>(
+  options: SafePersistConfig<DecodedState, Steps>,
+): PipeMiddleware<DecodedState>
 ```
+
+`persist(options)` returns registered middleware for `pipe.use(...)`. Create the store with `.create(initialState)` after registering it. `decode` is required so values read from storage are validated before they become live state.
 
 ## Local storage example
 
 ```ts lineNumbers
 import { persist } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
-const store = persist({ theme: 'light' as 'light' | 'dark' }, { local: 'theme' });
+type ThemeState = { theme: 'light' | 'dark' };
+
+const decodeTheme = (value: unknown): ThemeState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('theme' in value) || (value.theme !== 'light' && value.theme !== 'dark')) return null;
+  return { theme: value.theme };
+};
+
+const store = pipe
+  .use(persist({ local: 'theme', decode: decodeTheme }))
+  .create<ThemeState>({ theme: 'light' });
 ```
 
 ## Session and cookie storage
 
 ```ts lineNumbers
-const sessionStore = persist({ token: null as string | null }, { session: 'session' });
-const cookieStore = persist({ accepted: false }, { cookie: 'cookie-consent' });
+type SessionState = { token: string | null };
+type ConsentState = { accepted: boolean };
+
+const decodeSession = (value: unknown): SessionState | null => {
+  if (typeof value !== 'object' || value === null || !('token' in value)) return null;
+  return typeof value.token === 'string' || value.token === null ? { token: value.token } : null;
+};
+
+const decodeConsent = (value: unknown): ConsentState | null => {
+  if (typeof value !== 'object' || value === null || !('accepted' in value)) return null;
+  return typeof value.accepted === 'boolean' ? { accepted: value.accepted } : null;
+};
+
+const sessionStore = pipe
+  .use(persist({ session: 'session', decode: decodeSession }))
+  .create<SessionState>({ token: null });
+
+const cookieStore = pipe
+  .use(persist({ cookie: 'cookie-consent', decode: decodeConsent }))
+  .create<ConsentState>({ accepted: false });
 ```
 
 ## Migration example
 
 ```ts lineNumbers
-const settings = persist(
-  { theme: 'light', count: 0 },
-  {
+import type { PersistMigration } from '@ilokesto/state/middleware';
+
+type SettingsV1 = { theme: string };
+type SettingsState = { theme: string; count: number };
+
+const toV1: PersistMigration<unknown, SettingsV1> = (old) => ({
+  theme: typeof old === 'string' ? old : 'light',
+});
+const toCurrent: PersistMigration<SettingsV1, SettingsState> = (old) => ({
+  ...old,
+  count: 0,
+});
+const decodeSettings = (value: unknown): SettingsState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('theme' in value) || typeof value.theme !== 'string') return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { theme: value.theme, count: value.count };
+};
+
+const settings = pipe
+  .use(persist({
     local: 'settings',
-    migrate: [
-      (old) => ({ theme: String(old), count: 0 }),
-      (old) => ({ ...old, count: Number(old.count ?? 0) }),
-    ],
-  },
-);
+    migrate: [toV1, toCurrent],
+    decode: decodeSettings,
+  }))
+  .create<SettingsState>({ theme: 'light', count: 0 });
 ```
 
 ## Storage format and caveats
@@ -69,9 +114,17 @@ Pass `skipHydration: true` to defer hydration. The store keeps the initial state
 import { persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
+type CounterState = { count: number };
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { count: value.count };
+};
+
 const counterStore = pipe
   .use(persist({ local: 'counter', decode: decodeCounter, skipHydration: true }))
-  .create({ count: 0 });
+  .create<CounterState>({ count: 0 });
 
 // In a React client component:
 useEffect(() => {
@@ -94,16 +147,18 @@ Pass `onRehydrateStorage` to observe eager or manual hydration. The factory runs
 On success, the callback receives the hydrated state and `undefined`. Empty storage is also successful and preserves the live pre-hydration state. Storage, parsing, migration, and decoding failures preserve that live state and call the callback with `undefined` and the original error. `store.persist.hasHydrated()` is already `true` inside the post callback. If the post callback throws, that exception propagates and is not passed back into the same callback.
 
 ```ts lineNumbers
-persist({
-  local: 'theme',
-  decode: decodeTheme,
-  skipHydration: true,
-  onRehydrateStorage: (state) => (rehydratedState, error) => {
-    if (error) {
-      console.error('Rehydration failed', error);
-      return;
-    }
-    console.log('Rehydrated from', state, 'to', rehydratedState);
-  },
-});
+const themeStore = pipe
+  .use(persist({
+    local: 'theme',
+    decode: decodeTheme,
+    skipHydration: true,
+    onRehydrateStorage: (state) => (rehydratedState, error) => {
+      if (error) {
+        console.error('Rehydration failed', error);
+        return;
+      }
+      console.log('Rehydrated from', state, 'to', rehydratedState);
+    },
+  }))
+  .create<ThemeState>({ theme: 'light' });
 ```

--- a/packages/state/docs/middleware/validate.ko.mdx
+++ b/packages/state/docs/middleware/validate.ko.mdx
@@ -10,14 +10,14 @@ description: "Standard Schema로 invalid synchronous state update를 막습니�
 ## Signature
 
 ```ts lineNumbers
-validate<T>(initialState: T | Store<T>, schema: StandardSchemaV1<T, T>): Store<T>
-validate<T>(schema: StandardSchemaV1<T, T>): (initialState: T | Store<T>) => Store<T>
+validate<T>(schema: StandardSchemaV1<T, T>): PipeMiddleware<T>
 ```
 
 ## 예제
 
 ```ts lineNumbers
 import { validate } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
 type CounterState = { count: number };
 
@@ -34,7 +34,9 @@ const schema = {
   },
 } as const;
 
-const store = validate({ count: 0 }, schema);
+const store = pipe
+  .use(validate(schema))
+  .create<CounterState>({ count: 0 });
 ```
 
 ## 실패하면 어떻게 되나

--- a/packages/state/docs/middleware/validate.mdx
+++ b/packages/state/docs/middleware/validate.mdx
@@ -10,14 +10,14 @@ description: "Block invalid synchronous state updates with Standard Schema."
 ## Signature
 
 ```ts lineNumbers
-validate<T>(initialState: T | Store<T>, schema: StandardSchemaV1<T, T>): Store<T>
-validate<T>(schema: StandardSchemaV1<T, T>): (initialState: T | Store<T>) => Store<T>
+validate<T>(schema: StandardSchemaV1<T, T>): PipeMiddleware<T>
 ```
 
 ## Example
 
 ```ts lineNumbers
 import { validate } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
 
 type CounterState = { count: number };
 
@@ -34,7 +34,9 @@ const schema = {
   },
 } as const;
 
-const store = validate({ count: 0 }, schema);
+const store = pipe
+  .use(validate(schema))
+  .create<CounterState>({ count: 0 });
 ```
 
 ## What happens on failure

--- a/packages/state/docs/utility/adaptor.ko.mdx
+++ b/packages/state/docs/utility/adaptor.ko.mdx
@@ -113,11 +113,10 @@ Adapter는 여전히 일반 store update pipeline을 통해 subscriber에게 알
 import { logger, validate } from '@ilokesto/state/middleware';
 import { adaptor, pipe } from '@ilokesto/state/utils';
 
-const store = pipe(
-  { tags: [] as string[] },
-  validate(tagsSchema),
-  logger({ diff: true }),
-);
+const store = pipe
+  .use(validate(tagsSchema))
+  .use(logger({ diff: true }))
+  .create({ tags: [] as string[] });
 
 const useTags = create(store);
 const writeTags = useTags.writeOnly();

--- a/packages/state/docs/utility/adaptor.mdx
+++ b/packages/state/docs/utility/adaptor.mdx
@@ -113,11 +113,10 @@ The adapter still notifies subscribers through the normal store update pipeline.
 import { logger, validate } from '@ilokesto/state/middleware';
 import { adaptor, pipe } from '@ilokesto/state/utils';
 
-const store = pipe(
-  { tags: [] as string[] },
-  validate(tagsSchema),
-  logger({ diff: true }),
-);
+const store = pipe
+  .use(validate(tagsSchema))
+  .use(logger({ diff: true }))
+  .create({ tags: [] as string[] });
 
 const useTags = create(store);
 const writeTags = useTags.writeOnly();

--- a/packages/state/docs/utility/index.ko.mdx
+++ b/packages/state/docs/utility/index.ko.mdx
@@ -21,11 +21,19 @@ import { create } from '@ilokesto/state/react';
 import { logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const preferencesStore = pipe(
-  { theme: 'system' as 'system' | 'light' | 'dark' },
-  persist({ local: 'preferences' }),
-  logger({ collapsed: true }),
-);
+type PreferencesState = { theme: 'system' | 'light' | 'dark' };
+
+const decodePreferences = (value: unknown): PreferencesState | null => {
+  if (typeof value !== 'object' || value === null || !('theme' in value)) return null;
+  return value.theme === 'system' || value.theme === 'light' || value.theme === 'dark'
+    ? { theme: value.theme }
+    : null;
+};
+
+const preferencesStore = pipe
+  .use(persist({ local: 'preferences', decode: decodePreferences }))
+  .use(logger({ collapsed: true }))
+  .create<PreferencesState>({ theme: 'system' });
 
 export const usePreferences = create(preferencesStore);
 ```
@@ -61,10 +69,9 @@ import { create } from '@ilokesto/state/react';
 import { validate } from '@ilokesto/state/middleware';
 import { adaptor, pipe } from '@ilokesto/state/utils';
 
-const profileStore = pipe(
-  { name: '', tags: [] as string[] },
-  validate(profileSchema),
-);
+const profileStore = pipe
+  .use(validate(profileSchema))
+  .create({ name: '', tags: [] as string[] });
 
 const useProfile = create(profileStore);
 

--- a/packages/state/docs/utility/index.mdx
+++ b/packages/state/docs/utility/index.mdx
@@ -21,11 +21,19 @@ import { create } from '@ilokesto/state/react';
 import { logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const preferencesStore = pipe(
-  { theme: 'system' as 'system' | 'light' | 'dark' },
-  persist({ local: 'preferences' }),
-  logger({ collapsed: true }),
-);
+type PreferencesState = { theme: 'system' | 'light' | 'dark' };
+
+const decodePreferences = (value: unknown): PreferencesState | null => {
+  if (typeof value !== 'object' || value === null || !('theme' in value)) return null;
+  return value.theme === 'system' || value.theme === 'light' || value.theme === 'dark'
+    ? { theme: value.theme }
+    : null;
+};
+
+const preferencesStore = pipe
+  .use(persist({ local: 'preferences', decode: decodePreferences }))
+  .use(logger({ collapsed: true }))
+  .create<PreferencesState>({ theme: 'system' });
 
 export const usePreferences = create(preferencesStore);
 ```
@@ -61,10 +69,9 @@ import { create } from '@ilokesto/state/react';
 import { validate } from '@ilokesto/state/middleware';
 import { adaptor, pipe } from '@ilokesto/state/utils';
 
-const profileStore = pipe(
-  { name: '', tags: [] as string[] },
-  validate(profileSchema),
-);
+const profileStore = pipe
+  .use(validate(profileSchema))
+  .create({ name: '', tags: [] as string[] });
 
 const useProfile = create(profileStore);
 

--- a/packages/state/docs/utility/pipe.ko.mdx
+++ b/packages/state/docs/utility/pipe.ko.mdx
@@ -5,13 +5,15 @@ description: "Adapter에 연결하기 전에 Store를 만들고 middleware를 �
 
 # pipe
 
-`pipe`는 `@ilokesto/state/utils`의 작은 composition helper입니다.
+`pipe`는 `@ilokesto/state/utils`의 builder-only composition helper입니다.
 
 ```ts lineNumbers
-pipe<T>(initialState: T, ...middlewares: Array<(store: Store<T>) => Store<T>>): Store<T>
+pipe.use(middleware): PipeBuilder
+PipeBuilder.use(middleware): PipeBuilder
+PipeBuilder.create<T>(initialState: T): Store<T>
 ```
 
-`initialState`로 새 `Store<T>`를 만들고, 각 middleware function을 왼쪽에서 오른쪽으로 적용합니다. 결과는 framework adapter에 넘길 수 있는 준비된 store입니다.
+Root `pipe` object는 `.use()`만 제공합니다. 각 `.use()`는 다른 middleware를 등록하거나 `.create(initialState)`를 호출할 수 있는 builder를 반환합니다. `.create()`는 새 `Store<T>`를 만들고 등록된 middleware를 선언 순서대로 적용한 뒤 framework adapter에 넘길 store를 반환합니다.
 
 ## 기본 사용법
 
@@ -20,51 +22,49 @@ import { create } from '@ilokesto/state/react';
 import { logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const counterStore = pipe(
-  { count: 0 },
-  persist({ local: 'counter' }),
-  logger({ collapsed: true, diff: true }),
-);
+type CounterState = { count: number };
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { count: value.count };
+};
+
+const counterStore = pipe
+  .use(persist({ local: 'counter', decode: decodeCounter }))
+  .use(logger({ collapsed: true, diff: true }))
+  .create<CounterState>({ count: 0 });
 
 export const useCounter = create(counterStore);
 ```
 
-위 순서는 persistence가 initial value를 준비하고, 그 다음 logger가 이후 update를 관찰한다는 뜻입니다. 각 middleware가 store를 받아 다시 반환하므로 순서가 중요합니다.
+Middleware setup은 첫 번째 `.use()`부터 마지막 `.use()`까지 실행됩니다. Update에서는 처음 등록한 middleware가 가장 바깥쪽입니다. 순서가 중요하며 `pipe`는 선언 순서를 바꾸지 않고 검증합니다.
 
-## Middleware를 직접 호출하면 안 되나?
+## Builder syntax를 쓰는 이유
 
-직접 조합할 수도 있습니다.
-
-```ts lineNumbers
-const store = logger({ collapsed: true })(persist({ local: 'counter' })({ count: 0 }));
-```
-
-`pipe`는 같은 흐름을 더 읽기 쉽게 만들고, 코드에 보이는 순서와 runtime 순서를 맞춰줍니다.
+`pipe`는 호출할 수 없고 variadic middleware list도 받지 않습니다. `.use()`마다 middleware 하나를 등록한 뒤 plain initial state로 store를 만드세요.
 
 ```ts lineNumbers
-const store = pipe(
-  { count: 0 },
-  persist({ local: 'counter' }),
-  logger({ collapsed: true }),
-);
+const store = pipe
+  .use(validate(counterSchema))
+  .use(logger({ collapsed: true }))
+  .create({ count: 0 });
 ```
 
-위에서 아래로 읽으면 됩니다: state 생성, persistence 적용, logging 적용.
+위에서 아래로 읽으면 됩니다: validation 등록, logging 등록, state 생성.
 
 ## Validation과 함께 쓰기
 
 Validation은 side effect를 수행하는 middleware보다 앞에 두는 경우가 많습니다. 그래야 invalid state가 persist되거나 tooling으로 전달되지 않습니다.
 
 ```ts lineNumbers
-import { devtools, persist, validate } from '@ilokesto/state/middleware';
+import { devtools, validate } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const settingsStore = pipe(
-  { theme: 'system' as 'system' | 'light' | 'dark' },
-  validate(settingsSchema),
-  persist({ local: 'settings' }),
-  devtools('settings'),
-);
+const settingsStore = pipe
+  .use(validate(settingsSchema))
+  .use(devtools('settings'))
+  .create({ theme: 'system' as 'system' | 'light' | 'dark' });
 ```
 
 Validation이 update를 거부하면 뒤쪽 middleware는 invalid state를 보지 않아야 합니다.
@@ -78,10 +78,9 @@ import { create } from '@ilokesto/state/react';
 import { logger } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const todoStore = pipe(
-  { items: [] as string[] },
-  logger({ diff: true }),
-);
+const todoStore = pipe
+  .use(logger({ diff: true }))
+  .create({ items: [] as string[] });
 
 export const useTodos = create(reduceTodos, todoStore);
 ```
@@ -90,27 +89,26 @@ Reducer action은 next state로 변환되고, 그 결과 update가 store middlew
 
 ## 기존 Store instance
 
-`pipe`는 항상 initial state에서 새 `Store<T>`를 만듭니다. 이미 특정 `Store<T>` instance를 소유하고 있고 그 instance를 보존해야 한다면 `pipe` 대신 middleware helper에 store를 직접 넘기세요.
+`pipe`는 항상 plain initial state에서 새 `Store<T>`를 만듭니다. `.create()`는 기존 `Store`를 거부합니다. 다른 module이 정확한 store instance를 이미 소유한다면 그 store를 framework adapter에 직접 넘기고, 생성에는 `pipe`를 사용하지 마세요.
 
 ```ts lineNumbers
 import { Store } from '@ilokesto/store';
-import { logger } from '@ilokesto/state/middleware';
+import { create } from '@ilokesto/state/react';
 
 const existingStore = new Store({ count: 0 });
-const storeWithLogger = logger({ collapsed: true })(existingStore);
+const useCounter = create(existingStore);
 ```
 
-다른 module이 이미 store를 subscribe하고 있거나, utility layer 밖 infrastructure가 store를 만든 경우 이 방식을 사용하세요.
+다른 module이 이미 store를 subscribe하고 있거나 utility layer 밖 infrastructure가 store를 만든 경우 이 방식을 사용하세요.
 
 ## Piped store 테스트하기
 
 `pipe`는 plain `Store<T>`를 반환하므로 framework adapter 없이 먼저 test할 수 있습니다.
 
 ```ts lineNumbers
-const store = pipe(
-  { count: 0 },
-  validate(counterSchema),
-);
+const store = pipe
+  .use(validate(counterSchema))
+  .create({ count: 0 });
 
 store.setState({ count: 1 });
 expect(store.getState()).toEqual({ count: 1 });
@@ -120,7 +118,8 @@ Persistence나 browser-only middleware는 필요한 storage API를 제공하는 
 
 ## 자주 하는 실수
 
-- **`pipe`가 기존 store를 mutate한다고 생각하기.** `pipe`는 `initialState`에서 새 `Store<T>`를 만듭니다.
-- **순서 무시하기.** Middleware는 왼쪽에서 오른쪽으로 적용되고, side-effect middleware는 보통 validation 뒤에 둡니다.
+- **`pipe(initialState, ...middleware)` 호출하기.** `pipe`는 object입니다. `pipe.use(...)`로 시작하고 `.create(initialState)`로 끝내세요.
+- **기존 store를 `.create()`에 넘기기.** Builder는 plain initial state만 받고 새 `Store<T>`를 만듭니다.
+- **순서 무시하기.** Middleware는 선언 순서대로 등록되며 side-effect middleware는 보통 validation 뒤에 둡니다.
 - **framework adapter call을 `pipe` 안에 넣기.** `pipe`는 store middleware를 조합하지 React/Vue/Svelte/Solid/Angular adapter call을 조합하지 않습니다.
 - **store 생성 후 update에 `pipe`를 사용하기.** Store가 이미 있으면 `setState`, `dispatch`, 또는 [`adaptor`](/ko/state/utility/adaptor)를 사용하세요.

--- a/packages/state/docs/utility/pipe.mdx
+++ b/packages/state/docs/utility/pipe.mdx
@@ -5,13 +5,15 @@ description: "Create a Store and apply middleware left-to-right before connectin
 
 # pipe
 
-`pipe` is a small composition helper from `@ilokesto/state/utils`.
+`pipe` is a builder-only composition helper from `@ilokesto/state/utils`.
 
 ```ts lineNumbers
-pipe<T>(initialState: T, ...middlewares: Array<(store: Store<T>) => Store<T>>): Store<T>
+pipe.use(middleware): PipeBuilder
+PipeBuilder.use(middleware): PipeBuilder
+PipeBuilder.create<T>(initialState: T): Store<T>
 ```
 
-It creates a new `Store<T>` from `initialState`, then applies each middleware function from left to right. The result is a prepared store that can be passed to a framework adapter.
+The root `pipe` object exposes only `.use()`. Each `.use()` returns a builder that can register another middleware or call `.create(initialState)`. `.create()` creates a new `Store<T>`, applies the registered middleware in declaration order, and returns the prepared store for a framework adapter.
 
 ## Basic usage
 
@@ -20,51 +22,49 @@ import { create } from '@ilokesto/state/react';
 import { logger, persist } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const counterStore = pipe(
-  { count: 0 },
-  persist({ local: 'counter' }),
-  logger({ collapsed: true, diff: true }),
-);
+type CounterState = { count: number };
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  if (!('count' in value) || typeof value.count !== 'number') return null;
+  return { count: value.count };
+};
+
+const counterStore = pipe
+  .use(persist({ local: 'counter', decode: decodeCounter }))
+  .use(logger({ collapsed: true, diff: true }))
+  .create<CounterState>({ count: 0 });
 
 export const useCounter = create(counterStore);
 ```
 
-The middleware order above means persistence prepares the initial value, then logger observes later updates. Middleware order matters because each middleware receives and returns the store.
+Middleware setup runs from the first `.use()` to the last. During updates, the first registered middleware is outermost. Order matters, and `pipe` validates the declared order without rearranging it.
 
-## Why not just call middleware manually?
+## Why builder syntax?
 
-You can always compose middleware by hand:
-
-```ts lineNumbers
-const store = logger({ collapsed: true })(persist({ local: 'counter' })({ count: 0 }));
-```
-
-`pipe` makes the same flow easier to scan and keeps the order visually aligned with runtime order.
+`pipe` is not callable and does not accept a variadic middleware list. Register one middleware per `.use()`, then create the store from plain initial state.
 
 ```ts lineNumbers
-const store = pipe(
-  { count: 0 },
-  persist({ local: 'counter' }),
-  logger({ collapsed: true }),
-);
+const store = pipe
+  .use(validate(counterSchema))
+  .use(logger({ collapsed: true }))
+  .create({ count: 0 });
 ```
 
-Read the list from top to bottom: create state, apply persistence, apply logging.
+Read the chain from top to bottom: register validation, register logging, then create state.
 
 ## Use with validation
 
 Validation is often best placed before middleware that performs side effects, so invalid states do not get persisted or sent to tooling.
 
 ```ts lineNumbers
-import { devtools, persist, validate } from '@ilokesto/state/middleware';
+import { devtools, validate } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const settingsStore = pipe(
-  { theme: 'system' as 'system' | 'light' | 'dark' },
-  validate(settingsSchema),
-  persist({ local: 'settings' }),
-  devtools('settings'),
-);
+const settingsStore = pipe
+  .use(validate(settingsSchema))
+  .use(devtools('settings'))
+  .create({ theme: 'system' as 'system' | 'light' | 'dark' });
 ```
 
 If validation rejects an update, later middleware in the chain should not see the invalid state.
@@ -78,10 +78,9 @@ import { create } from '@ilokesto/state/react';
 import { logger } from '@ilokesto/state/middleware';
 import { pipe } from '@ilokesto/state/utils';
 
-const todoStore = pipe(
-  { items: [] as string[] },
-  logger({ diff: true }),
-);
+const todoStore = pipe
+  .use(logger({ diff: true }))
+  .create({ items: [] as string[] });
 
 export const useTodos = create(reduceTodos, todoStore);
 ```
@@ -90,27 +89,26 @@ Reducer actions are converted to next state, then the store middleware pipeline 
 
 ## Existing Store instances
 
-`pipe` always creates a new `Store<T>` from the initial state. If you already own a specific `Store<T>` instance and need to preserve that exact instance, pass the store to middleware helpers directly instead of using `pipe`.
+`pipe` always creates a new `Store<T>` from plain initial state. `.create()` rejects an existing `Store`. If another module already owns the exact store instance, pass that store directly to the framework adapter and do not use `pipe` for its construction.
 
 ```ts lineNumbers
 import { Store } from '@ilokesto/store';
-import { logger } from '@ilokesto/state/middleware';
+import { create } from '@ilokesto/state/react';
 
 const existingStore = new Store({ count: 0 });
-const storeWithLogger = logger({ collapsed: true })(existingStore);
+const useCounter = create(existingStore);
 ```
 
-Use this style when another module already subscribes to the store or when the store is created by infrastructure outside the utility layer.
+Use this style when another module already subscribes to the store or when infrastructure outside the utility layer created it.
 
 ## Testing a piped store
 
 Because `pipe` returns a plain `Store<T>`, it can be tested before any framework adapter is involved.
 
 ```ts lineNumbers
-const store = pipe(
-  { count: 0 },
-  validate(counterSchema),
-);
+const store = pipe
+  .use(validate(counterSchema))
+  .create({ count: 0 });
 
 store.setState({ count: 1 });
 expect(store.getState()).toEqual({ count: 1 });
@@ -120,7 +118,8 @@ For persistence or browser-only middleware, run tests in an environment that pro
 
 ## Common mistakes
 
-- **Assuming `pipe` mutates an existing store.** It creates a new `Store<T>` from `initialState`.
-- **Ignoring order.** Middleware is applied left-to-right, and side-effect middleware should usually come after validation.
+- **Calling `pipe(initialState, ...middleware)`.** `pipe` is an object; start with `pipe.use(...)` and finish with `.create(initialState)`.
+- **Passing an existing store to `.create()`.** The builder accepts plain initial state only and creates a new `Store<T>`.
+- **Ignoring order.** Middleware is registered in declaration order, and side-effect middleware should usually come after validation.
 - **Putting framework adapter calls inside `pipe`.** `pipe` composes store middleware, not React/Vue/Svelte/Solid/Angular adapter calls.
 - **Using `pipe` for one-off direct updates.** Use `setState`, `dispatch`, or [`adaptor`](/en/state/utility/adaptor) for updates after the store exists.


### PR DESCRIPTION
## Summary
- replace callable and variadic `pipe(...)` guidance with `pipe.use(...).create(initialState)` across the state documentation
- document middleware factories and `persist` as registered pipe middleware, including required safe decoders and typed migrations
- keep all 12 affected English/Korean page pairs aligned and add a patch changeset for `@ilokesto/state`

## Evidence
- `pipe` exposes only `use`; builders expose `use` and `create`
- `persist` accepts `SafePersistConfig` options and requires `decode` before persisted values become live state
- repository-wide stale-syntax checks find no executable callable `pipe`, immediate middleware, or unwrapped `persist` examples in the changed pages

## Verification
- `pnpm install`
- `pnpm --filter @ilokesto/store build`
- `pnpm --filter @ilokesto/state test` (178 passed)
- `pnpm --filter @ilokesto/state typecheck`
- `pnpm --filter @ilokesto/state test:typecheck`
- EN/KO code-block parity and `git diff --check`
- built-package runtime driver confirmed builder-only rejection and safe persist behavior

Fixes #38