### PR TITLE
fix(state): recover debounce after updater errors

### DIFF
--- a/.changeset/state-debounce-exception-safety.md
+++ b/.changeset/state-debounce-exception-safety.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Restore debounce scheduling after a function updater throws during flush.

--- a/packages/state/src/middleware/debounce.ts
+++ b/packages/state/src/middleware/debounce.ts
@@ -31,21 +31,23 @@ const applyDebounce = <T>(initialState: T | Store<T>, wait = 300): Store<T> => {
 
     timeout = setTimeout(() => {
       let currentState = store.getState() as T;
-
-      updates.forEach((update) => {
-        if (typeof update === 'function') {
-          currentState = (update as (prev: Readonly<T>) => T)(currentState);
-        } else {
-          currentState = update;
-        }
-      });
-
       const pendingNext = savedNext;
-      updates = [];
-      timeout = null;
-      savedNext = null;
-      unregisterTimeout?.();
-      unregisterTimeout = null;
+
+      try {
+        updates.forEach((update) => {
+          if (typeof update === 'function') {
+            currentState = (update as (prev: Readonly<T>) => T)(currentState);
+          } else {
+            currentState = update;
+          }
+        });
+      } finally {
+        updates = [];
+        timeout = null;
+        savedNext = null;
+        unregisterTimeout?.();
+        unregisterTimeout = null;
+      }
 
       if (pendingNext) {
         pendingNext(currentState);
@@ -71,7 +73,8 @@ const applyDebounce = <T>(initialState: T | Store<T>, wait = 300): Store<T> => {
  *
  * Coalesces all updates within the wait period into a single commit.
  * Function updaters are applied sequentially against the latest state at
- * flush time; value updates overwrite previous ones.
+ * flush time; value updates overwrite previous ones. If an updater throws,
+ * its error surfaces and later updates remain schedulable.
  *
  * @param wait - Debounce delay in milliseconds. Defaults to `300`.
  * @returns Pipe middleware registered with `@ilokesto/state/debounce` metadata.

--- a/packages/state/src/middleware/debounce.ts
+++ b/packages/state/src/middleware/debounce.ts
@@ -17,6 +17,7 @@ const applyDebounce = <T>(initialState: T | Store<T>, wait = 300): Store<T> => {
   const store = getStore(initialState);
 
   let timeout: ReturnType<typeof setTimeout> | null = null;
+  let scheduleGeneration = 0;
   let updates: Array<StoreSetStateAction<T>> = [];
   let savedNext: Dispatch<StoreSetStateAction<T>> | null = null;
   let unregisterTimeout: (() => void) | null = null;
@@ -29,6 +30,7 @@ const applyDebounce = <T>(initialState: T | Store<T>, wait = 300): Store<T> => {
       return;
     }
 
+    const currentGeneration = ++scheduleGeneration;
     timeout = setTimeout(() => {
       let currentState = store.getState() as T;
       const pendingNext = savedNext;
@@ -42,11 +44,13 @@ const applyDebounce = <T>(initialState: T | Store<T>, wait = 300): Store<T> => {
           }
         });
       } finally {
-        updates = [];
-        timeout = null;
-        savedNext = null;
-        unregisterTimeout?.();
-        unregisterTimeout = null;
+        if (scheduleGeneration === currentGeneration) {
+          updates = [];
+          timeout = null;
+          savedNext = null;
+          unregisterTimeout?.();
+          unregisterTimeout = null;
+        }
       }
 
       if (pendingNext) {

--- a/packages/state/test/pipe-logger-debounce.test.ts
+++ b/packages/state/test/pipe-logger-debounce.test.ts
@@ -53,6 +53,33 @@ function expectPipeConfigurationError(action: () => void, code: PipeConfiguratio
   throw new TypeError('Expected pipe configuration error');
 }
 
+function captureExpectedTimerError(expectedError: Error, action: () => void): boolean {
+  let caughtExpectedError = false;
+  const originalSetTimeout = globalThis.setTimeout;
+  const catchExpectedError = (callback: () => void, wait?: number) => {
+    return originalSetTimeout(() => {
+      try {
+        callback();
+      } catch (error) {
+        if (error !== expectedError) {
+          throw error;
+        }
+
+        caughtExpectedError = true;
+      }
+    }, wait);
+  };
+  Reflect.set(globalThis, 'setTimeout', catchExpectedError);
+
+  try {
+    action();
+  } finally {
+    Reflect.set(globalThis, 'setTimeout', originalSetTimeout);
+  }
+
+  return caughtExpectedError;
+}
+
 test('Given logger and debounce, when curried forms are used via pipe, then it preserves logger and debounce contracts', () => {
   // Given
   callBunFakeTimer('useFakeTimers');
@@ -151,37 +178,49 @@ test('Given a debounced Store, when a function updater throws during flush, then
   callBunFakeTimer('useFakeTimers');
   const store = pipe.use(debounce(25)).create({ count: 0 });
   const expectedError = new Error('Expected updater failure');
-  let caughtExpectedError = false;
-  const originalSetTimeout = globalThis.setTimeout;
-  const catchUpdaterErrors = (callback: () => void, wait?: number) => {
-    return originalSetTimeout(() => {
-      try {
-        callback();
-      } catch (error) {
-        if (error !== expectedError) {
-          throw error;
-        }
-
-        caughtExpectedError = true;
-      }
-    }, wait);
-  };
-  Reflect.set(globalThis, 'setTimeout', catchUpdaterErrors);
 
   try {
     // When
-    store.setState(() => {
-      throw expectedError;
+    const caughtExpectedError = captureExpectedTimerError(expectedError, () => {
+      store.setState(() => {
+        throw expectedError;
+      });
+      callBunFakeTimer('advanceTimersByTime', [25]);
+      store.setState({ count: 1 });
+      callBunFakeTimer('advanceTimersByTime', [25]);
     });
-    callBunFakeTimer('advanceTimersByTime', [25]);
-    store.setState({ count: 1 });
-    callBunFakeTimer('advanceTimersByTime', [25]);
 
     // Then
     expect(caughtExpectedError).toBe(true);
     expect(store.getState()).toEqual({ count: 1 });
   } finally {
-    Reflect.set(globalThis, 'setTimeout', originalSetTimeout);
+    callBunFakeTimer('clearAllTimers');
+    callBunFakeTimer('useRealTimers');
+  }
+});
+
+test('Given a debounced Store, when a flushing updater disposes, reuses, and throws, then the new schedule still flushes', () => {
+  // Given
+  callBunFakeTimer('useFakeTimers');
+  const store = pipe.use(debounce(25)).create({ count: 0 });
+  const expectedError = new Error('Expected updater failure');
+
+  try {
+    // When
+    const caughtExpectedError = captureExpectedTimerError(expectedError, () => {
+      store.setState(() => {
+        dispose(store);
+        store.setState({ count: 1 });
+        throw expectedError;
+      });
+      callBunFakeTimer('advanceTimersByTime', [25]);
+      callBunFakeTimer('advanceTimersByTime', [25]);
+    });
+
+    // Then
+    expect(caughtExpectedError).toBe(true);
+    expect(store.getState()).toEqual({ count: 1 });
+  } finally {
     callBunFakeTimer('clearAllTimers');
     callBunFakeTimer('useRealTimers');
   }

--- a/packages/state/test/pipe-logger-debounce.test.ts
+++ b/packages/state/test/pipe-logger-debounce.test.ts
@@ -146,6 +146,47 @@ test('Given duplicate logger or debounce pipe middleware, when a chain is built,
   }
 });
 
+test('Given a debounced Store, when a function updater throws during flush, then later updates still flush', () => {
+  // Given
+  callBunFakeTimer('useFakeTimers');
+  const store = pipe.use(debounce(25)).create({ count: 0 });
+  const expectedError = new Error('Expected updater failure');
+  let caughtExpectedError = false;
+  const originalSetTimeout = globalThis.setTimeout;
+  const catchUpdaterErrors = (callback: () => void, wait?: number) => {
+    return originalSetTimeout(() => {
+      try {
+        callback();
+      } catch (error) {
+        if (error !== expectedError) {
+          throw error;
+        }
+
+        caughtExpectedError = true;
+      }
+    }, wait);
+  };
+  Reflect.set(globalThis, 'setTimeout', catchUpdaterErrors);
+
+  try {
+    // When
+    store.setState(() => {
+      throw expectedError;
+    });
+    callBunFakeTimer('advanceTimersByTime', [25]);
+    store.setState({ count: 1 });
+    callBunFakeTimer('advanceTimersByTime', [25]);
+
+    // Then
+    expect(caughtExpectedError).toBe(true);
+    expect(store.getState()).toEqual({ count: 1 });
+  } finally {
+    Reflect.set(globalThis, 'setTimeout', originalSetTimeout);
+    callBunFakeTimer('clearAllTimers');
+    callBunFakeTimer('useRealTimers');
+  }
+});
+
 test('Given a debounced Store via pipe, when timers expire and disposal interrupts later updates, then expiry unregisters cleanup and the Store remains reusable', () => {
   // Given
   callBunFakeTimer('useFakeTimers');


### PR DESCRIPTION
## Summary

- reset debounce scheduling state in a finally block when queued updater evaluation throws
- preserve propagation of the original updater error
- add deterministic fake-timer coverage proving a later update still flushes
- include a patch changeset

## Verification

- pnpm --filter @ilokesto/state exec bun test test/pipe-logger-debounce.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file LSP diagnostics
- git diff --check

Closes #72