### PR TITLE
ci(sync-docs): fix secret guard context

### DIFF
--- a/.github/workflows/_sync-docs.yml
+++ b/.github/workflows/_sync-docs.yml
@@ -13,15 +13,18 @@ on:
 jobs:
   sync-docs:
     runs-on: ubuntu-latest
-    if: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
+    env:
+      DOCS_SYNC_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN }}
     steps:
       - name: Checkout source repository
+        if: ${{ env.DOCS_SYNC_TOKEN != '' }}
         uses: actions/checkout@v4
         with:
           path: source
           fetch-depth: 0
 
       - name: Checkout docs repository
+        if: ${{ env.DOCS_SYNC_TOKEN != '' }}
         uses: actions/checkout@v4
         with:
           repository: ilokesto/docs
@@ -29,11 +32,13 @@ jobs:
           path: docs
 
       - name: Set up Git identity
+        if: ${{ env.DOCS_SYNC_TOKEN != '' }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Sync package docs
+        if: ${{ env.DOCS_SYNC_TOKEN != '' }}
         env:
           PACKAGE: ${{ inputs.package }}
         run: |
@@ -42,6 +47,7 @@ jobs:
           cp -R "source/packages/$PACKAGE/docs/." "docs/content/docs/$PACKAGE/"
 
       - name: Create pull request
+        if: ${{ env.DOCS_SYNC_TOKEN != '' }}
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.DOCS_SYNC_TOKEN }}

--- a/tests/monorepo/sync-docs-workflow.test.mjs
+++ b/tests/monorepo/sync-docs-workflow.test.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('docs sync keeps the optional token guard in step context', async () => {
+  const workflow = await readFile(
+    new URL('../../.github/workflows/_sync-docs.yml', import.meta.url),
+    'utf8',
+  );
+
+  assert.match(workflow, /env:\n\s+DOCS_SYNC_TOKEN: \$\{\{ secrets\.DOCS_SYNC_TOKEN \}\}/);
+  assert.doesNotMatch(workflow, /jobs:\n[\s\S]*?if: \$\{\{ secrets\.DOCS_SYNC_TOKEN/u);
+
+  const steps = workflow.split('\n      - name: ').slice(1);
+  const guardedStepNames = [
+    'Checkout source repository',
+    'Checkout docs repository',
+    'Set up Git identity',
+    'Sync package docs',
+    'Create pull request',
+  ];
+  assert.equal(guardedStepNames.every((name) => steps.some((step) => step.startsWith(name))), true);
+  for (const name of guardedStepNames) {
+    const step = steps.find((candidate) => candidate.startsWith(name));
+    assert.ok(step);
+    assert.match(step, /if: \$\{\{ env\.DOCS_SYNC_TOKEN != '' \}\}/);
+  }
+});


### PR DESCRIPTION
## Summary

- Fix the Docs Sync workflow evaluation failure caused by using the `secrets` context in `jobs.sync-docs.if`.
- Pass the optional token through the job environment and guard operational steps with a step-level condition.
- Add regression coverage for the guard placement.

## Verification

- `pnpm test:monorepo` — 138 passed
- YAML parsing and `actionlint` passed
- Token-present and token-absent guard paths manually checked

## Root cause

GitHub Actions does not allow the `secrets` context in a job-level `if` expression. The previous workflow therefore failed before creating any jobs. This change keeps runs successful when the optional token is absent and preserves normal syncing when it is configured.