### PR TITLE
fix(modal): guarantee removal with a closing fallback when animationend never fires

### DIFF
--- a/.changeset/modal-closing-animationend-fallback.md
+++ b/.changeset/modal-closing-animationend-fallback.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/modal": patch
+---
+
+Guarantee modal removal with a closing fallback that fires when no `animationend` event occurs (for example when a consumer sets `style={{ animation: 'none' }}`), while retaining `animationend` as the normal fast path. The fallback reads the effective animation duration and is canceled when the fast path completes.

--- a/packages/modal/src/adapters/ModalAdapterInline.tsx
+++ b/packages/modal/src/adapters/ModalAdapterInline.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import { useModalStackInfo } from '../hooks/useIsTopModal';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import { getCloseAnimationDurationMs, getCloseFallbackDelayMs } from '../shared/animationDuration';
 import type { ModalAdapterProps, ModalPosition } from '../shared/types';
 
 const focusableSelector = [
@@ -86,6 +87,21 @@ export function ModalAdapterInline<TResult>({
         remove();
       }
     }
+  }, [status, prefersReducedMotion, remove]);
+
+  // Closing fallback: guarantee removal even when a consumer style suppresses
+  // the exit animation so no animationend ever fires.
+  useEffect(() => {
+    if (status !== 'closing' || prefersReducedMotion) {
+      return;
+    }
+    const delay = getCloseFallbackDelayMs(getCloseAnimationDurationMs(containerRef.current));
+    const timer = window.setTimeout(() => {
+      remove();
+    }, delay);
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [status, prefersReducedMotion, remove]);
 
   useEffect(() => {

--- a/packages/modal/src/adapters/ModalAdapterTopLayer.tsx
+++ b/packages/modal/src/adapters/ModalAdapterTopLayer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useCallback, useId } from 'react';
 import { useIsTopModal } from '../hooks/useIsTopModal';
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion';
+import { getCloseAnimationDurationMs, getCloseFallbackDelayMs } from '../shared/animationDuration';
 import type { ModalAdapterProps, ModalPosition } from '../shared/types';
 
 const focusableSelector = [
@@ -78,6 +79,25 @@ export function ModalAdapterTopLayer<TResult>({
         remove();
       }
     }
+  }, [status, prefersReducedMotion, remove]);
+
+  // Closing fallback: guarantee removal even when a consumer style suppresses
+  // the exit animation so no animationend ever fires.
+  useEffect(() => {
+    if (status !== 'closing' || prefersReducedMotion) {
+      return;
+    }
+    const delay = getCloseFallbackDelayMs(getCloseAnimationDurationMs(dialogRef.current));
+    const timer = window.setTimeout(() => {
+      const dialog = dialogRef.current;
+      if (dialog && dialog.open) {
+        dialog.close();
+      }
+      remove();
+    }, delay);
+    return () => {
+      window.clearTimeout(timer);
+    };
   }, [status, prefersReducedMotion, remove]);
 
   useEffect(() => {

--- a/packages/modal/src/shared/animationDuration.ts
+++ b/packages/modal/src/shared/animationDuration.ts
@@ -1,0 +1,39 @@
+const DEFAULT_CLOSE_ANIMATION_MS = 200;
+const CLOSE_FALLBACK_BUFFER_MS = 50;
+
+function parseDurationToken(token: string): number | null {
+  const match = /^(\d+(?:\.\d+)?)(ms|s)$/.exec(token);
+  if (!match) {
+    return null;
+  }
+  const value = Number(match[1]);
+  return match[2] === 's' ? value * 1000 : value;
+}
+
+export function getCloseAnimationDurationMs(element: HTMLElement | null): number {
+  if (!element) {
+    return DEFAULT_CLOSE_ANIMATION_MS;
+  }
+
+  const longhand = parseDurationToken(element.style.animationDuration);
+  if (longhand !== null) {
+    return longhand;
+  }
+
+  const shorthand = element.style.animation;
+  if (shorthand) {
+    for (const token of shorthand.split(/\s+/)) {
+      const parsed = parseDurationToken(token);
+      if (parsed !== null) {
+        return parsed;
+      }
+    }
+    return 0;
+  }
+
+  return DEFAULT_CLOSE_ANIMATION_MS;
+}
+
+export function getCloseFallbackDelayMs(durationMs: number): number {
+  return durationMs > 0 ? durationMs + CLOSE_FALLBACK_BUFFER_MS : 0;
+}

--- a/packages/modal/test/modalClosingFallback.test.tsx
+++ b/packages/modal/test/modalClosingFallback.test.tsx
@@ -1,0 +1,137 @@
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, screen } from '@testing-library/react';
+import { ModalAdapterInline } from '../src/adapters/ModalAdapterInline';
+import { ModalAdapterTopLayer } from '../src/adapters/ModalAdapterTopLayer';
+import { renderWithModalStack } from './modalStackTestUtils';
+
+describe('modal closing fallback', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = '';
+    vi.useRealTimers();
+  });
+
+  it('removes an inline modal even when the consumer disables the exit animation', () => {
+    vi.useFakeTimers();
+    const remove = vi.fn();
+
+    renderWithModalStack(
+      <ModalAdapterInline
+        id="no-animation"
+        isOpen={false}
+        status="closing"
+        close={vi.fn()}
+        remove={remove}
+        useLifecycle={vi.fn()}
+        style={{ animation: 'none' }}
+        ariaLabel="No animation inline"
+        render={() => null}
+      />
+    );
+
+    expect(remove).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps animationend as the inline fast path and cancels the fallback', () => {
+    vi.useFakeTimers();
+    const remove = vi.fn();
+
+    const { unmount } = renderWithModalStack(
+      <ModalAdapterInline
+        id="animated"
+        isOpen={false}
+        status="closing"
+        close={vi.fn()}
+        remove={remove}
+        useLifecycle={vi.fn()}
+        ariaLabel="Animated inline"
+        render={() => null}
+      />
+    );
+
+    act(() => {
+      fireEvent.animationEnd(screen.getByRole('dialog', { name: 'Animated inline' }));
+    });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes a top-layer dialog even when the consumer disables the exit animation', () => {
+    vi.useFakeTimers();
+    const remove = vi.fn();
+
+    renderWithModalStack(
+      <ModalAdapterTopLayer
+        id="no-animation-dialog"
+        isOpen={false}
+        status="closing"
+        close={vi.fn()}
+        remove={remove}
+        useLifecycle={vi.fn()}
+        style={{ animation: 'none' }}
+        ariaLabel="No animation top-layer"
+        render={() => null}
+      />
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'No animation top-layer' }) as HTMLDialogElement;
+    const closeSpy = vi.spyOn(dialog, 'close');
+
+    expect(remove).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps animationend as the top-layer fast path and cancels the fallback', () => {
+    vi.useFakeTimers();
+    const remove = vi.fn();
+
+    const { unmount } = renderWithModalStack(
+      <ModalAdapterTopLayer
+        id="animated-dialog"
+        isOpen={false}
+        status="closing"
+        close={vi.fn()}
+        remove={remove}
+        useLifecycle={vi.fn()}
+        ariaLabel="Animated top-layer"
+        render={() => null}
+      />
+    );
+
+    act(() => {
+      fireEvent.animationEnd(screen.getByRole('dialog', { name: 'Animated top-layer' }));
+    });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(remove).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a cleanup-safe closing fallback to both `ModalAdapterInline` and `ModalAdapterTopLayer` that schedules removal when no `animationend` event fires — for example when a consumer passes `style={{ animation: 'none' }}`.
- `animationend` remains the normal fast path; when it fires, removal unmounts the adapter and the fallback timer is cleared.
- The fallback delay is derived from the panel/dialog effective animation duration (longhand first, then the `animation` shorthand), so a custom longer exit animation is not cut short, and a disabled animation removes promptly.

## Evidence
- `packages/modal/src/shared/animationDuration.ts` — reads the effective animation duration from the element inline style (works in real browsers via longhand expansion and in jsdom via the preserved shorthand string).
- `packages/modal/src/adapters/ModalAdapterInline.tsx` and `ModalAdapterTopLayer.tsx` — the fallback effect runs only while `status === 'closing'` and reduced-motion is off (reduced motion already fast-tracks removal), mirrors the `animationend` cleanup (top-layer also calls `dialog.close()`), and clears the timer on cleanup.
- Before the fix, the regression tests failed with `remove` never called when `animation: 'none'` suppressed the exit animation; the modal stayed closing indefinitely, `display()` never settled, and inline modals kept their scroll lock.

## Tests
- `pnpm --filter @ilokesto/modal typecheck`
- `pnpm --filter @ilokesto/modal test` (45 passed, including 4 new closing-fallback tests)
- `pnpm --filter @ilokesto/modal build`
- `pnpm --filter @ilokesto/modal test:pack`
- `pnpm --filter @ilokesto/modal test:e2e` (12 passed)
- `pnpm --filter @ilokesto/modal test:a11y` (2 passed)

Closes #46