### PR TITLE
ci(sync-docs): skip docs sync when DOCS_SYNC_TOKEN is not configured

### DIFF
--- a/.github/workflows/_sync-docs.yml
+++ b/.github/workflows/_sync-docs.yml
@@ -8,11 +8,12 @@ on:
         type: string
     secrets:
       DOCS_SYNC_TOKEN:
-        required: true
+        required: false
 
 jobs:
   sync-docs:
     runs-on: ubuntu-latest
+    if: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Make `DOCS_SYNC_TOKEN` optional in the reusable `.github/workflows/_sync-docs.yml` and guard the `sync-docs` job with `if: ${{ secrets.DOCS_SYNC_TOKEN != '' }}`.
- When the secret is absent the run is skipped (success) instead of failing at workflow evaluation; when the secret is added later the sync runs normally.

## Root cause
- Every `Sync * Docs` workflow (form, state, overlay, …) reuses `_sync-docs.yml`, which declared `DOCS_SYNC_TOKEN` as `required: true`. The repository has no `DOCS_SYNC_TOKEN` secret configured (`gh secret list` → no secrets found), so each caller workflow failed with `Error when evaluating 'secrets': Secret DOCS_SYNC_TOKEN is required, but not provided while calling.` — a pre-existing infra gap, not caused by any docs change.

## Effect
- Stops the persistent `Sync Form Docs: All jobs have failed` (and the same for state/overlay) noise.
- Docs sync remains inert until `DOCS_SYNC_TOKEN` is added as a repository secret (a PAT or fine-grained token with write access to `ilokesto/docs`); after that, sync resumes automatically with no further workflow change.

## Verification
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_sync-docs.yml'))"` → YAML valid.
- No package source changed; CI `verify` is unaffected.