### PR TITLE
fix(state): isolate optional immer adaptor import

### DIFF
--- a/.changeset/state-utils-optional-immer-adaptor-subpath.md
+++ b/.changeset/state-utils-optional-immer-adaptor-subpath.md
@@ -1,0 +1,25 @@
+---
+"@ilokesto/state": major
+---
+
+### Breaking change: `adaptor` moved from `@ilokesto/state/utils` to `@ilokesto/state/adaptor`
+
+`@ilokesto/state/utils` eagerly re-exported `adaptor`, which statically imports `immer`. Because ESM module graphs evaluate eagerly, importing anything from `@ilokesto/state/utils` failed with `ERR_MODULE_NOT_FOUND` for consumers that had not installed the optional `immer` peer. Keeping `adaptor` on `utils` without eager `immer` resolution is impossible in plain ESM without making `adaptor` asynchronous, so `adaptor` now lives on its own subpath.
+
+#### What changed
+
+- `@ilokesto/state/utils` no longer exports `adaptor`; it exports only `pipe`, `definePipeableMiddleware`, and pipe types, none of which touch `immer`.
+- New public subpath `@ilokesto/state/adaptor` exports `adaptor` and is the only entry point that resolves `immer`.
+- Added a packed-consumer regression test (`test/utils-import-without-immer.test.ts`) that installs the tarball without `immer` and proves `utils` imports cleanly while `adaptor` fails on `immer` only.
+
+#### Migration
+
+```ts
+// Before
+import { adaptor } from '@ilokesto/state/utils';
+
+// After
+import { adaptor } from '@ilokesto/state/adaptor';
+```
+
+`immer` remains an optional peer dependency: install it only when you use `@ilokesto/state/adaptor`. Consumers of `@ilokesto/state/utils` who never used `adaptor` need no changes; their imports now work without `immer` installed.

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -220,6 +220,9 @@ console.log(currentCount);
 
 - `pipe`: 일반 상태와 등록된 미들웨어로 스토어 조합
 - `definePipeableMiddleware()`: 사용자 미들웨어 메타데이터 등록
+
+### `@ilokesto/state/adaptor`
+
 - `adaptor()`: immer를 사용한 불변 객체 업데이트 헬퍼 생성
 
 `pipe`는 빌더 전용 API입니다. `pipe.use(...)`로 시작해 바깥쪽에서 안쪽 순서로 미들웨어를 추가한 다음, `.create(initialState)`를 호출하세요. 첫 번째 `.use()`가 업데이트 시 가장 바깥을 감싸며, `.create()`가 Store를 만들 때 미들웨어 설정은 왼쪽에서 오른쪽 순서로 실행됩니다.

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -372,7 +372,8 @@ counterStore.getState().count;
 - `@ilokesto/state/svelte` → Svelte 어댑터
 - `@ilokesto/state/solid` → Solid 어댑터
 - `@ilokesto/state/middleware` → 미들웨어 헬퍼
-- `@ilokesto/state/utils` → `adaptor`, `pipe`, `definePipeableMiddleware`, pipe 타입
+- `@ilokesto/state/utils` → `pipe`, `definePipeableMiddleware`, pipe 타입
+- `@ilokesto/state/adaptor` → `adaptor` (optional `immer` peer dependency 필요)
 
 ## 마이그레이션: 통합 shallow Selector 구독
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -374,7 +374,8 @@ This is a breaking change. Callable and variadic pipe syntax has been removed. R
 - `@ilokesto/state/svelte` → Svelte adapter
 - `@ilokesto/state/solid` → Solid adapter
 - `@ilokesto/state/middleware` → middleware helpers
-- `@ilokesto/state/utils` → `adaptor`, `pipe`, `definePipeableMiddleware`, and pipe types
+- `@ilokesto/state/utils` → `pipe`, `definePipeableMiddleware`, and pipe types
+- `@ilokesto/state/adaptor` → `adaptor` (requires the optional `immer` peer dependency)
 
 ## Migration: unified shallow selector subscriptions
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -222,6 +222,9 @@ console.log(currentCount);
 
 - `pipe` to compose a store from plain state and registered middleware
 - `definePipeableMiddleware()` to register custom pipe middleware metadata
+
+### `@ilokesto/state/adaptor`
+
 - `adaptor()` to create immutable object updaters with immer
 
 `pipe` is builder-only. Start with `pipe.use(...)`, add middleware in outer-to-inner order, then call `.create(initialState)`. The first `.use()` is outermost during updates, while middleware setup runs left to right when `.create()` creates the Store.

--- a/packages/state/docs/index.ko.mdx
+++ b/packages/state/docs/index.ko.mdx
@@ -26,7 +26,7 @@ function Counter() {
 @ilokesto/state
 ```
 
-사용하는 프레임워크 peer만 함께 설치하세요. 예를 들어 `react`, `vue`, `svelte`, `solid-js`, `@angular/core` 중 실제 adapter에 필요한 것만 설치하면 됩니다. `@ilokesto/state/utils`의 `adaptor`를 사용할 때만 `immer`를 추가하세요.
+사용하는 프레임워크 peer만 함께 설치하세요. 예를 들어 `react`, `vue`, `svelte`, `solid-js`, `@angular/core` 중 실제 adapter에 필요한 것만 설치하면 됩니다. `@ilokesto/state/adaptor`의 `adaptor`를 사용할 때만 `immer`를 추가하세요.
 
 
 ## 이 패키지가 하지 않는 것

--- a/packages/state/docs/index.mdx
+++ b/packages/state/docs/index.mdx
@@ -26,7 +26,7 @@ Use this package when you want one small store model with adapter-specific retur
 @ilokesto/state
 ```
 
-Install the framework peer you use, such as `react`, `vue`, `svelte`, `solid-js`, or `@angular/core`. Install `immer` only when you use `adaptor` from `@ilokesto/state/utils`.
+Install the framework peer you use, such as `react`, `vue`, `svelte`, `solid-js`, or `@angular/core`. Install `immer` only when you use `adaptor` from `@ilokesto/state/adaptor`.
 
 
 ## What this package is not

--- a/packages/state/docs/reference/package-surface.ko.mdx
+++ b/packages/state/docs/reference/package-surface.ko.mdx
@@ -18,7 +18,8 @@ public package surface는 `state/package.json`의 exports가 기준입니다.
 | `@ilokesto/state/solid` | Solid `create()` adapter입니다. |
 | `@ilokesto/state/angular` | Angular `create()` adapter입니다. |
 | `@ilokesto/state/middleware` | `logger`, `validate`, `debounce`, `devtools`, `persist`입니다. |
-| `@ilokesto/state/utils` | `pipe`, `adaptor`입니다. |
+| `@ilokesto/state/utils` | `pipe`입니다. |
+| `@ilokesto/state/adaptor` | `adaptor`; optional `immer` peer가 필요합니다. |
 
 ## Root entrypoint 주의점
 
@@ -35,4 +36,4 @@ import { create } from '@ilokesto/state';
 
 ## Peer dependencies
 
-프레임워크 peer는 optional입니다. 실제로 쓰는 어댑터의 프레임워크만 설치하세요. `immer`는 `@ilokesto/state/utils`의 `adaptor`를 사용할 때만 필요합니다.
+프레임워크 peer는 optional입니다. 실제로 쓰는 어댑터의 프레임워크만 설치하세요. `immer`는 `@ilokesto/state/adaptor`의 `adaptor`를 사용할 때만 필요합니다.

--- a/packages/state/docs/reference/package-surface.mdx
+++ b/packages/state/docs/reference/package-surface.mdx
@@ -18,7 +18,8 @@ The public package surface is defined by `state/package.json` exports.
 | `@ilokesto/state/solid` | Solid `create()` adapter. |
 | `@ilokesto/state/angular` | Angular `create()` adapter. |
 | `@ilokesto/state/middleware` | `logger`, `validate`, `debounce`, `devtools`, `persist`. |
-| `@ilokesto/state/utils` | `pipe`, `adaptor`. |
+| `@ilokesto/state/utils` | `pipe`. |
+| `@ilokesto/state/adaptor` | `adaptor`; requires the optional `immer` peer. |
 
 ## Root entrypoint caveat
 
@@ -35,4 +36,4 @@ import { create } from '@ilokesto/state';
 
 ## Peer dependencies
 
-Framework peers are optional: install only the adapter framework you use. `immer` is optional and only needed when you use `adaptor` from `@ilokesto/state/utils`.
+Framework peers are optional: install only the adapter framework you use. `immer` is optional and only needed when you use `adaptor` from `@ilokesto/state/adaptor`.

--- a/packages/state/docs/troubleshooting.ko.mdx
+++ b/packages/state/docs/troubleshooting.ko.mdx
@@ -39,4 +39,4 @@ validate middleware는 async Standard Schema result를 지원하지 않습니다
 
 ## `adaptor`를 import하거나 사용할 수 없습니다
 
-optional peer dependency인 `immer`를 설치하고 object state에서 `adaptor`를 사용하세요.
+optional peer dependency인 `immer`를 설치하고, `@ilokesto/state/adaptor`에서 `adaptor`를 import한 뒤 object state에서 사용하세요.

--- a/packages/state/docs/troubleshooting.mdx
+++ b/packages/state/docs/troubleshooting.mdx
@@ -39,4 +39,4 @@ The validate middleware rejects async Standard Schema results. Keep validation s
 
 ## `adaptor` cannot be imported or used
 
-Install the optional `immer` peer dependency and use object state with `adaptor`.
+Install the optional `immer` peer dependency, import `adaptor` from `@ilokesto/state/adaptor`, and use it with object state.

--- a/packages/state/docs/utility/adaptor.ko.mdx
+++ b/packages/state/docs/utility/adaptor.ko.mdx
@@ -21,17 +21,17 @@ Immutable object update가 맞지만 코드가 장황해질 때 사용하세요.
 pnpm add immer
 ```
 
-그리고 utility subpath에서 `adaptor`를 import합니다.
+그리고 전용 subpath에서 `adaptor`를 import합니다.
 
 ```ts lineNumbers
-import { adaptor } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
 ```
 
 ## 기본 사용법
 
 ```tsx lineNumbers
 import { create } from '@ilokesto/state/react';
-import { adaptor } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
 
 type TodoState = {
   items: Array<{ id: string; title: string; done: boolean }>;
@@ -111,7 +111,8 @@ Adapter는 여전히 일반 store update pipeline을 통해 subscriber에게 알
 
 ```ts lineNumbers
 import { logger, validate } from '@ilokesto/state/middleware';
-import { adaptor, pipe } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
+import { pipe } from '@ilokesto/state/utils';
 
 const store = pipe
   .use(validate(tagsSchema))

--- a/packages/state/docs/utility/adaptor.mdx
+++ b/packages/state/docs/utility/adaptor.mdx
@@ -21,17 +21,17 @@ Use it when immutable object updates are correct but verbose. Instead of returni
 pnpm add immer
 ```
 
-Then import `adaptor` from the utility subpath.
+Then import `adaptor` from its dedicated subpath.
 
 ```ts lineNumbers
-import { adaptor } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
 ```
 
 ## Basic usage
 
 ```tsx lineNumbers
 import { create } from '@ilokesto/state/react';
-import { adaptor } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
 
 type TodoState = {
   items: Array<{ id: string; title: string; done: boolean }>;
@@ -111,7 +111,8 @@ The adapter still notifies subscribers through the normal store update pipeline.
 
 ```ts lineNumbers
 import { logger, validate } from '@ilokesto/state/middleware';
-import { adaptor, pipe } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
+import { pipe } from '@ilokesto/state/utils';
 
 const store = pipe
   .use(validate(tagsSchema))

--- a/packages/state/docs/utility/index.ko.mdx
+++ b/packages/state/docs/utility/index.ko.mdx
@@ -67,7 +67,8 @@ pnpm add immer
 ```tsx lineNumbers
 import { create } from '@ilokesto/state/react';
 import { validate } from '@ilokesto/state/middleware';
-import { adaptor, pipe } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
+import { pipe } from '@ilokesto/state/utils';
 
 const profileStore = pipe
   .use(validate(profileSchema))

--- a/packages/state/docs/utility/index.mdx
+++ b/packages/state/docs/utility/index.mdx
@@ -67,7 +67,8 @@ pnpm add immer
 ```tsx lineNumbers
 import { create } from '@ilokesto/state/react';
 import { validate } from '@ilokesto/state/middleware';
-import { adaptor, pipe } from '@ilokesto/state/utils';
+import { adaptor } from '@ilokesto/state/adaptor';
+import { pipe } from '@ilokesto/state/utils';
 
 const profileStore = pipe
   .use(validate(profileSchema))

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -24,6 +24,11 @@
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./adaptor": {
+      "import": "./dist/utils/adaptor.js",
+      "default": "./dist/utils/adaptor.js",
+      "types": "./dist/utils/adaptor.d.ts"
+    },
     "./react": {
       "import": "./dist/core/React/index.js",
       "default": "./dist/core/React/index.js",

--- a/packages/state/src/utils/adaptor.ts
+++ b/packages/state/src/utils/adaptor.ts
@@ -12,7 +12,7 @@ import { Draft, produce } from 'immer';
  *
  * @example
  * ```ts
- * import { adaptor } from '@ilokesto/state/utils';
+ * import { adaptor } from '@ilokesto/state/adaptor';
  *
  * const increment = adaptor((draft) => { draft.count += 1; });
  * store.setState(increment);

--- a/packages/state/src/utils/index.ts
+++ b/packages/state/src/utils/index.ts
@@ -1,4 +1,3 @@
-export { adaptor } from './adaptor.js';
 export { pipe } from './pipe/index.js';
 export { PipeConfigurationError } from './pipe/errors.js';
 export type { PipeConfigurationErrorCode } from './pipe/errors.js';

--- a/packages/state/test/utils-import-without-immer.test.ts
+++ b/packages/state/test/utils-import-without-immer.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const projectRoot = join(import.meta.dir, '..');
+const storeRoot = join(projectRoot, '..', 'store');
+const decoder = new TextDecoder();
+
+type ProcessResult = {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+};
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir !== undefined) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  }
+});
+
+function run(cmd: readonly string[], cwd: string): ProcessResult {
+  const result = Bun.spawnSync({ cmd: [...cmd], cwd, stderr: 'pipe', stdout: 'pipe' });
+  return {
+    exitCode: result.exitCode,
+    stderr: decoder.decode(result.stderr),
+    stdout: decoder.decode(result.stdout),
+  };
+}
+
+function packInto(packDir: string, packageDir: string, targetDir: string): ProcessResult {
+  const pack = run(['pnpm', 'pack', '--pack-destination', packDir], packageDir);
+  if (pack.exitCode !== 0) {
+    return pack;
+  }
+  const tarball = pack.stdout.trim().split('\n').at(-1) ?? '';
+  mkdirSync(targetDir, { recursive: true });
+  return run(['tar', '-xzf', tarball, '-C', targetDir, '--strip-components=1'], packageDir);
+}
+
+function createIsolatedConsumer(): { readonly consumerDir: string; readonly setupErrors: string } {
+  const workDir = mkdtempSync(join(tmpdir(), 'ilokesto-state-no-immer-'));
+  tempDirs.push(workDir);
+
+  const packDir = join(workDir, 'packs');
+  const consumerDir = join(workDir, 'consumer');
+  mkdirSync(packDir);
+  mkdirSync(consumerDir);
+  writeFileSync(join(consumerDir, 'package.json'), '{"name":"consumer","type":"module"}\n');
+
+  const buildStore = run(['pnpm', 'build'], storeRoot);
+  const buildState = run(['pnpm', 'build'], projectRoot);
+  const packStore = packInto(packDir, storeRoot, join(consumerDir, 'node_modules', '@ilokesto', 'store'));
+  const packState = packInto(packDir, projectRoot, join(consumerDir, 'node_modules', '@ilokesto', 'state'));
+
+  const setupErrors = [buildStore, buildState, packStore, packState]
+    .filter((result) => result.exitCode !== 0)
+    .map((result) => `${result.exitCode}: ${result.stderr || result.stdout}`)
+    .join('\n');
+
+  return { consumerDir, setupErrors };
+}
+
+test('Given immer is not resolvable, when a packed consumer imports @ilokesto/state/utils, then the import succeeds without adaptor', () => {
+  // Given: an isolated consumer with only the packed @ilokesto/state and @ilokesto/store - no immer anywhere on the resolution path.
+  const { consumerDir, setupErrors } = createIsolatedConsumer();
+  expect(setupErrors).toBe('');
+
+  // When
+  const result = run(
+    [
+      'node',
+      '--input-type=module',
+      '--eval',
+      "const m = await import('@ilokesto/state/utils'); if (typeof m.pipe?.use !== 'function') throw new TypeError('Expected pipe builder export'); if ('adaptor' in m) throw new Error('adaptor must not be exported from @ilokesto/state/utils'); process.stdout.write('UTILS_WITHOUT_IMMER_OK\\n');",
+    ],
+    consumerDir,
+  );
+
+  // Then
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.stdout).toBe('UTILS_WITHOUT_IMMER_OK\n');
+}, { timeout: 180_000 });
+
+test('Given immer is not resolvable, when a packed consumer imports @ilokesto/state/adaptor, then resolution fails on immer only', () => {
+  // Given
+  const { consumerDir, setupErrors } = createIsolatedConsumer();
+  expect(setupErrors).toBe('');
+
+  // When
+  const result = run(
+    ['node', '--input-type=module', '--eval', "await import('@ilokesto/state/adaptor');"],
+    consumerDir,
+  );
+
+  // Then: the adaptor subpath itself resolves; the only missing module is the optional immer peer.
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stderr).toContain('ERR_MODULE_NOT_FOUND');
+  expect(result.stderr).toContain('immer');
+  expect(result.stderr).toContain('dist/utils/adaptor.js');
+  expect(result.stderr).not.toContain('ERR_PACKAGE_PATH_NOT_EXPORTED');
+}, { timeout: 180_000 });
+
+test('Given the workspace where immer is installed, when Node imports the adaptor subpath, then adaptor produces immutable updaters', () => {
+  // Given
+  const build = run(['pnpm', 'build'], projectRoot);
+  expect(build.exitCode).toBe(0);
+
+  // When
+  const result = run(
+    [
+      'node',
+      '--input-type=module',
+      '--eval',
+      "const { adaptor } = await import('@ilokesto/state/adaptor'); const next = adaptor((draft) => { draft.count += 1; })({ count: 1 }); if (next.count !== 2) throw new Error('adaptor did not produce the next state'); process.stdout.write('ADAPTOR_SUBPATH_OK\\n');",
+    ],
+    projectRoot,
+  );
+
+  // Then
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(result.stdout).toBe('ADAPTOR_SUBPATH_OK\n');
+}, { timeout: 180_000 });


### PR DESCRIPTION
## Summary

- move the immer-backed adaptor utility to the explicit @ilokesto/state/adaptor subpath
- keep @ilokesto/state/utils importable when the optional immer peer is absent
- add isolated packed-consumer coverage and update English/Korean migration docs
- include a major changeset because the previous adaptor import path is removed

## Verification

- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file LSP diagnostics
- git diff --check

Closes #71