### PR TITLE
fix(state): enforce persist after debounce

### DIFF
--- a/.changeset/state-persist-debounce-ordering.md
+++ b/.changeset/state-persist-debounce-ordering.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Reject `persist` before `debounce` pipe chains so deferred commits are persisted reliably.

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -333,6 +333,8 @@ const counterStore = pipe
 
 `before: ['id']`는 이 미들웨어가 더 앞에 선언되어 바깥쪽이 되어야 함을 뜻합니다. `after: ['id']`는 더 뒤에 선언되어 안쪽이 되어야 함을 뜻합니다. 대상 미들웨어가 없으면 관계는 무시됩니다. 파이프는 존재하는 관계의 오류와 순환을 거부하며, 미들웨어 순서를 자동으로 바꾸지 않습니다.
 
+둘을 함께 사용할 때 안전한 체인은 `pipe.use(debounce(...)).use(persist(...))`입니다. 반대 순서인 `pipe.use(persist(...)).use(debounce(...))`는 `MIDDLEWARE_ORDER`로 거부됩니다.
+
 기능(capability)은 미들웨어가 Store에 추가한 API를 이후 미들웨어와 최종 Store에서 보이게 합니다. `requires`는 `.use()`를 호출할 때 이미 사용할 수 있어야 하므로, 앞선 바깥 미들웨어가 나중의 안쪽 미들웨어가 제공하는 기능을 요구할 수 없습니다. `adds`는 즉시 바깥에서 안쪽으로 향하는 방향으로 기능을 제공합니다.
 
 <!-- pipe-example:custom-capability -->

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -335,6 +335,8 @@ Every middleware passed to `.use()` must be registered with `definePipeableMiddl
 
 `before: ['id']` means this middleware must be declared earlier, which makes it outer. `after: ['id']` means it must be declared later, which makes it inner. A relation to a middleware that is absent is ignored. Pipe rejects invalid present relationships and cycles, and it never reorders middleware for you.
 
+When both are used, the safe chain is `pipe.use(debounce(...)).use(persist(...))`. The reverse `pipe.use(persist(...)).use(debounce(...))` is rejected with `MIDDLEWARE_ORDER`.
+
 Capabilities make a middleware's Store additions visible to later middleware and the final Store. `requires` must already be available when `.use()` runs, so an earlier outer middleware cannot require a capability supplied by a later inner middleware. `adds` supplies capabilities in the immediate outer-to-inner direction.
 
 <!-- pipe-example:custom-capability -->

--- a/packages/state/docs/middleware/debounce.ko.mdx
+++ b/packages/state/docs/middleware/debounce.ko.mdx
@@ -28,6 +28,29 @@ store.setState({ query: 'il' });
 store.setState({ query: 'ilo' });
 ```
 
+## persist와 함께 사용하기
+
+두 middleware를 함께 사용할 때는 persistence가 debounced commit을 관찰하도록 `debounce`를 `persist`보다 먼저 선언하세요.
+
+```ts lineNumbers
+import { debounce, persist } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
+
+type SearchState = { readonly query: string };
+
+const decodeSearch = (value: unknown): SearchState | null => {
+  if (typeof value !== 'object' || value === null || !('query' in value)) return null;
+  return typeof value.query === 'string' ? { query: value.query } : null;
+};
+
+const store = pipe
+  .use(debounce(250))
+  .use(persist({ local: 'search', decode: decodeSearch }))
+  .create<SearchState>({ query: '' });
+```
+
+`pipe.use(persist(...)).use(debounce(...))`는 지연된 commit의 persistence를 건너뛰므로 거부됩니다.
+
 ## Function update
 
 function update는 순서를 유지한 채 저장되고, timer가 실행될 때 누적된 current state를 기준으로 replay됩니다. 그래서 debounce window 안에서도 updater function끼리 조합됩니다.

--- a/packages/state/docs/middleware/debounce.mdx
+++ b/packages/state/docs/middleware/debounce.mdx
@@ -28,6 +28,29 @@ store.setState({ query: 'il' });
 store.setState({ query: 'ilo' });
 ```
 
+## Using with persist
+
+When both middleware are used, declare `debounce` before `persist` so persistence observes the debounced commit:
+
+```ts lineNumbers
+import { debounce, persist } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
+
+type SearchState = { readonly query: string };
+
+const decodeSearch = (value: unknown): SearchState | null => {
+  if (typeof value !== 'object' || value === null || !('query' in value)) return null;
+  return typeof value.query === 'string' ? { query: value.query } : null;
+};
+
+const store = pipe
+  .use(debounce(250))
+  .use(persist({ local: 'search', decode: decodeSearch }))
+  .create<SearchState>({ query: '' });
+```
+
+`pipe.use(persist(...)).use(debounce(...))` is rejected because it would skip persistence for deferred commits.
+
 ## Function updates
 
 Function updates are kept in order and replayed against an accumulated current state when the timer fires. That means updater functions still compose with one another inside the debounce window.

--- a/packages/state/docs/middleware/index.ko.mdx
+++ b/packages/state/docs/middleware/index.ko.mdx
@@ -55,4 +55,4 @@ const store = pipe
 
 ## 순서 잡는 법
 
-invalid state가 절대 저장되면 안 된다면 validation을 persistence보다 앞에 두세요. 앞선 middleware를 통과한 실제 state를 보고 싶다면 logger를 뒤쪽에 두는 편이 좋습니다. debounce를 사용하면 그 뒤의 모든 흐름에 timing 변화가 생긴다는 점을 기억하세요.
+invalid state가 절대 저장되면 안 된다면 validation을 persistence보다 앞에 두세요. 앞선 middleware를 통과한 실제 state를 보고 싶다면 logger를 뒤쪽에 두는 편이 좋습니다. debounce를 사용하면 그 뒤의 모든 흐름에 timing 변화가 생긴다는 점을 기억하세요. debounce와 persist를 함께 사용할 때는 `pipe.use(debounce(...)).use(persist(...))` 순서로 선언하세요. 반대 순서는 `MIDDLEWARE_ORDER`로 거부됩니다.

--- a/packages/state/docs/middleware/index.mdx
+++ b/packages/state/docs/middleware/index.mdx
@@ -55,4 +55,4 @@ const store = pipe
 
 ## Ordering advice
 
-Put validation before persistence when invalid state should never be stored. Put logger near the end when you want to see the state that actually passed earlier middleware. If debounce is used, remember it changes timing for everything after it.
+Put validation before persistence when invalid state should never be stored. Put logger near the end when you want to see the state that actually passed earlier middleware. If debounce is used, remember it changes timing for everything after it. When both debounce and persist are used, declare `pipe.use(debounce(...)).use(persist(...))`; the reverse is rejected with `MIDDLEWARE_ORDER`.

--- a/packages/state/docs/middleware/persist.ko.mdx
+++ b/packages/state/docs/middleware/persist.ko.mdx
@@ -36,6 +36,29 @@ const store = pipe
   .create<ThemeState>({ theme: 'light' });
 ```
 
+## debounce와 함께 사용하기
+
+두 middleware를 함께 사용할 때는 persistence가 debounced commit을 관찰하도록 `debounce`를 `persist`보다 먼저 선언하세요.
+
+```ts lineNumbers
+import { debounce, persist } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
+
+type ThemeState = { readonly theme: 'light' | 'dark' };
+
+const decodeTheme = (value: unknown): ThemeState | null => {
+  if (typeof value !== 'object' || value === null || !('theme' in value)) return null;
+  return value.theme === 'light' || value.theme === 'dark' ? { theme: value.theme } : null;
+};
+
+const store = pipe
+  .use(debounce(250))
+  .use(persist({ local: 'theme', decode: decodeTheme }))
+  .create<ThemeState>({ theme: 'light' });
+```
+
+`pipe.use(persist(...)).use(debounce(...))`는 지연된 commit의 persistence를 건너뛰므로 거부됩니다.
+
 ## Session과 cookie storage
 
 ```ts lineNumbers

--- a/packages/state/docs/middleware/persist.mdx
+++ b/packages/state/docs/middleware/persist.mdx
@@ -36,6 +36,29 @@ const store = pipe
   .create<ThemeState>({ theme: 'light' });
 ```
 
+## Using with debounce
+
+When both middleware are used, declare `debounce` before `persist` so persistence observes the debounced commit:
+
+```ts lineNumbers
+import { debounce, persist } from '@ilokesto/state/middleware';
+import { pipe } from '@ilokesto/state/utils';
+
+type ThemeState = { readonly theme: 'light' | 'dark' };
+
+const decodeTheme = (value: unknown): ThemeState | null => {
+  if (typeof value !== 'object' || value === null || !('theme' in value)) return null;
+  return value.theme === 'light' || value.theme === 'dark' ? { theme: value.theme } : null;
+};
+
+const store = pipe
+  .use(debounce(250))
+  .use(persist({ local: 'theme', decode: decodeTheme }))
+  .create<ThemeState>({ theme: 'light' });
+```
+
+`pipe.use(persist(...)).use(debounce(...))` is rejected because it would skip persistence for deferred commits.
+
 ## Session and cookie storage
 
 ```ts lineNumbers

--- a/packages/state/src/middleware/debounce.ts
+++ b/packages/state/src/middleware/debounce.ts
@@ -78,7 +78,8 @@ const applyDebounce = <T>(initialState: T | Store<T>, wait = 300): Store<T> => {
  * Coalesces all updates within the wait period into a single commit.
  * Function updaters are applied sequentially against the latest state at
  * flush time; value updates overwrite previous ones. If an updater throws,
- * its error surfaces and later updates remain schedulable.
+ * its error surfaces and later updates remain schedulable. When used with
+ * `persist`, `persist` must be declared after `debounce` in the pipe chain.
  *
  * @param wait - Debounce delay in milliseconds. Defaults to `300`.
  * @returns Pipe middleware registered with `@ilokesto/state/debounce` metadata.

--- a/packages/state/src/middleware/persist/index.ts
+++ b/packages/state/src/middleware/persist/index.ts
@@ -3,7 +3,6 @@ import { getStore } from '../../lib/getStore.js';
 import { definePipeableMiddleware } from '../../utils/pipe/metadata.js';
 import type { PipeableMiddleware } from '../../utils/pipe/metadata.js';
 import type {
-  PipeAnyMiddleware,
   PipeCapability,
   PipeMiddleware,
   PipeMiddlewareMetadata,
@@ -16,14 +15,6 @@ import type {
   SafePersistConfig,
 } from './Persist.js';
 import { getSafeStorage, parseOptions, setStorage } from './persistUtils.js';
-
-type PersistMetadata = PipeMiddlewareMetadata<
-  '@ilokesto/state/persist',
-  readonly [],
-  readonly [],
-  'reject',
-  readonly []
->;
 
 type PersistCapability = PipeCapability<
   '@ilokesto/state/persist-controls',
@@ -47,7 +38,9 @@ type SafeCurriedPersist<State> = PipeableMiddleware<
     readonly [],
     readonly [PersistCapability],
     'reject',
-    readonly []
+    readonly [],
+    readonly [],
+    readonly ['@ilokesto/state/debounce']
   >,
   'persist-decoder'
 >;
@@ -181,7 +174,7 @@ export function persist<DecodedState, const Steps extends readonly MigrationFn[]
       ),
     {
       adds: [persistCapability],
-      after: [],
+      after: ['@ilokesto/state/debounce'],
       before: [],
       conflicts: [],
       duplicate: 'reject',

--- a/packages/state/src/middleware/persist/index.ts
+++ b/packages/state/src/middleware/persist/index.ts
@@ -156,7 +156,8 @@ export function persist<DecodedState, const Steps extends readonly MigrationFn[]
  * become live state.
  *
  * Supports `localStorage`, `sessionStorage`, and cookies. Cookie writes
- * include `path=/` so they are visible across all routes.
+ * include `path=/` so they are visible across all routes. When used with
+ * `debounce`, `persist` must be declared after `debounce` in the pipe chain.
  *
  * @param options - Persistence configuration. Must include a storage key,
  *   a `decode` function, and optionally `migrate`, `skipHydration`, and

--- a/packages/state/src/utils/pipe/metadata-types.ts
+++ b/packages/state/src/utils/pipe/metadata-types.ts
@@ -18,10 +18,12 @@ export type PipeMiddlewareMetadata<
   Adds extends readonly PipeCapability[] = readonly PipeCapability[],
   Duplicate extends PipeDuplicatePolicy = PipeDuplicatePolicy,
   Conflicts extends readonly string[] = readonly string[],
+  Before extends readonly string[] = readonly string[],
+  After extends readonly string[] = readonly string[],
 > = {
   readonly adds?: Adds;
-  readonly after?: readonly string[];
-  readonly before?: readonly string[];
+  readonly after?: After;
+  readonly before?: Before;
   readonly conflicts?: Conflicts;
   readonly duplicate?: Duplicate;
   readonly id: Id;

--- a/packages/state/src/utils/pipe/metadata-validation-types.ts
+++ b/packages/state/src/utils/pipe/metadata-validation-types.ts
@@ -31,7 +31,11 @@ type PipeMetadataIds<Chain extends PipeMetadataChain> = PipeMetadataId<Chain[num
 type PipeRelationshipIds<
   Metadata extends PipeMiddlewareMetadata,
   Key extends PipeRelationshipKey,
-> = Metadata[Key] extends readonly string[] ? Metadata[Key][number] : never;
+> = Extract<Metadata[Key], readonly string[]> extends infer Relationships extends readonly string[]
+  ? string extends Relationships[number]
+    ? never
+    : Relationships[number]
+  : never;
 
 type PipeCapabilityIds<
   Metadata extends PipeMiddlewareMetadata,

--- a/packages/state/src/utils/pipe/metadata.ts
+++ b/packages/state/src/utils/pipe/metadata.ts
@@ -144,8 +144,8 @@ export function definePipeableMiddleware<
   const Adds extends readonly PipeCapability[] = readonly [],
   const Duplicate extends PipeDuplicatePolicy = 'reject',
   const Conflicts extends readonly string[] = readonly string[],
-  const Before extends readonly string[] = readonly [],
-  const After extends readonly string[] = readonly [],
+  const Before extends readonly string[] = readonly string[],
+  const After extends readonly string[] = readonly string[],
 >(
   middleware: PipeAnyMiddleware<Requires, Adds>,
   metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,
@@ -160,8 +160,8 @@ export function definePipeableMiddleware<
   const Adds extends readonly PipeCapability[] = readonly [],
   const Duplicate extends PipeDuplicatePolicy = 'reject',
   const Conflicts extends readonly string[] = readonly string[],
-  const Before extends readonly string[] = readonly [],
-  const After extends readonly string[] = readonly [],
+  const Before extends readonly string[] = readonly string[],
+  const After extends readonly string[] = readonly string[],
 >(
   middleware: PipeMiddleware<State, Requires, Adds>,
   metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,

--- a/packages/state/src/utils/pipe/metadata.ts
+++ b/packages/state/src/utils/pipe/metadata.ts
@@ -144,12 +144,14 @@ export function definePipeableMiddleware<
   const Adds extends readonly PipeCapability[] = readonly [],
   const Duplicate extends PipeDuplicatePolicy = 'reject',
   const Conflicts extends readonly string[] = readonly string[],
+  const Before extends readonly string[] = readonly [],
+  const After extends readonly string[] = readonly [],
 >(
   middleware: PipeAnyMiddleware<Requires, Adds>,
-  metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts>,
+  metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,
 ): PipeableMiddleware<
   PipeAnyMiddleware<Requires, Adds>,
-  PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts>
+  PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>
 >;
 export function definePipeableMiddleware<
   State,
@@ -158,12 +160,14 @@ export function definePipeableMiddleware<
   const Adds extends readonly PipeCapability[] = readonly [],
   const Duplicate extends PipeDuplicatePolicy = 'reject',
   const Conflicts extends readonly string[] = readonly string[],
+  const Before extends readonly string[] = readonly [],
+  const After extends readonly string[] = readonly [],
 >(
   middleware: PipeMiddleware<State, Requires, Adds>,
-  metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts>,
+  metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,
 ): PipeableMiddleware<
   PipeMiddleware<State, Requires, Adds>,
-  PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts>
+  PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>
 >;
 /**
  * Register metadata on a pipe middleware function.

--- a/packages/state/src/utils/pipe/relationship-validation-types.ts
+++ b/packages/state/src/utils/pipe/relationship-validation-types.ts
@@ -25,7 +25,11 @@ type PipeMetadataIds<Chain extends PipeMetadataChain> = PipeMetadataId<Chain[num
 type PipeRelationshipIds<
   Metadata extends PipeMiddlewareMetadata,
   Key extends PipeRelationshipKey,
-> = Metadata[Key] extends readonly string[] ? Metadata[Key][number] : never;
+> = Extract<Metadata[Key], readonly string[]> extends infer Relationships extends readonly string[]
+  ? string extends Relationships[number]
+    ? never
+    : Relationships[number]
+  : never;
 
 type PipeMetadataWithIdFromUnion<
   Metadata extends PipeMiddlewareMetadata,

--- a/packages/state/test/fixtures/pipe-types/dist-consumer/index.ts
+++ b/packages/state/test/fixtures/pipe-types/dist-consumer/index.ts
@@ -65,6 +65,15 @@ const stateIdentity: PipeMiddleware<CounterState> = (store) => store;
 const stateIdentityMiddleware = definePipeableMiddleware(stateIdentity, {
   id: '@consumer/state-identity',
 } as const);
+const explicitGenericMiddleware: PipeAnyMiddleware = (store) => store;
+const explicitAfter = definePipeableMiddleware<'@consumer/explicit-after'>(
+  explicitGenericMiddleware,
+  { after: ['@consumer/dependency'], id: '@consumer/explicit-after' } as const,
+);
+const explicitBefore = definePipeableMiddleware<'@consumer/explicit-before'>(
+  explicitGenericMiddleware,
+  { before: ['@consumer/dependency'], id: '@consumer/explicit-before' } as const,
+);
 
 const metadata: PipeMiddlewareMetadata = { id: '@consumer/metadata' };
 const duplicatePolicy: PipeDuplicatePolicy = 'reject';
@@ -133,6 +142,8 @@ function configurationErrorCode(error: unknown): string {
 
 metadata.id;
 duplicatePolicy;
+explicitAfter;
+explicitBefore;
 configurationErrorCode(configurationError);
 historyConfigurationError.code;
 store.increment();

--- a/packages/state/test/fixtures/pipe-types/dist-consumer/public-invalid/index.ts
+++ b/packages/state/test/fixtures/pipe-types/dist-consumer/public-invalid/index.ts
@@ -1,5 +1,12 @@
 import { Store } from '@ilokesto/store';
-import { dispose, history, HistoryConfigurationError, throttle } from '@ilokesto/state/middleware';
+import {
+  debounce,
+  dispose,
+  history,
+  HistoryConfigurationError,
+  persist,
+  throttle,
+} from '@ilokesto/state/middleware';
 import type {
   HistoryControls,
   HistoryOptions,
@@ -19,6 +26,17 @@ type LegacyCallRejection<Root> = Root extends (...arguments_: never[]) => unknow
   ? unknown
   : { readonly __pipeCallableRootError: '__pipeCallableRootError' };
 
+type CounterState = {
+  readonly count: number;
+};
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null || !('count' in value)) {
+    return null;
+  }
+
+  return typeof value.count === 'number' ? { count: value.count } : null;
+};
 const identityMiddleware: PipeAnyMiddleware = (store) => store;
 const identity = definePipeableMiddleware(identityMiddleware, { id: '@consumer/identity' } as const);
 const rejectedLegacyCall: LegacyCallRejection<typeof pipe> = true;
@@ -26,6 +44,9 @@ const legacyStore = pipe({ count: 0 });
 const rejectedStoreInput = pipe.use(identity).create(new Store({ count: 0 }));
 const historyStore = history({ count: 0 }, undefined);
 const throttledStore = throttle({ count: 0 }, 10);
+const unsafePersistDebounceOrder = pipe
+  .use(persist({ decode: decodeCounter, local: 'persist-before-debounce' }))
+  .use(debounce(25));
 const historyConfigurationError = new HistoryConfigurationError('CONTROL_COLLISION', 'undo');
 type PublicMiddlewareTypes =
   | HistoryControls

--- a/packages/state/test/fixtures/pipe-types/invalid-persist-debounce-order/index.ts
+++ b/packages/state/test/fixtures/pipe-types/invalid-persist-debounce-order/index.ts
@@ -1,0 +1,20 @@
+import { debounce, persist } from '../../../../src/middleware';
+import { pipe } from '../../../../src/utils/pipe';
+
+type CounterState = {
+  readonly count: number;
+};
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null || !('count' in value)) {
+    return null;
+  }
+
+  return typeof value.count === 'number' ? { count: value.count } : null;
+};
+
+const unsafeOrder = pipe
+  .use(persist({ decode: decodeCounter, local: 'persist-before-debounce' }))
+  .use(debounce(25));
+
+unsafeOrder;

--- a/packages/state/test/fixtures/pipe-types/valid-metadata/index.ts
+++ b/packages/state/test/fixtures/pipe-types/valid-metadata/index.ts
@@ -42,6 +42,15 @@ const stateSpecific = definePipeableMiddleware(
   },
 );
 
+const explicitAfter = definePipeableMiddleware<'@fixture/explicit-after'>(
+  <State>(store: Store<State>): Store<State> => store,
+  { after: ['@fixture/dependency'], id: '@fixture/explicit-after' } as const,
+);
+const explicitBefore = definePipeableMiddleware<'@fixture/explicit-before'>(
+  <State>(store: Store<State>): Store<State> => store,
+  { before: ['@fixture/dependency'], id: '@fixture/explicit-before' } as const,
+);
+
 declare const clockStore: Store<{ readonly label: string }> & ClockCapability['shape'];
 
 const genericStore = stateAgnostic(clockStore);
@@ -49,6 +58,8 @@ const counterStore = stateSpecific(new Store<CounterState>({ count: 0 }));
 
 genericStore.getState().label;
 counterStore.getState().count;
+explicitAfter;
+explicitBefore;
 
 const genericLiteralContract: PipeableMiddleware<
   PipeAnyMiddleware<typeof requires, typeof noCapabilities>,

--- a/packages/state/test/fixtures/pipe-types/valid-persist-safe/index.ts
+++ b/packages/state/test/fixtures/pipe-types/valid-persist-safe/index.ts
@@ -1,6 +1,6 @@
 import { Store } from '@ilokesto/store';
 
-import { logger, persist, validate } from '../../../../src/middleware';
+import { debounce, logger, persist, validate } from '../../../../src/middleware';
 import type {
   PersistDecoder,
   PersistMigration,
@@ -65,6 +65,10 @@ const curriedCookie: PersistStore<CounterState> = pipe
 const curriedSession: PersistStore<CounterState> = pipe
   .use(persist({ decode: decodeCounter, session: 'safe-session-pipe' }))
   .create({ count: 0 });
+const debounceBeforePersist: PersistStore<CounterState> = pipe
+  .use(debounce(25))
+  .use(persist({ decode: decodeCounter, local: 'debounce-before-persist' }))
+  .create({ count: 0 });
 const persistBeforeValidate: PersistStore<CounterState> = pipe
   .use(persist({ decode: decodeCounter, local: 'before-validate' }))
   .use(validate(counterSchema))
@@ -96,6 +100,7 @@ directSession.getState().count;
 curriedLocal.getState().count;
 curriedCookie.getState().count;
 curriedSession.getState().count;
+debounceBeforePersist.getState().count;
 persistBeforeValidate.getState().count;
 persistAfterValidate.getState().count;
 persistBeforeCustom.getState().count;

--- a/packages/state/test/helpers/pipeTypeFixtureRegistry.ts
+++ b/packages/state/test/helpers/pipeTypeFixtureRegistry.ts
@@ -16,8 +16,12 @@ export type PipeTypeFixtureCase =
 export const pipeTypeFixtureCases = {
   'dist-consumer': { kind: 'dist-valid' },
   'dist-consumer/public-invalid': {
-    diagnosticCount: 7,
-    expectedMarkers: ['__pipeCallableRootError', '__pipeStoreInputError'],
+    diagnosticCount: 8,
+    expectedMarkers: [
+      '__pipeCallableRootError',
+      '__pipeMiddlewareOrderError',
+      '__pipeStoreInputError',
+    ],
     kind: 'dist-invalid',
   },
   'invalid-callable-root': {
@@ -64,6 +68,11 @@ export const pipeTypeFixtureCases = {
   'invalid-persist-chain': {
     diagnosticCount: 1,
     expectedMarkers: ['__persistMigrationChainError'],
+    kind: 'invalid',
+  },
+  'invalid-persist-debounce-order': {
+    diagnosticCount: 1,
+    expectedMarkers: ['__pipeMiddlewareOrderError'],
     kind: 'invalid',
   },
   'invalid-persist-decoder-state': {

--- a/packages/state/test/pipe-persist-debounce.test.ts
+++ b/packages/state/test/pipe-persist-debounce.test.ts
@@ -1,0 +1,103 @@
+import { expect, jest, test } from 'bun:test';
+
+import { debounce, persist } from '../src/middleware';
+import { PipeConfigurationError } from '../src/utils/pipe/errors';
+import { pipe } from '../src/utils/pipe';
+import { withBrowserFakes } from './helpers/browserFakes';
+
+type CounterState = {
+  readonly count: number;
+};
+
+type BunFakeTimerMethod =
+  | 'advanceTimersByTime'
+  | 'clearAllTimers'
+  | 'useFakeTimers'
+  | 'useRealTimers';
+
+function callBunFakeTimer(methodName: BunFakeTimerMethod, args: readonly unknown[] = []): void {
+  const method: unknown = Reflect.get(jest, methodName);
+  if (typeof method !== 'function') {
+    throw new TypeError(`Bun fake timer method ${methodName} is unavailable`);
+  }
+
+  Reflect.apply(method, jest, args);
+}
+
+const decodeCounter = (value: unknown): CounterState | null => {
+  if (typeof value !== 'object' || value === null || !('count' in value)) {
+    return null;
+  }
+
+  return typeof value.count === 'number' ? { count: value.count } : null;
+};
+
+function useAtRuntime(builder: object, middleware: object): object {
+  const use = Reflect.get(builder, 'use');
+  if (typeof use !== 'function') {
+    throw new TypeError('Pipe builder must expose use');
+  }
+
+  const nextBuilder = Reflect.apply(use, builder, [middleware]);
+  if (typeof nextBuilder !== 'object' || nextBuilder === null) {
+    throw new TypeError('Pipe use must return a builder');
+  }
+
+  return nextBuilder;
+}
+
+test('Given persist before debounce, when the pipe chain is declared, then it rejects before storage effects', () => {
+  // Given
+  withBrowserFakes<CounterState>((storage) => {
+    const unsafeOrder = () => useAtRuntime(
+      useAtRuntime(pipe, persist({ decode: decodeCounter, local: 'persist-before-debounce' })),
+      debounce(25),
+    );
+
+    // When / Then
+    try {
+      unsafeOrder();
+      throw new TypeError('Expected pipe configuration error');
+    } catch (error) {
+      expect(error).toBeInstanceOf(PipeConfigurationError);
+      if (error instanceof PipeConfigurationError) {
+        expect(error.code).toBe('MIDDLEWARE_ORDER');
+      } else {
+        throw error;
+      }
+    }
+
+    expect(storage.reads).toBe(0);
+    expect(storage.writes).toBe(0);
+  });
+});
+
+test('Given debounce before persist, when an update commits after the debounce window, then it persists the committed state', () => {
+  // Given
+  callBunFakeTimer('useFakeTimers');
+
+  try {
+    withBrowserFakes<CounterState>((storage) => {
+      const store = pipe
+        .use(debounce(25))
+        .use(persist({ decode: decodeCounter, local: 'debounce-before-persist' }))
+        .create<CounterState>({ count: 0 });
+
+      // When
+      store.setState({ count: 1 });
+      callBunFakeTimer('advanceTimersByTime', [25]);
+
+      // Then
+      expect(storage.reads).toBe(1);
+      expect(storage.writes).toBe(1);
+      expect(store.getState()).toEqual({ count: 1 });
+      expect(JSON.parse(storage.getItem('debounce-before-persist') ?? '')).toEqual({
+        state: { count: 1 },
+        version: 0,
+      });
+    });
+  } finally {
+    callBunFakeTimer('clearAllTimers');
+    callBunFakeTimer('useRealTimers');
+  }
+});

--- a/packages/state/test/tsconfig.json
+++ b/packages/state/test/tsconfig.json
@@ -19,6 +19,7 @@
     "fixtures/pipe-types/invalid-missing-capability",
     "fixtures/pipe-types/invalid-order",
     "fixtures/pipe-types/invalid-persist-chain",
+    "fixtures/pipe-types/invalid-persist-debounce-order",
     "fixtures/pipe-types/invalid-persist-decoder-state",
     "fixtures/pipe-types/invalid-persist-first-input",
     "fixtures/pipe-types/invalid-persist-session-migrate",


### PR DESCRIPTION
## Summary

- encode persist as running after debounce when both middleware are present
- reject unsafe persist-before-debounce chains before storage or timer side effects
- preserve relationship literals through public pipe metadata types and diagnostics
- add deterministic runtime and source/dist type fixtures
- document the supported order in English and Korean
- include a patch changeset

## Verification

- pnpm --filter @ilokesto/state exec bun test test/pipe-persist-debounce.test.ts test/pipe-types.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file LSP diagnostics
- git diff --check

Closes #73