### PR TITLE
docs(form): align docs to defaultValues contract and actual root exports

### DIFF
--- a/.changeset/form-docs-default-values-exports.md
+++ b/.changeset/form-docs-default-values-exports.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/form": patch
+---
+
+Align form documentation with the actual public contract: use `defaultValues` (not the non-existent `initialValues`) in all examples and prose, and document only the types the root entrypoint actually exports. `FieldState` and `FormState` are now described as runtime shapes returned by `getFieldState()` and `getState()`, not as root imports.

--- a/packages/form/docs/advanced/normalized-store.ko.mdx
+++ b/packages/form/docs/advanced/normalized-store.ko.mdx
@@ -5,7 +5,7 @@ description: "정규화된 필드 기록이 getState, getValues, 어댑터 구�
 
 # 정규화 저장소
 
-관찰 가능한 내부 상태는 `FormState<TValues>` 모양입니다. 여기에는 `initialValues`, `fields`, `submitCount`, `arrayKeys`가 있습니다. `fields` 기록은 정규화된 경로 키로 저장되며 말단 값마다 하나의 `FieldState`를 가집니다. 그래서 `getFieldState(path)`가 가볍게 동작하고, 어댑터가 하나의 스냅샷에서 errors, dirty fields, touched fields를 요약할 수 있습니다.
+관찰 가능한 내부 상태는 `FormState<TValues>` 모양입니다. 여기에는 `defaultValues`, `fields`, `submitCount`, `arrayKeys`가 있습니다. `fields` 기록은 정규화된 경로 키로 저장되며 말단 값마다 하나의 `FieldState`를 가집니다. 그래서 `getFieldState(path)`가 가볍게 동작하고, 어댑터가 하나의 스냅샷에서 errors, dirty fields, touched fields를 요약할 수 있습니다.
 
 ```ts lineNumbers
 const snapshot = form.getState();

--- a/packages/form/docs/advanced/normalized-store.mdx
+++ b/packages/form/docs/advanced/normalized-store.mdx
@@ -5,7 +5,7 @@ description: "How normalized field records explain getState, getValues, and adap
 
 # Normalized store
 
-Internally visible state is shaped as `FormState<TValues>`: `initialValues`, `fields`, `submitCount`, and `arrayKeys`. The `fields` record is keyed by normalized path keys and stores one `FieldState` per leaf. This is why `getFieldState(path)` can be cheap and why adapters can summarize errors, dirty fields, and touched fields from one snapshot.
+Internally visible state is shaped as `FormState<TValues>`: `defaultValues`, `fields`, `submitCount`, and `arrayKeys`. The `fields` record is keyed by normalized path keys and stores one `FieldState` per leaf. This is why `getFieldState(path)` can be cheap and why adapters can summarize errors, dirty fields, and touched fields from one snapshot.
 
 ```ts lineNumbers
 const snapshot = form.getState();

--- a/packages/form/docs/guides/build-a-login-form.ko.mdx
+++ b/packages/form/docs/guides/build-a-login-form.ko.mdx
@@ -9,7 +9,7 @@ description: "필드 바인딩, 검증, 제출, 초기화를 갖춘 실무형 �
 
 ```tsx lineNumbers
 const form = new CreateForm({
-  initialValues: { email: '', password: '', remember: false },
+  defaultValues: { email: '', password: '', remember: false },
   schema: loginSchema,
   validateOn: ['blur', 'submit'],
 });

--- a/packages/form/docs/guides/build-a-login-form.mdx
+++ b/packages/form/docs/guides/build-a-login-form.mdx
@@ -9,7 +9,7 @@ Start by keeping the form instance outside the component so it is not recreated 
 
 ```tsx lineNumbers
 const form = new CreateForm({
-  initialValues: { email: '', password: '', remember: false },
+  defaultValues: { email: '', password: '', remember: false },
   schema: loginSchema,
   validateOn: ['blur', 'submit'],
 });

--- a/packages/form/docs/guides/validation-flow.ko.mdx
+++ b/packages/form/docs/guides/validation-flow.ko.mdx
@@ -9,7 +9,7 @@ description: "validateOn, field-local 스키마, 수동 trigger, 제출 검증�
 
 ```ts lineNumbers
 const form = new CreateForm({
-  initialValues,
+  defaultValues,
   schema: profileSchema,
   validateOn: ['blur', 'submit'],
 });

--- a/packages/form/docs/guides/validation-flow.mdx
+++ b/packages/form/docs/guides/validation-flow.mdx
@@ -9,7 +9,7 @@ A practical validation flow usually combines three layers. First, a form-level S
 
 ```ts lineNumbers
 const form = new CreateForm({
-  initialValues,
+  defaultValues,
   schema: profileSchema,
   validateOn: ['blur', 'submit'],
 });

--- a/packages/form/docs/index.ko.mdx
+++ b/packages/form/docs/index.ko.mdx
@@ -21,7 +21,7 @@ description: "프레임워크와 분리된 폼 상태, 검증, 배열 메타데�
 import { CreateForm } from '@ilokesto/form';
 
 const form = new CreateForm({
-  initialValues: {
+  defaultValues: {
     email: '',
     profile: { name: 'Ada' },
     tags: ['docs'],

--- a/packages/form/docs/index.mdx
+++ b/packages/form/docs/index.mdx
@@ -21,7 +21,7 @@ Install the framework peer you use as well: `react`, `vue`, `solid-js`, or `svel
 import { CreateForm } from '@ilokesto/form';
 
 const form = new CreateForm({
-  initialValues: {
+  defaultValues: {
     email: '',
     profile: { name: 'Ada' },
     tags: ['docs'],

--- a/packages/form/docs/quick-start.ko.mdx
+++ b/packages/form/docs/quick-start.ko.mdx
@@ -27,7 +27,7 @@ type LoginValues = {
 };
 
 export const loginForm = new CreateForm<LoginValues>({
-  initialValues: {
+  defaultValues: {
     email: '',
     password: '',
     remember: false,
@@ -36,7 +36,7 @@ export const loginForm = new CreateForm<LoginValues>({
 });
 ```
 
-`initialValues`는 reset 기준값이자 처음 필드 값입니다. `validateOn`은 자동 검증이 실행될 시점을 정합니다. 그래도 필요한 순간에는 언제든 `trigger()`를 직접 호출할 수 있습니다.
+`defaultValues`는 reset 기준값이자 처음 필드 값입니다. `validateOn`은 자동 검증이 실행될 시점을 정합니다. 그래도 필요한 순간에는 언제든 `trigger()`를 직접 호출할 수 있습니다.
 
 ## 3. React에서 필드 연결하기
 

--- a/packages/form/docs/quick-start.mdx
+++ b/packages/form/docs/quick-start.mdx
@@ -27,7 +27,7 @@ type LoginValues = {
 };
 
 export const loginForm = new CreateForm<LoginValues>({
-  initialValues: {
+  defaultValues: {
     email: '',
     password: '',
     remember: false,
@@ -36,7 +36,7 @@ export const loginForm = new CreateForm<LoginValues>({
 });
 ```
 
-`initialValues` establishes the reset baseline and the first `FieldState` values. `validateOn` tells the core when automatic validation should run. You can still call `trigger()` manually at any time.
+`defaultValues` establishes the reset baseline and the first `FieldState` values. `validateOn` tells the core when automatic validation should run. You can still call `trigger()` manually at any time.
 
 ## 3. Bind fields in React
 

--- a/packages/form/docs/reference/create-form.ko.mdx
+++ b/packages/form/docs/reference/create-form.ko.mdx
@@ -5,11 +5,11 @@ description: "렌더러 없이 폼 컨트롤러를 만들고 상태를 구독하
 
 # CreateForm
 
-`CreateForm<TValues>`는 모든 어댑터 뒤에 있는 코어 클래스입니다. 생성자에는 `CreateFormOptions`를 전달합니다. 옵션에는 `initialValues`, 선택적인 폼 전체 `schema`, 선택적인 `schemaOptions`, 선택적인 `validateOn`이 있습니다. 인스턴스는 `Form<TValues>`를 구현하므로 어댑터와 테스트가 하나의 안정된 계약에 의존할 수 있습니다.
+`CreateForm<TValues>`는 모든 어댑터 뒤에 있는 코어 클래스입니다. 생성자에는 `CreateFormOptions`를 전달합니다. 옵션에는 `defaultValues`, 선택적인 폼 전체 `schema`, 선택적인 `schemaOptions`, 선택적인 `validateOn`이 있습니다. 인스턴스는 `Form<TValues>`를 구현하므로 어댑터와 테스트가 하나의 안정된 계약에 의존할 수 있습니다.
 
 ```ts lineNumbers
 const form = new CreateForm({
-  initialValues: { email: '', profile: { name: '' } },
+  defaultValues: { email: '', profile: { name: '' } },
   schema: profileSchema,
   schemaOptions: { libraryOptions: { abortEarly: false } },
   validateOn: ['change', 'blur', 'submit'],

--- a/packages/form/docs/reference/create-form.mdx
+++ b/packages/form/docs/reference/create-form.mdx
@@ -5,11 +5,11 @@ description: "Create a form controller, subscribe to state, and operate values w
 
 # CreateForm
 
-`CreateForm<TValues>` is the core class behind every adapter. Construct it with `CreateFormOptions`: `initialValues`, optional form-level `schema`, optional `schemaOptions`, and optional `validateOn`. The instance implements `Form<TValues>`, so adapters and tests can rely on one stable contract.
+`CreateForm<TValues>` is the core class behind every adapter. Construct it with `CreateFormOptions`: `defaultValues`, optional form-level `schema`, optional `schemaOptions`, and optional `validateOn`. The instance implements `Form<TValues>`, so adapters and tests can rely on one stable contract.
 
 ```ts lineNumbers
 const form = new CreateForm({
-  initialValues: { email: '', profile: { name: '' } },
+  defaultValues: { email: '', profile: { name: '' } },
   schema: profileSchema,
   schemaOptions: { libraryOptions: { abortEarly: false } },
   validateOn: ['change', 'blur', 'submit'],

--- a/packages/form/docs/reference/entrypoints.ko.mdx
+++ b/packages/form/docs/reference/entrypoints.ko.mdx
@@ -5,7 +5,7 @@ description: "코어와 프레임워크 어댑터를 올바른 패키지 하위 
 
 # 진입점
 
-`@ilokesto/form`에는 프레임워크와 분리된 루트 진입점 하나와 네 개의 어댑터 진입점이 있습니다. `CreateForm`, `CreateFormOptions`, `FieldPathInput`, `FieldState`, `FormState`, `FormError`, `StandardSchemaV1`은 루트에서 가져옵니다. 프레임워크 도우미는 `@ilokesto/form/react`, `@ilokesto/form/vue`, `@ilokesto/form/solid`, `@ilokesto/form/svelte`에서 가져옵니다.
+`@ilokesto/form`에는 프레임워크와 분리된 루트 진입점 하나와 네 개의 어댑터 진입점이 있습니다. `CreateForm`, `CreateFormOptions`, `FieldPathInput`, `Form`, `FormError`, `ResetOptions`, `StandardSchemaV1`은 루트에서 가져옵니다. `FieldState`와 `FormState`는 `getFieldState()`와 `getState()`가 반환하는 런타임 모양이며 루트에서 가져올 수 없습니다. 프레임워크 도우미는 `@ilokesto/form/react`, `@ilokesto/form/vue`, `@ilokesto/form/solid`, `@ilokesto/form/svelte`에서 가져옵니다.
 
 ```ts lineNumbers
 import { CreateForm, type FormError } from '@ilokesto/form';

--- a/packages/form/docs/reference/entrypoints.mdx
+++ b/packages/form/docs/reference/entrypoints.mdx
@@ -5,7 +5,7 @@ description: "Import the core and framework adapters from the correct package su
 
 # Entrypoints
 
-`@ilokesto/form` has one framework-neutral root entrypoint and four adapter entrypoints. Import `CreateForm`, `CreateFormOptions`, `FieldPathInput`, `FieldState`, `FormState`, `FormError`, and `StandardSchemaV1` from the root. Import framework helpers from `@ilokesto/form/react`, `@ilokesto/form/vue`, `@ilokesto/form/solid`, or `@ilokesto/form/svelte`.
+`@ilokesto/form` has one framework-neutral root entrypoint and four adapter entrypoints. Import `CreateForm`, `CreateFormOptions`, `FieldPathInput`, `Form`, `FormError`, `ResetOptions`, and `StandardSchemaV1` from the root. `FieldState` and `FormState` are runtime shapes returned by `getFieldState()` and `getState()`; they are not importable from the root. Import framework helpers from `@ilokesto/form/react`, `@ilokesto/form/vue`, `@ilokesto/form/solid`, or `@ilokesto/form/svelte`.
 
 ```ts lineNumbers
 import { CreateForm, type FormError } from '@ilokesto/form';

--- a/packages/form/docs/reference/submit-and-reset.ko.mdx
+++ b/packages/form/docs/reference/submit-and-reset.ko.mdx
@@ -19,7 +19,7 @@ await form.submit(
 );
 ```
 
-`reset()`은 원래 `initialValues`로 되돌립니다. `reset(nextValues)`는 기준값을 교체하고 새 값 주변의 필드 메타데이터를 정리합니다. 서버 흐름에서는 `submit`, `setErrors`, `clearErrors`를 함께 사용하세요. 클라이언트 검증을 통과한 값을 제출하고, 서버 오류를 필드에 매핑한 뒤, 사용자가 수정하거나 다시 시도할 때 그 오류를 지웁니다.
+`reset()`은 원래 `defaultValues`로 되돌립니다. `reset(nextValues)`는 기준값을 교체하고 새 값 주변의 필드 메타데이터를 정리합니다. 서버 흐름에서는 `submit`, `setErrors`, `clearErrors`를 함께 사용하세요. 클라이언트 검증을 통과한 값을 제출하고, 서버 오류를 필드에 매핑한 뒤, 사용자가 수정하거나 다시 시도할 때 그 오류를 지웁니다.
 
 ## 실무 사용 팁
 

--- a/packages/form/docs/reference/submit-and-reset.mdx
+++ b/packages/form/docs/reference/submit-and-reset.mdx
@@ -19,7 +19,7 @@ await form.submit(
 );
 ```
 
-`reset()` restores the original `initialValues`. `reset(nextValues)` replaces the baseline and clears field metadata around the new values. Combine `submit`, `setErrors`, and `clearErrors` for server flows: submit valid client values, map server errors to fields, clear those errors when the user changes or retries.
+`reset()` restores the original `defaultValues`. `reset(nextValues)` replaces the baseline and clears field metadata around the new values. Combine `submit`, `setErrors`, and `clearErrors` for server flows: submit valid client values, map server errors to fields, clear those errors when the user changes or retries.
 
 ## Practical guidance
 

--- a/packages/form/docs/reference/types.ko.mdx
+++ b/packages/form/docs/reference/types.ko.mdx
@@ -5,14 +5,12 @@ description: "코어와 어댑터가 내보내는 공개 타입입니다."
 
 # 타입
 
-중요한 코어 타입은 `CreateFormOptions`, `FieldPathInput`, `FieldState`, `FormState`, `FormError`, `StandardSchemaV1`, `ValidationTrigger`, `FieldSchemaOptions`, `SetValueOptions`, `Form`, `FormArray`입니다. 어댑터 패키지도 `RegisterOptions` 별칭과 프레임워크별 반환 타입을 내보냅니다.
+루트 진입점은 `CreateFormOptions`, `FieldPathInput`, `Form`, `FormError`, `ResetOptions`, `StandardSchemaV1`(`CreateForm` 클래스 포함)을 내보냅니다. `getFieldState(path)`는 `FieldState`를 반환하고 `getState()`는 `FormState`를 반환합니다. 이 런타임 모양은 루트에서 가져오는 것이 아니라 field-state와 normalized-store 문서에서 설명합니다. 어댑터 패키지도 `RegisterOptions` 별칭과 프레임워크별 반환 타입을 내보냅니다.
 
 ```ts lineNumbers
 import type {
   CreateFormOptions,
   FieldPathInput,
-  FieldState,
-  FormState,
   FormError,
   StandardSchemaV1,
 } from '@ilokesto/form';

--- a/packages/form/docs/reference/types.mdx
+++ b/packages/form/docs/reference/types.mdx
@@ -5,14 +5,12 @@ description: "Public types exported by the core and adapters."
 
 # Types
 
-The most important core types are `CreateFormOptions`, `FieldPathInput`, `FieldState`, `FormState`, `FormError`, `StandardSchemaV1`, `ValidationTrigger`, `FieldSchemaOptions`, `SetValueOptions`, `Form`, and `FormArray`. Adapter packages also export their `RegisterOptions` alias and framework-specific return types.
+The root entrypoint exports `CreateFormOptions`, `FieldPathInput`, `Form`, `FormError`, `ResetOptions`, and `StandardSchemaV1` (plus the `CreateForm` class). `getFieldState(path)` returns a `FieldState` and `getState()` returns a `FormState`; those runtime shapes are documented on the field-state and normalized-store pages rather than imported from the root. Adapter packages also export their `RegisterOptions` alias and framework-specific return types.
 
 ```ts lineNumbers
 import type {
   CreateFormOptions,
   FieldPathInput,
-  FieldState,
-  FormState,
   FormError,
   StandardSchemaV1,
 } from '@ilokesto/form';


### PR DESCRIPTION
## Summary
- Replace `initialValues` with `defaultValues` across all English and Korean form docs to match the actual `CreateFormOptions` contract (and the internal `FormState.defaultValues` field name). Affected pages: quick-start, index, build-a-login-form, validation-flow, create-form, submit-and-reset, normalized-store (EN + KO).
- Document only the types the root entrypoint actually exports. `entrypoints` and `types` pages no longer claim `FieldState` and `FormState` are importable from `@ilokesto/form`; they are now described as runtime shapes returned by `getFieldState()` and `getState()`. The `types` import example now lists only root-exported types (`CreateFormOptions`, `FieldPathInput`, `FormError`, `StandardSchemaV1`).

## Evidence
- `packages/form/src/index.ts` exports `CreateForm`, `CreateFormOptions`, `FieldPathInput`, `Form`, `FormError`, `ResetOptions`, `StandardSchemaV1` from the root — it does not export `FieldState` or `FormState`.
- `packages/form/src/core/types.ts` defines `CreateFormOptions.defaultValues` and `FormState.defaultValues`; the docs previously used the non-existent `initialValues` option name, so documented examples did not type-check.

This is a doc-only change; no public API is expanded or altered.

## Tests
- `pnpm --filter @ilokesto/form typecheck`
- `pnpm --filter @ilokesto/form test` (121 passed)
- `pnpm --filter @ilokesto/form build`
- `grep -rn "initialValues" packages/form/docs` returns no remaining occurrences; EN/KO page pairs stay aligned.

Closes #47