### PR TITLE
fix(state): preserve readonly adapter contracts

### DIFF
--- a/.changeset/state-readonly-adapter-contract.md
+++ b/.changeset/state-readonly-adapter-contract.md
@@ -2,11 +2,11 @@
 "@ilokesto/state": major
 ---
 
-Preserve `@ilokesto/store`'s `Readonly<T>` contract across the React, Vue, Angular, Svelte, and Solid adapters. Selector inputs, full-state reactive reads, lifecycle-free `readOnly()` results, and Svelte subscriptions now expose read-only state. Object state is `Readonly<T>`; callable state retains its call signature.
+Preserve `@ilokesto/store`'s `Readonly<T>` contract across the React, Vue, Angular, Svelte, and Solid adapters. Selector inputs, full-state reactive reads, lifecycle-free `readOnly()` results, and Svelte subscriptions expose `Readonly<T>` for object state. Callable state remains exact `T`, preserving arbitrary generic and overloaded signatures; its own-property modifiers remain as declared.
 
 ### Migration
 
-Code that mutates adapter state in a selector, subscription, reactive result, or `readOnly()` result must move that update to the correct writer.
+Code that mutates object adapter state in a selector, subscription, reactive result, or `readOnly()` result must move that update to the correct writer. Callable state preserves the mutability of its declared own properties.
 
 For plain state, use an immutable updater through `writeOnly()`, `setState`, or Svelte's `update`:
 

--- a/.changeset/state-readonly-adapter-contract.md
+++ b/.changeset/state-readonly-adapter-contract.md
@@ -2,12 +2,32 @@
 "@ilokesto/state": major
 ---
 
-Preserve `@ilokesto/store`'s `Readonly<T>` contract across the React, Vue, Angular, Svelte, and Solid adapters. Selector inputs, full-state reactive reads, lifecycle-free `readOnly()` results, and Svelte subscriptions now expose read-only state.
+Preserve `@ilokesto/store`'s `Readonly<T>` contract across the React, Vue, Angular, Svelte, and Solid adapters. Selector inputs, full-state reactive reads, lifecycle-free `readOnly()` results, and Svelte subscriptions now expose read-only state. Object state is `Readonly<T>`; callable state retains its call signature.
 
 ### Migration
 
-Code that mutates adapter state in a selector, subscription, reactive result, or `readOnly()` result must move that update to the adapter writer. Replace mutation such as `state.count += 1` with an immutable next state through `writeOnly()`, `setState`, `update`, or `dispatch` as appropriate:
+Code that mutates adapter state in a selector, subscription, reactive result, or `readOnly()` result must move that update to the correct writer.
+
+For plain state, use an immutable updater through `writeOnly()`, `setState`, or Svelte's `update`:
 
 ```ts
 counter.writeOnly()((current) => ({ ...current, count: current.count + 1 }));
+```
+
+For reducer state, dispatch a typed action. The reducer computes the next state:
+
+```ts
+type CounterAction = { readonly type: 'increment' };
+
+const counter = create(
+  (state: { readonly count: number }, action: CounterAction) => {
+    switch (action.type) {
+      case 'increment':
+        return { count: state.count + 1 };
+    }
+  },
+  { count: 0 },
+);
+
+counter.writeOnly()({ type: 'increment' });
 ```

--- a/.changeset/state-readonly-adapter-contract.md
+++ b/.changeset/state-readonly-adapter-contract.md
@@ -1,0 +1,13 @@
+---
+"@ilokesto/state": major
+---
+
+Preserve `@ilokesto/store`'s `Readonly<T>` contract across the React, Vue, Angular, Svelte, and Solid adapters. Selector inputs, full-state reactive reads, lifecycle-free `readOnly()` results, and Svelte subscriptions now expose read-only state.
+
+### Migration
+
+Code that mutates adapter state in a selector, subscription, reactive result, or `readOnly()` result must move that update to the adapter writer. Replace mutation such as `state.count += 1` with an immutable next state through `writeOnly()`, `setState`, `update`, or `dispatch` as appropriate:
+
+```ts
+counter.writeOnly()((current) => ({ ...current, count: current.count + 1 }));
+```

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -33,7 +33,7 @@ React, Vue, Angular, Svelte, Solid는 일반 상태와 Reducer 상태 모두에�
 - 선택 결과와 관련된 업데이트는 consumer에 정확히 한 번 알립니다.
 - React unmount, Vue scope dispose, Angular `DestroyRef`, Solid owner cleanup, Svelte unsubscribe 시 구독을 해제합니다.
 - React server snapshot은 Store의 초기 상태에서 값을 선택하므로 현재 상태가 이미 변경되었어도 hydration 의미론을 유지합니다.
-- Selector 입력, 전체 상태 reactive 결과, `readOnly()` snapshot은 `Readonly<T>`로 타입 지정됩니다. write API는 mutable next-state와 updater 계약을 유지합니다.
+- Selector 입력, 전체 상태 reactive 결과, `readOnly()` snapshot은 read-only state를 사용합니다. object state는 `Readonly<T>`이고 callable state는 call signature를 유지합니다. plain-state writer는 mutable next-state와 updater 계약을 유지하고, reducer writer는 typed action을 받습니다.
 
 이 계약은 `Store.subscribeSelector`를 기반으로 하며, 어댑터는 프레임워크별 동등성 옵션을 노출하지 않습니다. `create(initialState)`와 `create(reducer, initialState)`에 동일하게 적용됩니다.
 

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -33,6 +33,7 @@ React, Vue, Angular, Svelte, Solid는 일반 상태와 Reducer 상태 모두에�
 - 선택 결과와 관련된 업데이트는 consumer에 정확히 한 번 알립니다.
 - React unmount, Vue scope dispose, Angular `DestroyRef`, Solid owner cleanup, Svelte unsubscribe 시 구독을 해제합니다.
 - React server snapshot은 Store의 초기 상태에서 값을 선택하므로 현재 상태가 이미 변경되었어도 hydration 의미론을 유지합니다.
+- Selector 입력, 전체 상태 reactive 결과, `readOnly()` snapshot은 `Readonly<T>`로 타입 지정됩니다. write API는 mutable next-state와 updater 계약을 유지합니다.
 
 이 계약은 `Store.subscribeSelector`를 기반으로 하며, 어댑터는 프레임워크별 동등성 옵션을 노출하지 않습니다. `create(initialState)`와 `create(reducer, initialState)`에 동일하게 적용됩니다.
 

--- a/packages/state/README.ko.md
+++ b/packages/state/README.ko.md
@@ -33,7 +33,7 @@ React, Vue, Angular, Svelte, Solid는 일반 상태와 Reducer 상태 모두에�
 - 선택 결과와 관련된 업데이트는 consumer에 정확히 한 번 알립니다.
 - React unmount, Vue scope dispose, Angular `DestroyRef`, Solid owner cleanup, Svelte unsubscribe 시 구독을 해제합니다.
 - React server snapshot은 Store의 초기 상태에서 값을 선택하므로 현재 상태가 이미 변경되었어도 hydration 의미론을 유지합니다.
-- Selector 입력, 전체 상태 reactive 결과, `readOnly()` snapshot은 read-only state를 사용합니다. object state는 `Readonly<T>`이고 callable state는 call signature를 유지합니다. plain-state writer는 mutable next-state와 updater 계약을 유지하고, reducer writer는 typed action을 받습니다.
+- Selector 입력, 전체 상태 reactive 결과, `readOnly()` snapshot은 object state에 `Readonly<T>`를 사용합니다. callable state는 exact `T`로 유지되어 임의의 generic/overloaded signature를 보존하며 own-property modifier도 선언된 그대로입니다. plain-state writer는 mutable next-state와 updater 계약을 유지하고, reducer writer는 typed action을 받습니다.
 
 이 계약은 `Store.subscribeSelector`를 기반으로 하며, 어댑터는 프레임워크별 동등성 옵션을 노출하지 않습니다. `create(initialState)`와 `create(reducer, initialState)`에 동일하게 적용됩니다.
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -35,6 +35,7 @@ React, Vue, Angular, Svelte, and Solid use the same selector subscription behavi
 - A relevant update notifies the consumer exactly once.
 - Subscriptions are removed by the framework lifecycle: React unmount, Vue scope disposal, Angular `DestroyRef`, Solid owner cleanup, or Svelte unsubscribe.
 - React's server snapshot selects from the store's initial state, preserving hydration semantics even if the current state has already changed.
+- Selector inputs, full-state reactive results, and `readOnly()` snapshots are typed as `Readonly<T>`; write APIs retain their mutable next-state and updater contracts.
 
 This contract is built on `Store.subscribeSelector`; adapters do not expose framework-specific equality options. It applies equally to `create(initialState)` and `create(reducer, initialState)`.
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -35,7 +35,7 @@ React, Vue, Angular, Svelte, and Solid use the same selector subscription behavi
 - A relevant update notifies the consumer exactly once.
 - Subscriptions are removed by the framework lifecycle: React unmount, Vue scope disposal, Angular `DestroyRef`, Solid owner cleanup, or Svelte unsubscribe.
 - React's server snapshot selects from the store's initial state, preserving hydration semantics even if the current state has already changed.
-- Selector inputs, full-state reactive results, and `readOnly()` snapshots are typed as `Readonly<T>`; write APIs retain their mutable next-state and updater contracts.
+- Selector inputs, full-state reactive results, and `readOnly()` snapshots use read-only state: object state is `Readonly<T>`, while callable state retains its call signature. Plain-state writers retain mutable next-state and updater contracts, while reducer writers accept typed actions.
 
 This contract is built on `Store.subscribeSelector`; adapters do not expose framework-specific equality options. It applies equally to `create(initialState)` and `create(reducer, initialState)`.
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -35,7 +35,7 @@ React, Vue, Angular, Svelte, and Solid use the same selector subscription behavi
 - A relevant update notifies the consumer exactly once.
 - Subscriptions are removed by the framework lifecycle: React unmount, Vue scope disposal, Angular `DestroyRef`, Solid owner cleanup, or Svelte unsubscribe.
 - React's server snapshot selects from the store's initial state, preserving hydration semantics even if the current state has already changed.
-- Selector inputs, full-state reactive results, and `readOnly()` snapshots use read-only state: object state is `Readonly<T>`, while callable state retains its call signature. Plain-state writers retain mutable next-state and updater contracts, while reducer writers accept typed actions.
+- Selector inputs, full-state reactive results, and `readOnly()` snapshots use `Readonly<T>` for object state. Callable state remains exact `T`, preserving arbitrary generic and overloaded signatures; its own-property modifiers remain as declared. Plain-state writers retain mutable next-state and updater contracts, while reducer writers accept typed actions.
 
 This contract is built on `Store.subscribeSelector`; adapters do not expose framework-specific equality options. It applies equally to `create(initialState)` and `create(reducer, initialState)`.
 

--- a/packages/state/docs/advanced/selector-semantics.ko.mdx
+++ b/packages/state/docs/advanced/selector-semantics.ko.mdx
@@ -5,7 +5,7 @@ description: "adapter별 selector와 snapshot 동작입니다."
 
 # Selector 동작
 
-selector는 adapter-level projection function입니다. underlying store state를 바꾸지 않고 reactive reader가 받을 값을 결정합니다.
+selector는 adapter-level projection function입니다. `Readonly<T>` state를 받고 underlying store state를 바꾸지 않으며 reactive reader가 받을 값을 결정합니다. 전체 state reactive 결과와 lifecycle 밖의 `readOnly()` snapshot도 `Readonly<T>`를 유지하지만 writer API는 mutable next-state와 updater 계약을 유지합니다.
 
 ## 공통 shallow 비교
 

--- a/packages/state/docs/advanced/selector-semantics.ko.mdx
+++ b/packages/state/docs/advanced/selector-semantics.ko.mdx
@@ -5,7 +5,7 @@ description: "adapter별 selector와 snapshot 동작입니다."
 
 # Selector 동작
 
-selector는 adapter-level projection function입니다. read-only state를 받고 underlying store state를 바꾸지 않으며 reactive reader가 받을 값을 결정합니다. object state는 `Readonly<T>`이고 callable state는 call signature를 유지합니다. 전체 state reactive 결과와 lifecycle 밖의 `readOnly()` snapshot도 같은 계약을 사용합니다. plain-state writer는 mutable next-state와 updater 계약을 유지하고 reducer writer는 typed action을 받습니다.
+selector는 adapter-level projection function입니다. snapshot을 받고 underlying store state를 바꾸지 않으며 reactive reader가 받을 값을 결정합니다. object state는 `Readonly<T>`이고 callable state는 exact `T`로 유지되어 임의의 generic/overloaded signature와 선언된 own-property modifier를 보존합니다. 전체 state reactive 결과와 lifecycle 밖의 `readOnly()` snapshot도 같은 계약을 사용합니다. plain-state writer는 mutable next-state와 updater 계약을 유지하고 reducer writer는 typed action을 받습니다.
 
 ## 공통 shallow 비교
 

--- a/packages/state/docs/advanced/selector-semantics.ko.mdx
+++ b/packages/state/docs/advanced/selector-semantics.ko.mdx
@@ -5,7 +5,7 @@ description: "adapter별 selector와 snapshot 동작입니다."
 
 # Selector 동작
 
-selector는 adapter-level projection function입니다. `Readonly<T>` state를 받고 underlying store state를 바꾸지 않으며 reactive reader가 받을 값을 결정합니다. 전체 state reactive 결과와 lifecycle 밖의 `readOnly()` snapshot도 `Readonly<T>`를 유지하지만 writer API는 mutable next-state와 updater 계약을 유지합니다.
+selector는 adapter-level projection function입니다. read-only state를 받고 underlying store state를 바꾸지 않으며 reactive reader가 받을 값을 결정합니다. object state는 `Readonly<T>`이고 callable state는 call signature를 유지합니다. 전체 state reactive 결과와 lifecycle 밖의 `readOnly()` snapshot도 같은 계약을 사용합니다. plain-state writer는 mutable next-state와 updater 계약을 유지하고 reducer writer는 typed action을 받습니다.
 
 ## 공통 shallow 비교
 

--- a/packages/state/docs/advanced/selector-semantics.mdx
+++ b/packages/state/docs/advanced/selector-semantics.mdx
@@ -5,7 +5,7 @@ description: "How selectors and snapshots behave across adapters."
 
 # Selector semantics
 
-Selectors are adapter-level projection functions. They receive `Readonly<T>` state and do not change the underlying store state; they decide what a reactive reader receives. Full-state reactive results and lifecycle-free `readOnly()` snapshots also preserve `Readonly<T>`, while writer APIs retain their mutable next-state and updater contracts.
+Selectors are adapter-level projection functions. They receive read-only state and do not change the underlying store state; they decide what a reactive reader receives. Object state is `Readonly<T>`, while callable state retains its call signature. Full-state reactive results and lifecycle-free `readOnly()` snapshots use the same contract. Plain-state writers retain mutable next-state and updater contracts, while reducer writers accept typed actions.
 
 ## Shared shallow comparison
 

--- a/packages/state/docs/advanced/selector-semantics.mdx
+++ b/packages/state/docs/advanced/selector-semantics.mdx
@@ -5,7 +5,7 @@ description: "How selectors and snapshots behave across adapters."
 
 # Selector semantics
 
-Selectors are adapter-level projection functions. They do not change the underlying store state; they decide what a reactive reader receives.
+Selectors are adapter-level projection functions. They receive `Readonly<T>` state and do not change the underlying store state; they decide what a reactive reader receives. Full-state reactive results and lifecycle-free `readOnly()` snapshots also preserve `Readonly<T>`, while writer APIs retain their mutable next-state and updater contracts.
 
 ## Shared shallow comparison
 

--- a/packages/state/docs/advanced/selector-semantics.mdx
+++ b/packages/state/docs/advanced/selector-semantics.mdx
@@ -5,7 +5,7 @@ description: "How selectors and snapshots behave across adapters."
 
 # Selector semantics
 
-Selectors are adapter-level projection functions. They receive read-only state and do not change the underlying store state; they decide what a reactive reader receives. Object state is `Readonly<T>`, while callable state retains its call signature. Full-state reactive results and lifecycle-free `readOnly()` snapshots use the same contract. Plain-state writers retain mutable next-state and updater contracts, while reducer writers accept typed actions.
+Selectors are adapter-level projection functions. They receive snapshots and do not change the underlying store state; they decide what a reactive reader receives. Object state is `Readonly<T>`, while callable state remains exact `T`, preserving arbitrary generic and overloaded signatures and its declared own-property modifiers. Full-state reactive results and lifecycle-free `readOnly()` snapshots use the same contract. Plain-state writers retain mutable next-state and updater contracts, while reducer writers accept typed actions.
 
 ## Shared shallow comparison
 

--- a/packages/state/docs/reference/read-write.ko.mdx
+++ b/packages/state/docs/reference/read-write.ko.mdx
@@ -9,7 +9,7 @@ description: "readOnly, writeOnly, subscribe와 생명주기 안전 사용법입
 
 ## `readOnly()`
 
-`readOnly()`는 underlying store를 동기적으로 읽습니다. selector를 넘길 수 있습니다.
+`readOnly()`는 underlying store를 동기적으로 읽습니다. 전체 state read는 `Readonly<T>`를 반환하고 selector는 `Readonly<T>`를 받습니다. selector를 넘길 수 있습니다.
 
 ```ts lineNumbers
 const current = useCounter.readOnly();

--- a/packages/state/docs/reference/read-write.ko.mdx
+++ b/packages/state/docs/reference/read-write.ko.mdx
@@ -9,7 +9,7 @@ description: "readOnly, writeOnly, subscribe와 생명주기 안전 사용법입
 
 ## `readOnly()`
 
-`readOnly()`는 underlying store를 동기적으로 읽습니다. 전체 state read는 `Readonly<T>`를 반환하고 selector는 `Readonly<T>`를 받습니다. selector를 넘길 수 있습니다.
+`readOnly()`는 underlying store를 동기적으로 읽습니다. 전체 object-state read는 `Readonly<T>`를 반환하고 selector도 이를 받습니다. callable state는 own property를 read-only로 유지하면서 call signature를 보존합니다. selector를 넘길 수 있습니다.
 
 ```ts lineNumbers
 const current = useCounter.readOnly();

--- a/packages/state/docs/reference/read-write.ko.mdx
+++ b/packages/state/docs/reference/read-write.ko.mdx
@@ -9,7 +9,7 @@ description: "readOnly, writeOnly, subscribe와 생명주기 안전 사용법입
 
 ## `readOnly()`
 
-`readOnly()`는 underlying store를 동기적으로 읽습니다. 전체 object-state read는 `Readonly<T>`를 반환하고 selector도 이를 받습니다. callable state는 own property를 read-only로 유지하면서 call signature를 보존합니다. selector를 넘길 수 있습니다.
+`readOnly()`는 underlying store를 동기적으로 읽습니다. 전체 object-state read는 `Readonly<T>`를 반환하고 selector도 이를 받습니다. callable state는 exact `T`로 유지되어 임의의 generic/overloaded signature와 선언된 own-property modifier를 보존합니다. selector를 넘길 수 있습니다.
 
 ```ts lineNumbers
 const current = useCounter.readOnly();

--- a/packages/state/docs/reference/read-write.mdx
+++ b/packages/state/docs/reference/read-write.mdx
@@ -9,7 +9,7 @@ description: "readOnly, writeOnly, subscribe, and lifecycle-safe usage."
 
 ## `readOnly()`
 
-`readOnly()` synchronously reads from the underlying store. It returns `Readonly<T>` for a full-state read, and its selector receives `Readonly<T>`. You can pass a selector.
+`readOnly()` synchronously reads from the underlying store. Full object-state reads return `Readonly<T>` and selectors receive it; callable state keeps its call signature while its own properties remain read-only. You can pass a selector.
 
 ```ts lineNumbers
 const current = useCounter.readOnly();

--- a/packages/state/docs/reference/read-write.mdx
+++ b/packages/state/docs/reference/read-write.mdx
@@ -9,7 +9,7 @@ description: "readOnly, writeOnly, subscribe, and lifecycle-safe usage."
 
 ## `readOnly()`
 
-`readOnly()` synchronously reads from the underlying store. You can pass a selector.
+`readOnly()` synchronously reads from the underlying store. It returns `Readonly<T>` for a full-state read, and its selector receives `Readonly<T>`. You can pass a selector.
 
 ```ts lineNumbers
 const current = useCounter.readOnly();

--- a/packages/state/docs/reference/read-write.mdx
+++ b/packages/state/docs/reference/read-write.mdx
@@ -9,7 +9,7 @@ description: "readOnly, writeOnly, subscribe, and lifecycle-safe usage."
 
 ## `readOnly()`
 
-`readOnly()` synchronously reads from the underlying store. Full object-state reads return `Readonly<T>` and selectors receive it; callable state keeps its call signature while its own properties remain read-only. You can pass a selector.
+`readOnly()` synchronously reads from the underlying store. Full object-state reads return `Readonly<T>` and selectors receive it. Callable state remains exact `T`, preserving arbitrary generic and overloaded signatures and its own-property modifiers as declared. You can pass a selector.
 
 ```ts lineNumbers
 const current = useCounter.readOnly();

--- a/packages/state/src/core/Angular/createUseSignal.ts
+++ b/packages/state/src/core/Angular/createUseSignal.ts
@@ -4,6 +4,7 @@ import { DestroyRef, inject, signal } from '@angular/core';
 import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
+import { readonlySnapshot, type ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 import { shallow } from '../shared/shallow.js';
 import type { AngularOptions, Selector } from './types.js';
 
@@ -23,9 +24,9 @@ function resolveDestroyRef(options?: AngularOptions): DestroyRef {
 
 function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>, options?: AngularOptions) {
   const destroyRef = resolveDestroyRef(options);
-  const selection = signal(selector(store.getState()));
+  const selection = signal(selector(readonlySnapshot(store.getState())));
   const unsubscribe = store.subscribeSelector(
-    selector,
+    (state) => selector(readonlySnapshot(state)),
     (nextSelection) => {
       selection.set(nextSelection);
     },
@@ -47,7 +48,7 @@ export function createUseSignal<T, Action extends ReducerAction>(store: Store<T>
       const state =
         typeof selectorOrOptions === 'function'
           ? createSelection(store, selectorOrOptions, maybeOptions)
-          : createSelection(store, identity<Readonly<T>>, selectorOrOptions);
+          : createSelection(store, identity<ReadonlySnapshot<T>>, selectorOrOptions);
 
       if (isReduce) {
         return {
@@ -66,8 +67,8 @@ export function createUseSignal<T, Action extends ReducerAction>(store: Store<T>
     {
       writeOnly: () => (isReduce ? dispatch : write),
       readOnly: <S = T>(selector?: Selector<T, S>): S => {
-        const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
-        return select(store.getState());
+        const select = (selector ?? identity<ReadonlySnapshot<T>>) as Selector<T, S>;
+        return select(readonlySnapshot(store.getState()));
       },
       subscribe,
     },

--- a/packages/state/src/core/Angular/createUseSignal.ts
+++ b/packages/state/src/core/Angular/createUseSignal.ts
@@ -5,12 +5,7 @@ import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
 import { shallow } from '../shared/shallow.js';
-import type {
-  ActionWriter,
-  AngularOptions,
-  Selector,
-  StateWriter,
-} from './types.js';
+import type { AngularOptions, Selector } from './types.js';
 
 function resolveDestroyRef(options?: AngularOptions): DestroyRef {
   if (options?.destroyRef) {
@@ -28,7 +23,7 @@ function resolveDestroyRef(options?: AngularOptions): DestroyRef {
 
 function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>, options?: AngularOptions) {
   const destroyRef = resolveDestroyRef(options);
-  const selection = signal(selector(store.getState() as T));
+  const selection = signal(selector(store.getState()));
   const unsubscribe = store.subscribeSelector(
     selector,
     (nextSelection) => {
@@ -52,7 +47,7 @@ export function createUseSignal<T, Action extends ReducerAction>(store: Store<T>
       const state =
         typeof selectorOrOptions === 'function'
           ? createSelection(store, selectorOrOptions, maybeOptions)
-          : createSelection(store, identity<T>, selectorOrOptions);
+          : createSelection(store, identity<Readonly<T>>, selectorOrOptions);
 
       if (isReduce) {
         return {
@@ -64,15 +59,15 @@ export function createUseSignal<T, Action extends ReducerAction>(store: Store<T>
 
       return {
         state,
-        setState: write as StateWriter<T>,
+        setState: write,
         subscribe,
       } as const;
     },
     {
       writeOnly: () => (isReduce ? dispatch : write),
       readOnly: <S = T>(selector?: Selector<T, S>): S => {
-        const select = (selector ?? identity<T>) as Selector<T, S>;
-        return select(store.getState() as T);
+        const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
+        return select(store.getState());
       },
       subscribe,
     },

--- a/packages/state/src/core/Angular/index.ts
+++ b/packages/state/src/core/Angular/index.ts
@@ -19,8 +19,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a function that must be called inside an injection context or with
  * an explicit `{ destroyRef }`. Without a selector, `state` is a `Signal` of a
- * read-only snapshot: object state is `Readonly<T>`, while callable state keeps
- * its call signature. Selectors and `.readOnly()` use the same snapshot.
+ * read-only snapshot: object state is `Readonly<T>`, while callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Angular/index.ts
+++ b/packages/state/src/core/Angular/index.ts
@@ -18,9 +18,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Create an Angular signal from plain state or a reducer.
  *
  * Returns a function that must be called inside an injection context or with
- * an explicit `{ destroyRef }`. Returns `{ state, setState, subscribe }` or
- * `{ state, dispatch, subscribe }`. Selectors and `.readOnly()` receive
- * `Readonly<T>` snapshots; use `.writeOnly()` for lifecycle-independent updates.
+ * an explicit `{ destroyRef }`. Without a selector, `state` is a `Signal` of a
+ * read-only snapshot: object state is `Readonly<T>`, while callable state keeps
+ * its call signature. Selectors and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Angular/index.ts
+++ b/packages/state/src/core/Angular/index.ts
@@ -19,8 +19,8 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a function that must be called inside an injection context or with
  * an explicit `{ destroyRef }`. Returns `{ state, setState, subscribe }` or
- * `{ state, dispatch, subscribe }`. Use `.writeOnly()` or `.readOnly()` for
- * lifecycle-independent access.
+ * `{ state, dispatch, subscribe }`. Selectors and `.readOnly()` receive
+ * `Readonly<T>` snapshots; use `.writeOnly()` for lifecycle-independent updates.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Angular/types.ts
+++ b/packages/state/src/core/Angular/types.ts
@@ -3,7 +3,7 @@ import type { DestroyRef, Signal } from '@angular/core';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
 
-export type Selector<T, S> = (state: T) => S;
+export type Selector<T, S> = (state: Readonly<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
@@ -24,24 +24,24 @@ export type AngularReducerResult<S, T, Action> = Readonly<{
 }>;
 
 export type UseState<T> = {
-  (): AngularStateResult<T, T>;
-  (options: AngularOptions): AngularStateResult<T, T>;
+  (): AngularStateResult<Readonly<T>, T>;
+  (options: AngularOptions): AngularStateResult<Readonly<T>, T>;
   <S>(selector: Selector<T, S>, options?: AngularOptions): AngularStateResult<S, T>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
   subscribe: Store<T>['subscribe'];
 };
 
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): AngularReducerResult<T, T, Action>;
-  (options: AngularOptions): AngularReducerResult<T, T, Action>;
+  (): AngularReducerResult<Readonly<T>, T, Action>;
+  (options: AngularOptions): AngularReducerResult<Readonly<T>, T, Action>;
   <S>(selector: Selector<T, S>, options?: AngularOptions): AngularReducerResult<S, T, Action>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
   subscribe: Store<T>['subscribe'];

--- a/packages/state/src/core/Angular/types.ts
+++ b/packages/state/src/core/Angular/types.ts
@@ -2,8 +2,9 @@ import type { Store } from '@ilokesto/store';
 import type { DestroyRef, Signal } from '@angular/core';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import type { ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 
-export type Selector<T, S> = (state: Readonly<T>) => S;
+export type Selector<T, S> = (state: ReadonlySnapshot<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
@@ -24,24 +25,24 @@ export type AngularReducerResult<S, T, Action> = Readonly<{
 }>;
 
 export type UseState<T> = {
-  (): AngularStateResult<Readonly<T>, T>;
-  (options: AngularOptions): AngularStateResult<Readonly<T>, T>;
+  (): AngularStateResult<ReadonlySnapshot<T>, T>;
+  (options: AngularOptions): AngularStateResult<ReadonlySnapshot<T>, T>;
   <S>(selector: Selector<T, S>, options?: AngularOptions): AngularStateResult<S, T>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
   subscribe: Store<T>['subscribe'];
 };
 
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): AngularReducerResult<Readonly<T>, T, Action>;
-  (options: AngularOptions): AngularReducerResult<Readonly<T>, T, Action>;
+  (): AngularReducerResult<ReadonlySnapshot<T>, T, Action>;
+  (options: AngularOptions): AngularReducerResult<ReadonlySnapshot<T>, T, Action>;
   <S>(selector: Selector<T, S>, options?: AngularOptions): AngularReducerResult<S, T, Action>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
   subscribe: Store<T>['subscribe'];

--- a/packages/state/src/core/React/createUseState.ts
+++ b/packages/state/src/core/React/createUseState.ts
@@ -7,14 +7,14 @@ import { identity } from '../shared/identity.js';
 import { shallow } from '../shared/shallow.js';
 import type { UseReducer, UseState } from './types.js';
 
-type Selector<T, S> = (state: T) => S;
+type Selector<T, S> = (state: Readonly<T>) => S;
 
 function createShallowSelector<T, S>(
-  selector: (state: T) => S,
-): (state: T) => S {
+  selector: (state: Readonly<T>) => S,
+): (state: Readonly<T>) => S {
   let previous: Readonly<{ value: S }> | undefined;
 
-  return (state: T): S => {
+  return (state: Readonly<T>): S => {
     const next = selector(state);
 
     if (previous && shallow(previous.value, next)) {
@@ -28,7 +28,7 @@ function createShallowSelector<T, S>(
 
 export function useStoreState<T, S, Writer>(
   store: Store<T>,
-  selector: (state: T) => S,
+  selector: (state: Readonly<T>) => S,
   write: Writer,
 ) {
   const subscribe = useMemo(
@@ -59,7 +59,7 @@ export function createUseState<T, Action extends ReducerAction>(
   const write = store.setState.bind(store);
   const dispatch = (action: Action): void => dispatchStoreAction(store, action);
 
-  function readOnly(): T;
+  function readOnly(): Readonly<T>;
   function readOnly<S>(selector: Selector<T, S>): S;
   function readOnly<S>(selector?: Selector<T, S>) {
     const currentState = store.getState();
@@ -68,10 +68,10 @@ export function createUseState<T, Action extends ReducerAction>(
   }
 
   function createUseSelectedState<Writer>(writer: Writer) {
-    function useSelectedState(): readonly [T, Writer];
+    function useSelectedState(): readonly [Readonly<T>, Writer];
     function useSelectedState<S>(selector: Selector<T, S>): readonly [S, Writer];
     function useSelectedState(selector?: Selector<T, unknown>) {
-      const select = selector ?? identity<T>;
+      const select = selector ?? identity<Readonly<T>>;
 
       return useStoreState(store, select, writer);
     }

--- a/packages/state/src/core/React/createUseState.ts
+++ b/packages/state/src/core/React/createUseState.ts
@@ -4,17 +4,21 @@ import { useMemo, useSyncExternalStore } from 'react';
 import { dispatchStoreAction } from '../../lib/actionMetadata.js';
 import type { ReducerAction } from '../../types/ReduceFn.js';
 import { identity } from '../shared/identity.js';
+import {
+  readonlySnapshot,
+  type ReadonlySnapshot,
+} from '../shared/readonlySnapshot.js';
 import { shallow } from '../shared/shallow.js';
 import type { UseReducer, UseState } from './types.js';
 
-type Selector<T, S> = (state: Readonly<T>) => S;
+type Selector<T, S> = (state: ReadonlySnapshot<T>) => S;
 
 function createShallowSelector<T, S>(
-  selector: (state: Readonly<T>) => S,
-): (state: Readonly<T>) => S {
+  selector: (state: ReadonlySnapshot<T>) => S,
+): (state: ReadonlySnapshot<T>) => S {
   let previous: Readonly<{ value: S }> | undefined;
 
-  return (state: Readonly<T>): S => {
+  return (state: ReadonlySnapshot<T>): S => {
     const next = selector(state);
 
     if (previous && shallow(previous.value, next)) {
@@ -28,23 +32,27 @@ function createShallowSelector<T, S>(
 
 export function useStoreState<T, S, Writer>(
   store: Store<T>,
-  selector: (state: Readonly<T>) => S,
+  selector: (state: ReadonlySnapshot<T>) => S,
   write: Writer,
 ) {
   const subscribe = useMemo(
     () => (listener: () => void) =>
-      store.subscribeSelector(selector, listener, shallow),
+      store.subscribeSelector(
+        (state) => selector(readonlySnapshot(state)),
+        listener,
+        shallow,
+      ),
     [store, selector],
   );
 
   const getSnapshot = useMemo(() => {
     const shallowSelector = createShallowSelector(selector);
-    return () => shallowSelector(store.getState());
+    return () => shallowSelector(readonlySnapshot(store.getState()));
   }, [store, selector]);
 
   const getServerSnapshot = useMemo(() => {
     const shallowSelector = createShallowSelector(selector);
-    return () => shallowSelector(store.getInitialState());
+    return () => shallowSelector(readonlySnapshot(store.getInitialState()));
   }, [store, selector]);
 
   const value = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
@@ -59,19 +67,19 @@ export function createUseState<T, Action extends ReducerAction>(
   const write = store.setState.bind(store);
   const dispatch = (action: Action): void => dispatchStoreAction(store, action);
 
-  function readOnly(): Readonly<T>;
+  function readOnly(): ReadonlySnapshot<T>;
   function readOnly<S>(selector: Selector<T, S>): S;
   function readOnly<S>(selector?: Selector<T, S>) {
-    const currentState = store.getState();
+    const currentState = readonlySnapshot(store.getState());
 
     return selector ? selector(currentState) : currentState;
   }
 
   function createUseSelectedState<Writer>(writer: Writer) {
-    function useSelectedState(): readonly [Readonly<T>, Writer];
+    function useSelectedState(): readonly [ReadonlySnapshot<T>, Writer];
     function useSelectedState<S>(selector: Selector<T, S>): readonly [S, Writer];
     function useSelectedState(selector?: Selector<T, unknown>) {
-      const select = selector ?? identity<Readonly<T>>;
+      const select = selector ?? identity<ReadonlySnapshot<T>>;
 
       return useStoreState(store, select, writer);
     }

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -17,7 +17,8 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a hook compatible with `useSyncExternalStore`. Call it with a
  * selector to subscribe to a slice; call without arguments to read the full
- * state. Use `.writeOnly()` or `.readOnly()` for lifecycle-independent access.
+ * read-only state. Selectors and `.readOnly()` receive `Readonly<T>` snapshots;
+ * use `.writeOnly()` for lifecycle-independent updates.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -16,9 +16,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Create a React state hook from plain state or a reducer.
  *
  * Returns a hook compatible with `useSyncExternalStore`. Call it with a
- * selector to subscribe to a slice; call without arguments to read the full
- * read-only state. Selectors and `.readOnly()` receive `Readonly<T>` snapshots;
- * use `.writeOnly()` for lifecycle-independent updates.
+ * selector to subscribe to a slice; call without arguments to receive a
+ * read-only first tuple item. Object state is `Readonly<T>`; callable state
+ * retains its call signature. Selectors and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -18,7 +18,8 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Returns a hook compatible with `useSyncExternalStore`. Call it with a
  * selector to subscribe to a slice; call without arguments to receive a
  * read-only first tuple item. Object state is `Readonly<T>`; callable state
- * retains its call signature. Selectors and `.readOnly()` use the same snapshot.
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/React/types.ts
+++ b/packages/state/src/core/React/types.ts
@@ -1,17 +1,18 @@
 import { SetStateAction } from 'react';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import type { ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 
 /**
  * React hook returned by `create()` for plain state.
  */
 export type UseState<T> = {
-  (): readonly [Readonly<T>, (nextState: SetStateAction<T>) => void];
-  <S>(selector: (state: Readonly<T>) => S): readonly [S, (nextState: SetStateAction<T>) => void];
+  (): readonly [ReadonlySnapshot<T>, (nextState: SetStateAction<T>) => void];
+  <S>(selector: (state: ReadonlySnapshot<T>) => S): readonly [S, (nextState: SetStateAction<T>) => void];
   writeOnly: () => (nextState: SetStateAction<T>) => void;
   readOnly: {
-    (): Readonly<T>;
-    <S>(selector: (state: Readonly<T>) => S): S;
+    (): ReadonlySnapshot<T>;
+    <S>(selector: (state: ReadonlySnapshot<T>) => S): S;
   };
 };
 
@@ -19,11 +20,11 @@ export type UseState<T> = {
  * React hook returned by `create()` for reducer state.
  */
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): readonly [Readonly<T>, (action: Action) => void];
-  <S>(selector: (state: Readonly<T>) => S): readonly [S, (action: Action) => void];
+  (): readonly [ReadonlySnapshot<T>, (action: Action) => void];
+  <S>(selector: (state: ReadonlySnapshot<T>) => S): readonly [S, (action: Action) => void];
   writeOnly: () => (action: Action) => void;
   readOnly: {
-    (): Readonly<T>;
-    <S>(selector: (state: Readonly<T>) => S): S;
+    (): ReadonlySnapshot<T>;
+    <S>(selector: (state: ReadonlySnapshot<T>) => S): S;
   };
 };

--- a/packages/state/src/core/React/types.ts
+++ b/packages/state/src/core/React/types.ts
@@ -6,12 +6,12 @@ import type { ReducerAction } from '../../types/ReduceFn.js';
  * React hook returned by `create()` for plain state.
  */
 export type UseState<T> = {
-  (): readonly [T, (nextState: SetStateAction<T>) => void];
-  <S>(selector: (state: T) => S): readonly [S, (nextState: SetStateAction<T>) => void];
+  (): readonly [Readonly<T>, (nextState: SetStateAction<T>) => void];
+  <S>(selector: (state: Readonly<T>) => S): readonly [S, (nextState: SetStateAction<T>) => void];
   writeOnly: () => (nextState: SetStateAction<T>) => void;
   readOnly: {
-    (): T;
-    <S>(selector: (state: T) => S): S;
+    (): Readonly<T>;
+    <S>(selector: (state: Readonly<T>) => S): S;
   };
 };
 
@@ -19,11 +19,11 @@ export type UseState<T> = {
  * React hook returned by `create()` for reducer state.
  */
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): readonly [T, (action: Action) => void];
-  <S>(selector: (state: T) => S): readonly [S, (action: Action) => void];
+  (): readonly [Readonly<T>, (action: Action) => void];
+  <S>(selector: (state: Readonly<T>) => S): readonly [S, (action: Action) => void];
   writeOnly: () => (action: Action) => void;
   readOnly: {
-    (): T;
-    <S>(selector: (state: T) => S): S;
+    (): Readonly<T>;
+    <S>(selector: (state: Readonly<T>) => S): S;
   };
 };

--- a/packages/state/src/core/Solid/createUseAccessor.ts
+++ b/packages/state/src/core/Solid/createUseAccessor.ts
@@ -5,7 +5,7 @@ import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
 import { shallow } from '../shared/shallow.js';
-import type { ActionWriter, Selector, StateWriter } from './types.js';
+import type { Selector } from './types.js';
 
 function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
   if (!getOwner()) {
@@ -15,7 +15,7 @@ function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
   }
 
   const [selection, setSelection] = createSignal(
-    selector(store.getState() as T),
+    selector(store.getState()),
     { equals: Object.is },
   );
   const unsubscribe = store.subscribeSelector(
@@ -36,7 +36,7 @@ export function createUseAccessor<T, Action extends ReducerAction>(store: Store<
 
   return Object.assign(
     <S = T>(selector?: Selector<T, S>) => {
-      const select = (selector ?? identity<T>) as Selector<T, S>;
+      const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
       const state = createSelection(store, select);
 
       if (isReduce) {
@@ -48,14 +48,14 @@ export function createUseAccessor<T, Action extends ReducerAction>(store: Store<
 
       return {
         state,
-        setState: write as StateWriter<T>,
+        setState: write,
       } as const;
     },
     {
       writeOnly: () => (isReduce ? dispatch : write),
       readOnly: <S = T>(selector?: Selector<T, S>): S => {
-        const select = (selector ?? identity<T>) as Selector<T, S>;
-        return select(store.getState() as T);
+        const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
+        return select(store.getState());
       },
     },
   );

--- a/packages/state/src/core/Solid/createUseAccessor.ts
+++ b/packages/state/src/core/Solid/createUseAccessor.ts
@@ -4,6 +4,7 @@ import { createSignal, getOwner, onCleanup } from 'solid-js';
 import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
+import { readonlySnapshot, type ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 import { shallow } from '../shared/shallow.js';
 import type { Selector } from './types.js';
 
@@ -15,11 +16,11 @@ function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
   }
 
   const [selection, setSelection] = createSignal(
-    selector(store.getState()),
+    selector(readonlySnapshot(store.getState())),
     { equals: Object.is },
   );
   const unsubscribe = store.subscribeSelector(
-    selector,
+    (state) => selector(readonlySnapshot(state)),
     (nextSelection) => {
       setSelection(() => nextSelection);
     },
@@ -36,7 +37,7 @@ export function createUseAccessor<T, Action extends ReducerAction>(store: Store<
 
   return Object.assign(
     <S = T>(selector?: Selector<T, S>) => {
-      const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
+      const select = (selector ?? identity<ReadonlySnapshot<T>>) as Selector<T, S>;
       const state = createSelection(store, select);
 
       if (isReduce) {
@@ -54,8 +55,8 @@ export function createUseAccessor<T, Action extends ReducerAction>(store: Store<
     {
       writeOnly: () => (isReduce ? dispatch : write),
       readOnly: <S = T>(selector?: Selector<T, S>): S => {
-        const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
-        return select(store.getState());
+        const select = (selector ?? identity<ReadonlySnapshot<T>>) as Selector<T, S>;
+        return select(readonlySnapshot(store.getState()));
       },
     },
   );

--- a/packages/state/src/core/Solid/index.ts
+++ b/packages/state/src/core/Solid/index.ts
@@ -19,8 +19,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a function that must be called inside a reactive owner (component
  * or `createRoot()`). Without a selector, `state` is an `Accessor` of a
- * read-only snapshot: object state is `Readonly<T>`, while callable state keeps
- * its call signature. Selectors and `.readOnly()` use the same snapshot.
+ * read-only snapshot: object state is `Readonly<T>`, while callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Solid/index.ts
+++ b/packages/state/src/core/Solid/index.ts
@@ -18,9 +18,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Create a Solid accessor from plain state or a reducer.
  *
  * Returns a function that must be called inside a reactive owner (component
- * or `createRoot()`). Returns `{ state, setState }` or `{ state, dispatch }`.
- * Selectors and `.readOnly()` receive `Readonly<T>` snapshots; use `.writeOnly()`
- * for lifecycle-independent updates.
+ * or `createRoot()`). Without a selector, `state` is an `Accessor` of a
+ * read-only snapshot: object state is `Readonly<T>`, while callable state keeps
+ * its call signature. Selectors and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Solid/index.ts
+++ b/packages/state/src/core/Solid/index.ts
@@ -19,7 +19,8 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a function that must be called inside a reactive owner (component
  * or `createRoot()`). Returns `{ state, setState }` or `{ state, dispatch }`.
- * Use `.writeOnly()` or `.readOnly()` for lifecycle-independent access.
+ * Selectors and `.readOnly()` receive `Readonly<T>` snapshots; use `.writeOnly()`
+ * for lifecycle-independent updates.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Solid/types.ts
+++ b/packages/state/src/core/Solid/types.ts
@@ -3,7 +3,7 @@ import type { Accessor } from 'solid-js';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
 
-export type Selector<T, S> = (state: T) => S;
+export type Selector<T, S> = (state: Readonly<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
@@ -19,21 +19,21 @@ export type SolidReducerResult<S, Action> = Readonly<{
 }>;
 
 export type UseState<T> = {
-  (): SolidStateResult<T, T>;
+  (): SolidStateResult<Readonly<T>, T>;
   <S>(selector: Selector<T, S>): SolidStateResult<S, T>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };
 
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): SolidReducerResult<T, Action>;
+  (): SolidReducerResult<Readonly<T>, Action>;
   <S>(selector: Selector<T, S>): SolidReducerResult<S, Action>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };

--- a/packages/state/src/core/Solid/types.ts
+++ b/packages/state/src/core/Solid/types.ts
@@ -2,8 +2,9 @@ import type { Store } from '@ilokesto/store';
 import type { Accessor } from 'solid-js';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import type { ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 
-export type Selector<T, S> = (state: Readonly<T>) => S;
+export type Selector<T, S> = (state: ReadonlySnapshot<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
@@ -19,21 +20,21 @@ export type SolidReducerResult<S, Action> = Readonly<{
 }>;
 
 export type UseState<T> = {
-  (): SolidStateResult<Readonly<T>, T>;
+  (): SolidStateResult<ReadonlySnapshot<T>, T>;
   <S>(selector: Selector<T, S>): SolidStateResult<S, T>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };
 
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): SolidReducerResult<Readonly<T>, Action>;
+  (): SolidReducerResult<ReadonlySnapshot<T>, Action>;
   <S>(selector: Selector<T, S>): SolidReducerResult<S, Action>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };

--- a/packages/state/src/core/Svelte/createStore.ts
+++ b/packages/state/src/core/Svelte/createStore.ts
@@ -5,14 +5,19 @@ import type { Readable, Subscriber, Unsubscriber, Updater } from 'svelte/store';
 import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
+import { readonlySnapshot, type ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 import { shallow } from '../shared/shallow.js';
 import type { Selector, UseReducer, UseState } from './types.js';
 
 function createReadable<T, S>(store: Store<T>, selector: Selector<T, S>): Readable<S> {
   return {
     subscribe(run: Subscriber<S>): Unsubscriber {
-      const initialSelection = selector(store.getState());
-      const unsubscribe = store.subscribeSelector(selector, run, shallow);
+      const initialSelection = selector(readonlySnapshot(store.getState()));
+      const unsubscribe = store.subscribeSelector(
+        (state) => selector(readonlySnapshot(state)),
+        run,
+        shallow,
+      );
 
       run(initialSelection);
       return unsubscribe;
@@ -23,17 +28,21 @@ function createReadable<T, S>(store: Store<T>, selector: Selector<T, S>): Readab
 export function createStore<T, Action extends ReducerAction>(store: Store<T>, isReduce: boolean) {
   const write = store.setState.bind(store);
   const dispatch = createDispatch<T, Action>(store);
-  const subscribe = (run: Subscriber<Readonly<T>>): Unsubscriber => {
-    const initialState = store.getState();
-    const unsubscribe = store.subscribeSelector(identity<Readonly<T>>, run, shallow);
+  const subscribe = (run: Subscriber<ReadonlySnapshot<T>>): Unsubscriber => {
+    const initialState = readonlySnapshot(store.getState());
+    const unsubscribe = store.subscribeSelector(
+      (state) => readonlySnapshot(state),
+      run,
+      shallow,
+    );
 
     run(initialState);
     return unsubscribe;
   };
   const select = <S>(selector: Selector<T, S>) => createReadable(store, selector);
   const readOnly = <S = T>(selector?: Selector<T, S>): S => {
-    const currentSelector = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
-    return currentSelector(store.getState());
+    const currentSelector = (selector ?? identity<ReadonlySnapshot<T>>) as Selector<T, S>;
+    return currentSelector(readonlySnapshot(store.getState()));
   };
 
   if (isReduce) {

--- a/packages/state/src/core/Svelte/createStore.ts
+++ b/packages/state/src/core/Svelte/createStore.ts
@@ -6,17 +6,12 @@ import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
 import { shallow } from '../shared/shallow.js';
-import type {
-  ActionWriter,
-  Selector,
-  UseReducer,
-  UseState,
-} from './types.js';
+import type { Selector, UseReducer, UseState } from './types.js';
 
 function createReadable<T, S>(store: Store<T>, selector: Selector<T, S>): Readable<S> {
   return {
     subscribe(run: Subscriber<S>): Unsubscriber {
-      const initialSelection = selector(store.getState() as T);
+      const initialSelection = selector(store.getState());
       const unsubscribe = store.subscribeSelector(selector, run, shallow);
 
       run(initialSelection);
@@ -28,17 +23,17 @@ function createReadable<T, S>(store: Store<T>, selector: Selector<T, S>): Readab
 export function createStore<T, Action extends ReducerAction>(store: Store<T>, isReduce: boolean) {
   const write = store.setState.bind(store);
   const dispatch = createDispatch<T, Action>(store);
-  const subscribe = (run: Subscriber<T>): Unsubscriber => {
-    const initialState = store.getState() as T;
-    const unsubscribe = store.subscribeSelector(identity<T>, run, shallow);
+  const subscribe = (run: Subscriber<Readonly<T>>): Unsubscriber => {
+    const initialState = store.getState();
+    const unsubscribe = store.subscribeSelector(identity<Readonly<T>>, run, shallow);
 
     run(initialState);
     return unsubscribe;
   };
   const select = <S>(selector: Selector<T, S>) => createReadable(store, selector);
   const readOnly = <S = T>(selector?: Selector<T, S>): S => {
-    const currentSelector = (selector ?? identity<T>) as Selector<T, S>;
-    return currentSelector(store.getState() as T);
+    const currentSelector = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
+    return currentSelector(store.getState());
   };
 
   if (isReduce) {

--- a/packages/state/src/core/Svelte/index.ts
+++ b/packages/state/src/core/Svelte/index.ts
@@ -18,7 +18,8 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Create a Svelte store from plain state or a reducer.
  *
  * Returns a writable Svelte store with `subscribe`, `set`, `update`,
- * `select`, `writeOnly()`, and `readOnly()`. For reducer state, returns a
+ * `select`, `writeOnly()`, and `readOnly()`. Selectors, subscriptions, and
+ * `.readOnly()` receive `Readonly<T>` snapshots. For reducer state, returns a
  * readable store with `dispatch` instead of `set`/`update`.
  */
 export function create<T, Action extends ReducerAction>(

--- a/packages/state/src/core/Svelte/index.ts
+++ b/packages/state/src/core/Svelte/index.ts
@@ -19,9 +19,10 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a writable Svelte store with `subscribe`, `set`, `update`,
  * `select`, `writeOnly()`, and `readOnly()`. Full-store subscriptions,
- * selectors, and `.readOnly()` receive read-only snapshots: object state is
- * `Readonly<T>`, while callable state keeps its call signature. For reducer
- * state, returns a readable store with `dispatch` instead of `set`/`update`.
+ * selectors, and `.readOnly()` receive snapshots: object state is `Readonly<T>`,
+ * while callable state remains exact `T`, including its declared own-property
+ * modifiers. For reducer state, returns a readable store with `dispatch`
+ * instead of `set`/`update`.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Svelte/index.ts
+++ b/packages/state/src/core/Svelte/index.ts
@@ -18,9 +18,10 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Create a Svelte store from plain state or a reducer.
  *
  * Returns a writable Svelte store with `subscribe`, `set`, `update`,
- * `select`, `writeOnly()`, and `readOnly()`. Selectors, subscriptions, and
- * `.readOnly()` receive `Readonly<T>` snapshots. For reducer state, returns a
- * readable store with `dispatch` instead of `set`/`update`.
+ * `select`, `writeOnly()`, and `readOnly()`. Full-store subscriptions,
+ * selectors, and `.readOnly()` receive read-only snapshots: object state is
+ * `Readonly<T>`, while callable state keeps its call signature. For reducer
+ * state, returns a readable store with `dispatch` instead of `set`/`update`.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Svelte/types.ts
+++ b/packages/state/src/core/Svelte/types.ts
@@ -3,29 +3,29 @@ import type { Readable, Writable } from 'svelte/store';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
 
-export type Selector<T, S> = (state: T) => S;
+export type Selector<T, S> = (state: Readonly<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
 
 export type SvelteReadable<S> = Readable<S>;
 
-export type SvelteStateStore<T> = Writable<T> & {
+export type SvelteStateStore<T> = Omit<Writable<T>, 'subscribe'> & Readable<Readonly<T>> & {
   setState: StateWriter<T>;
   select: <S>(selector: Selector<T, S>) => SvelteReadable<S>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };
 
-export type SvelteReducerStore<T, Action extends ReducerAction> = Readable<T> & {
+export type SvelteReducerStore<T, Action extends ReducerAction> = Readable<Readonly<T>> & {
   dispatch: ActionWriter<Action>;
   select: <S>(selector: Selector<T, S>) => SvelteReadable<S>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };

--- a/packages/state/src/core/Svelte/types.ts
+++ b/packages/state/src/core/Svelte/types.ts
@@ -2,30 +2,31 @@ import type { Store } from '@ilokesto/store';
 import type { Readable, Writable } from 'svelte/store';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import type { ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 
-export type Selector<T, S> = (state: Readonly<T>) => S;
+export type Selector<T, S> = (state: ReadonlySnapshot<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
 
 export type SvelteReadable<S> = Readable<S>;
 
-export type SvelteStateStore<T> = Omit<Writable<T>, 'subscribe'> & Readable<Readonly<T>> & {
+export type SvelteStateStore<T> = Omit<Writable<T>, 'subscribe'> & Readable<ReadonlySnapshot<T>> & {
   setState: StateWriter<T>;
   select: <S>(selector: Selector<T, S>) => SvelteReadable<S>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };
 
-export type SvelteReducerStore<T, Action extends ReducerAction> = Readable<Readonly<T>> & {
+export type SvelteReducerStore<T, Action extends ReducerAction> = Readable<ReadonlySnapshot<T>> & {
   dispatch: ActionWriter<Action>;
   select: <S>(selector: Selector<T, S>) => SvelteReadable<S>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };

--- a/packages/state/src/core/Vue/createUseComposable.ts
+++ b/packages/state/src/core/Vue/createUseComposable.ts
@@ -4,6 +4,7 @@ import { computed, getCurrentScope, onScopeDispose, shallowRef } from 'vue';
 import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
+import { readonlySnapshot, type ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 import { shallow } from '../shared/shallow.js';
 import type { Selector } from './types.js';
 
@@ -14,10 +15,10 @@ function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
     );
   }
 
-  const snapshot = shallowRef(selector(store.getState()));
+  const snapshot = shallowRef(selector(readonlySnapshot(store.getState())));
 
   const unsubscribe = store.subscribeSelector(
-    selector,
+    (state) => selector(readonlySnapshot(state)),
     (nextSelection) => {
       snapshot.value = nextSelection as typeof snapshot.value;
     },
@@ -35,7 +36,7 @@ export function createUseComposable<T, Action extends ReducerAction>(store: Stor
 
   return Object.assign(
     <S = T>(selector?: Selector<T, S>) => {
-      const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
+      const select = (selector ?? identity<ReadonlySnapshot<T>>) as Selector<T, S>;
       const state = createSelection(store, select);
 
       if (isReduce) {
@@ -53,8 +54,8 @@ export function createUseComposable<T, Action extends ReducerAction>(store: Stor
     {
       writeOnly: () => (isReduce ? dispatch : write),
       readOnly: <S = T>(selector?: Selector<T, S>): S => {
-        const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
-        return select(store.getState());
+        const select = (selector ?? identity<ReadonlySnapshot<T>>) as Selector<T, S>;
+        return select(readonlySnapshot(store.getState()));
       },
     },
   );

--- a/packages/state/src/core/Vue/createUseComposable.ts
+++ b/packages/state/src/core/Vue/createUseComposable.ts
@@ -5,7 +5,7 @@ import type { ReducerAction } from '../../types/ReduceFn.js';
 import { createDispatch } from '../shared/createDispatch.js';
 import { identity } from '../shared/identity.js';
 import { shallow } from '../shared/shallow.js';
-import type { ActionWriter, Selector, StateWriter } from './types.js';
+import type { Selector } from './types.js';
 
 function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
   if (!getCurrentScope()) {
@@ -14,7 +14,7 @@ function createSelection<T, S>(store: Store<T>, selector: Selector<T, S>) {
     );
   }
 
-  const snapshot = shallowRef(selector(store.getState() as T));
+  const snapshot = shallowRef(selector(store.getState()));
 
   const unsubscribe = store.subscribeSelector(
     selector,
@@ -35,7 +35,7 @@ export function createUseComposable<T, Action extends ReducerAction>(store: Stor
 
   return Object.assign(
     <S = T>(selector?: Selector<T, S>) => {
-      const select = (selector ?? identity<T>) as Selector<T, S>;
+      const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
       const state = createSelection(store, select);
 
       if (isReduce) {
@@ -47,14 +47,14 @@ export function createUseComposable<T, Action extends ReducerAction>(store: Stor
 
       return {
         state,
-        setState: write as StateWriter<T>,
+        setState: write,
       } as const;
     },
     {
       writeOnly: () => (isReduce ? dispatch : write),
       readOnly: <S = T>(selector?: Selector<T, S>): S => {
-        const select = (selector ?? identity<T>) as Selector<T, S>;
-        return select(store.getState() as T);
+        const select = (selector ?? identity<Readonly<T>>) as Selector<T, S>;
+        return select(store.getState());
       },
     },
   );

--- a/packages/state/src/core/Vue/index.ts
+++ b/packages/state/src/core/Vue/index.ts
@@ -19,7 +19,8 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a function that must be called inside `setup()` or an active
  * `effectScope()`. Returns `{ state, setState }` or `{ state, dispatch }`.
- * Use `.writeOnly()` or `.readOnly()` for lifecycle-independent access.
+ * Selectors and `.readOnly()` receive `Readonly<T>` snapshots; use `.writeOnly()`
+ * for lifecycle-independent updates.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Vue/index.ts
+++ b/packages/state/src/core/Vue/index.ts
@@ -19,8 +19,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  *
  * Returns a function that must be called inside `setup()` or an active
  * `effectScope()`. Without a selector, `state` is a `ComputedRef` of a
- * read-only snapshot: object state is `Readonly<T>`, while callable state keeps
- * its call signature. Selectors and `.readOnly()` use the same snapshot.
+ * read-only snapshot: object state is `Readonly<T>`, while callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Vue/index.ts
+++ b/packages/state/src/core/Vue/index.ts
@@ -18,9 +18,9 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * Create a Vue composable from plain state or a reducer.
  *
  * Returns a function that must be called inside `setup()` or an active
- * `effectScope()`. Returns `{ state, setState }` or `{ state, dispatch }`.
- * Selectors and `.readOnly()` receive `Readonly<T>` snapshots; use `.writeOnly()`
- * for lifecycle-independent updates.
+ * `effectScope()`. Without a selector, `state` is a `ComputedRef` of a
+ * read-only snapshot: object state is `Readonly<T>`, while callable state keeps
+ * its call signature. Selectors and `.readOnly()` use the same snapshot.
  */
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,

--- a/packages/state/src/core/Vue/types.ts
+++ b/packages/state/src/core/Vue/types.ts
@@ -2,8 +2,9 @@ import type { Store } from '@ilokesto/store';
 import type { ComputedRef } from 'vue';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
+import type { ReadonlySnapshot } from '../shared/readonlySnapshot.js';
 
-export type Selector<T, S> = (state: Readonly<T>) => S;
+export type Selector<T, S> = (state: ReadonlySnapshot<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
@@ -19,21 +20,21 @@ export type VueReducerResult<S, Action> = Readonly<{
 }>;
 
 export type UseState<T> = {
-  (): VueStateResult<Readonly<T>, T>;
+  (): VueStateResult<ReadonlySnapshot<T>, T>;
   <S>(selector: Selector<T, S>): VueStateResult<S, T>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };
 
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): VueReducerResult<Readonly<T>, Action>;
+  (): VueReducerResult<ReadonlySnapshot<T>, Action>;
   <S>(selector: Selector<T, S>): VueReducerResult<S, Action>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): Readonly<T>;
+    (): ReadonlySnapshot<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };

--- a/packages/state/src/core/Vue/types.ts
+++ b/packages/state/src/core/Vue/types.ts
@@ -3,7 +3,7 @@ import type { ComputedRef } from 'vue';
 
 import type { ReducerAction } from '../../types/ReduceFn.js';
 
-export type Selector<T, S> = (state: T) => S;
+export type Selector<T, S> = (state: Readonly<T>) => S;
 export type SetStateAction<T> = Parameters<Store<T>['setState']>[0];
 export type StateWriter<T> = (nextState: SetStateAction<T>) => void;
 export type ActionWriter<Action> = (action: Action) => void;
@@ -19,21 +19,21 @@ export type VueReducerResult<S, Action> = Readonly<{
 }>;
 
 export type UseState<T> = {
-  (): VueStateResult<T, T>;
+  (): VueStateResult<Readonly<T>, T>;
   <S>(selector: Selector<T, S>): VueStateResult<S, T>;
   writeOnly: () => StateWriter<T>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };
 
 export type UseReducer<T, Action extends ReducerAction> = {
-  (): VueReducerResult<T, Action>;
+  (): VueReducerResult<Readonly<T>, Action>;
   <S>(selector: Selector<T, S>): VueReducerResult<S, Action>;
   writeOnly: () => ActionWriter<Action>;
   readOnly: {
-    (): T;
+    (): Readonly<T>;
     <S>(selector: Selector<T, S>): S;
   };
 };

--- a/packages/state/src/core/shared/readonlySnapshot.ts
+++ b/packages/state/src/core/shared/readonlySnapshot.ts
@@ -1,15 +1,15 @@
 /**
- * A read-only state snapshot that retains a callable state's call signature.
+ * A state snapshot that preserves callable types exactly.
  *
- * `Readonly<T>` maps callable types to their own properties and erases their
- * call signature. Intersecting the reconstructed signature with `Readonly<T>`
- * keeps callable own properties read-only without freezing runtime values.
+ * `Readonly<T>` erases call signatures. TypeScript cannot map arbitrary
+ * generic or overloaded call signatures while preserving them, so callable
+ * state remains `T`, including its declared own-property modifiers.
  */
-export type ReadonlySnapshot<T> = T extends (
-  ...arguments_: infer Arguments
-) => infer Result
-  ? ((...arguments_: Arguments) => Result) & Readonly<T>
-  : Readonly<T>;
+type FunctionLike =
+  | ((...arguments_: never[]) => unknown)
+  | (abstract new (...arguments_: never[]) => unknown);
+
+export type ReadonlySnapshot<T> = T extends FunctionLike ? T : Readonly<T>;
 
 export function readonlySnapshot<T>(state: Readonly<T>): ReadonlySnapshot<T> {
   return state as ReadonlySnapshot<T>;

--- a/packages/state/src/core/shared/readonlySnapshot.ts
+++ b/packages/state/src/core/shared/readonlySnapshot.ts
@@ -1,0 +1,16 @@
+/**
+ * A read-only state snapshot that retains a callable state's call signature.
+ *
+ * `Readonly<T>` maps callable types to their own properties and erases their
+ * call signature. Intersecting the reconstructed signature with `Readonly<T>`
+ * keeps callable own properties read-only without freezing runtime values.
+ */
+export type ReadonlySnapshot<T> = T extends (
+  ...arguments_: infer Arguments
+) => infer Result
+  ? ((...arguments_: Arguments) => Result) & Readonly<T>
+  : Readonly<T>;
+
+export function readonlySnapshot<T>(state: Readonly<T>): ReadonlySnapshot<T> {
+  return state as ReadonlySnapshot<T>;
+}

--- a/packages/state/test/adapter-readonly-types.test.ts
+++ b/packages/state/test/adapter-readonly-types.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+import { compileTypeFixture } from './helpers/compileTypeFixture';
+
+type InvalidFixtureContract = Readonly<{
+  diagnosticCount: number;
+  expectedMarkers: readonly string[];
+}>;
+
+const fixtureRoot = join(import.meta.dir, 'fixtures', 'adapter-readonly-types');
+const invalidFixtureContract: InvalidFixtureContract = {
+  diagnosticCount: 10,
+  expectedMarkers: [
+    'angularSelectorMutation',
+    'angularReadResultMutation',
+    'reactSelectorMutation',
+    'reactReadResultMutation',
+    'solidSelectorMutation',
+    'solidReadResultMutation',
+    'svelteSelectorMutation',
+    'svelteReadResultMutation',
+    'vueSelectorMutation',
+    'vueReadResultMutation',
+  ],
+};
+
+function compileAdapterFixture(fixture: string) {
+  return compileTypeFixture(fixture, { fixtureRoot });
+}
+
+function expectReadonlyMutationErrors(fixture: string): void {
+  const result = compileAdapterFixture(fixture);
+  const diagnosticLines = result.diagnostics.split('\n').filter((line) => line.includes('error TS'));
+
+  expect(result.success).toBeFalse();
+  expect(result.exitCode).toBe(1);
+  expect(diagnosticLines).toHaveLength(invalidFixtureContract.diagnosticCount);
+  for (const marker of invalidFixtureContract.expectedMarkers) {
+    expect(result.diagnostics).toContain(marker);
+  }
+}
+
+test('Given source adapter contracts, when valid selectors and lifecycle-free reads compile, then every adapter accepts them', () => {
+  // Given / When
+  const result = compileAdapterFixture('source-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
+test('Given source adapter contracts, when selectors or lifecycle-free reads mutate state, then every adapter rejects them', () => {
+  // Given / When / Then
+  expectReadonlyMutationErrors('source-invalid');
+});
+
+test('Given generated adapter declarations, when valid public-subpath consumers compile, then every adapter accepts them', () => {
+  // Given / When
+  const result = compileAdapterFixture('dist-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
+test('Given generated adapter declarations, when public-subpath selectors or lifecycle-free reads mutate state, then every adapter rejects them', () => {
+  // Given / When / Then
+  expectReadonlyMutationErrors('dist-invalid');
+});

--- a/packages/state/test/adapter-readonly-types.test.ts
+++ b/packages/state/test/adapter-readonly-types.test.ts
@@ -66,6 +66,16 @@ test('Given source adapter contracts, when callable state is read, selected, or 
   expect(result.diagnostics).toBe('');
 });
 
+test('Given source adapter contracts, when generic and overloaded callable state is read, selected, or observed without a selector, then every adapter preserves exact signatures', () => {
+  // Given / When
+  const result = compileAdapterFixture('source-callable-signatures-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
 test('Given source adapter contracts, when selectors or lifecycle-free reads mutate state, then every adapter rejects them', () => {
   // Given / When / Then
   expectReadonlyMutationErrors('source-invalid');
@@ -84,6 +94,16 @@ test('Given generated adapter declarations, when valid public-subpath consumers 
 test('Given generated adapter declarations, when callable public-subpath state is read, selected, or observed without a selector, then every adapter preserves its call signature', () => {
   // Given / When
   const result = compileAdapterFixture('dist-callable-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
+test('Given generated adapter declarations, when generic and overloaded callable public-subpath state is read, selected, or observed without a selector, then every adapter preserves exact signatures', () => {
+  // Given / When
+  const result = compileAdapterFixture('dist-callable-signatures-valid');
 
   // Then
   expect(result.success, result.diagnostics).toBeTrue();

--- a/packages/state/test/adapter-readonly-types.test.ts
+++ b/packages/state/test/adapter-readonly-types.test.ts
@@ -10,18 +10,23 @@ type InvalidFixtureContract = Readonly<{
 
 const fixtureRoot = join(import.meta.dir, 'fixtures', 'adapter-readonly-types');
 const invalidFixtureContract: InvalidFixtureContract = {
-  diagnosticCount: 10,
+  diagnosticCount: 15,
   expectedMarkers: [
     'angularSelectorMutation',
     'angularReadResultMutation',
+    'angularFullResultMutation',
     'reactSelectorMutation',
     'reactReadResultMutation',
+    'reactFullResultMutation',
     'solidSelectorMutation',
     'solidReadResultMutation',
+    'solidFullResultMutation',
     'svelteSelectorMutation',
     'svelteReadResultMutation',
+    'svelteFullResultMutation',
     'vueSelectorMutation',
     'vueReadResultMutation',
+    'vueFullResultMutation',
   ],
 };
 
@@ -51,6 +56,16 @@ test('Given source adapter contracts, when valid selectors and lifecycle-free re
   expect(result.diagnostics).toBe('');
 });
 
+test('Given source adapter contracts, when callable state is read, selected, or observed without a selector, then every adapter preserves its call signature', () => {
+  // Given / When
+  const result = compileAdapterFixture('source-callable-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
 test('Given source adapter contracts, when selectors or lifecycle-free reads mutate state, then every adapter rejects them', () => {
   // Given / When / Then
   expectReadonlyMutationErrors('source-invalid');
@@ -59,6 +74,16 @@ test('Given source adapter contracts, when selectors or lifecycle-free reads mut
 test('Given generated adapter declarations, when valid public-subpath consumers compile, then every adapter accepts them', () => {
   // Given / When
   const result = compileAdapterFixture('dist-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
+test('Given generated adapter declarations, when callable public-subpath state is read, selected, or observed without a selector, then every adapter preserves its call signature', () => {
+  // Given / When
+  const result = compileAdapterFixture('dist-callable-valid');
 
   // Then
   expect(result.success, result.diagnostics).toBeTrue();

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-callable-signatures-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-callable-signatures-valid/index.ts
@@ -1,0 +1,67 @@
+import { create as createAngular } from '@ilokesto/state/angular';
+import { create as createReact } from '@ilokesto/state/react';
+import { create as createSolid } from '@ilokesto/state/solid';
+import { create as createSvelte } from '@ilokesto/state/svelte';
+import { create as createVue } from '@ilokesto/state/vue';
+
+type GenericIdentity = <Value>(value: Value) => Value;
+type OverloadedState = {
+  (value: number): number;
+  (value: string): string;
+  label: string;
+};
+
+declare const genericIdentity: GenericIdentity;
+declare const overloadedState: OverloadedState;
+
+const angularGeneric = createAngular<GenericIdentity>(genericIdentity);
+angularGeneric.readOnly()('angular').toUpperCase();
+angularGeneric((state) => state(1)).state().toFixed();
+angularGeneric().state()({ angular: true }).angular.valueOf();
+const angularOverloaded = createAngular<OverloadedState>(overloadedState);
+angularOverloaded.readOnly()('angular').toUpperCase();
+angularOverloaded((state) => state(1)).state().toFixed();
+angularOverloaded().state()('angular').toUpperCase();
+angularOverloaded().state().label = 'angular';
+
+const reactGeneric = createReact<GenericIdentity>(genericIdentity);
+reactGeneric.readOnly()('react').toUpperCase();
+reactGeneric((state) => state(1))[0].toFixed();
+reactGeneric()[0]({ react: true }).react.valueOf();
+const reactOverloaded = createReact<OverloadedState>(overloadedState);
+reactOverloaded.readOnly()('react').toUpperCase();
+reactOverloaded((state) => state(1))[0].toFixed();
+reactOverloaded()[0]('react').toUpperCase();
+reactOverloaded()[0].label = 'react';
+
+const solidGeneric = createSolid<GenericIdentity>(genericIdentity);
+solidGeneric.readOnly()('solid').toUpperCase();
+solidGeneric((state) => state(1)).state().toFixed();
+solidGeneric().state()({ solid: true }).solid.valueOf();
+const solidOverloaded = createSolid<OverloadedState>(overloadedState);
+solidOverloaded.readOnly()('solid').toUpperCase();
+solidOverloaded((state) => state(1)).state().toFixed();
+solidOverloaded().state()('solid').toUpperCase();
+solidOverloaded().state().label = 'solid';
+
+const svelteGeneric = createSvelte<GenericIdentity>(genericIdentity);
+svelteGeneric.readOnly()('svelte').toUpperCase();
+svelteGeneric.select((state) => state(1)).subscribe((value) => value.toFixed());
+svelteGeneric.subscribe((state) => state({ svelte: true }).svelte.valueOf());
+const svelteOverloaded = createSvelte<OverloadedState>(overloadedState);
+svelteOverloaded.readOnly()('svelte').toUpperCase();
+svelteOverloaded.select((state) => state(1)).subscribe((value) => value.toFixed());
+svelteOverloaded.subscribe((state) => {
+  state('svelte').toUpperCase();
+  state.label = 'svelte';
+});
+
+const vueGeneric = createVue<GenericIdentity>(genericIdentity);
+vueGeneric.readOnly()('vue').toUpperCase();
+vueGeneric((state) => state(1)).state.value.toFixed();
+vueGeneric().state.value({ vue: true }).vue.valueOf();
+const vueOverloaded = createVue<OverloadedState>(overloadedState);
+vueOverloaded.readOnly()('vue').toUpperCase();
+vueOverloaded((state) => state(1)).state.value.toFixed();
+vueOverloaded().state.value('vue').toUpperCase();
+vueOverloaded().state.value.label = 'vue';

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-callable-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-callable-valid/index.ts
@@ -1,0 +1,40 @@
+import { create as createAngular } from '@ilokesto/state/angular';
+import { create as createReact } from '@ilokesto/state/react';
+import { create as createSolid } from '@ilokesto/state/solid';
+import { create as createSvelte } from '@ilokesto/state/svelte';
+import { create as createVue } from '@ilokesto/state/vue';
+
+type CallableState = {
+  (): number;
+  label: string;
+};
+
+declare const initialState: CallableState;
+
+const angular = createAngular<CallableState>(initialState);
+angular.readOnly()().toFixed();
+angular((state) => state()).state().toFixed();
+angular().state()().toFixed();
+
+const react = createReact<CallableState>(initialState);
+react.readOnly()().toFixed();
+react((state) => state())[0].toFixed();
+react()[0]().toFixed();
+
+const solid = createSolid<CallableState>(initialState);
+solid.readOnly()().toFixed();
+solid((state) => state()).state().toFixed();
+solid().state()().toFixed();
+
+const svelte = createSvelte<CallableState>(initialState);
+svelte.readOnly()().toFixed();
+svelte.select((state) => state()).subscribe((value) => value.toFixed());
+svelte.subscribe((state) => {
+  state().toFixed();
+  state.label.toUpperCase();
+});
+
+const vue = createVue<CallableState>(initialState);
+vue.readOnly()().toFixed();
+vue((state) => state()).state.value.toFixed();
+vue().state.value().toFixed();

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-invalid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-invalid/index.ts
@@ -5,27 +5,37 @@ import { create as createSvelte } from '@ilokesto/state/svelte';
 import { create as createVue } from '@ilokesto/state/vue';
 
 type State = {
+  angularFullResultMutation: number;
   angularReadResultMutation: number;
   angularSelectorMutation: number;
+  reactFullResultMutation: number;
   reactReadResultMutation: number;
   reactSelectorMutation: number;
+  solidFullResultMutation: number;
   solidReadResultMutation: number;
   solidSelectorMutation: number;
+  svelteFullResultMutation: number;
   svelteReadResultMutation: number;
   svelteSelectorMutation: number;
+  vueFullResultMutation: number;
   vueReadResultMutation: number;
   vueSelectorMutation: number;
 };
 
 const initialState: State = {
+  angularFullResultMutation: 0,
   angularReadResultMutation: 0,
   angularSelectorMutation: 0,
+  reactFullResultMutation: 0,
   reactReadResultMutation: 0,
   reactSelectorMutation: 0,
+  solidFullResultMutation: 0,
   solidReadResultMutation: 0,
   solidSelectorMutation: 0,
+  svelteFullResultMutation: 0,
   svelteReadResultMutation: 0,
   svelteSelectorMutation: 0,
+  vueFullResultMutation: 0,
   vueReadResultMutation: 0,
   vueSelectorMutation: 0,
 };
@@ -36,6 +46,7 @@ angular((state) => {
   return state.angularSelectorMutation;
 });
 angular.readOnly().angularReadResultMutation = 1;
+angular().state().angularFullResultMutation = 1;
 
 const react = createReact<State>(initialState);
 react((state) => {
@@ -43,6 +54,7 @@ react((state) => {
   return state.reactSelectorMutation;
 });
 react.readOnly().reactReadResultMutation = 1;
+react()[0].reactFullResultMutation = 1;
 
 const solid = createSolid<State>(initialState);
 solid((state) => {
@@ -50,6 +62,7 @@ solid((state) => {
   return state.solidSelectorMutation;
 });
 solid.readOnly().solidReadResultMutation = 1;
+solid().state().solidFullResultMutation = 1;
 
 const svelte = createSvelte<State>(initialState);
 svelte.select((state) => {
@@ -57,6 +70,9 @@ svelte.select((state) => {
   return state.svelteSelectorMutation;
 });
 svelte.readOnly().svelteReadResultMutation = 1;
+svelte.subscribe((state) => {
+  state.svelteFullResultMutation = 1;
+});
 
 const vue = createVue<State>(initialState);
 vue((state) => {
@@ -64,3 +80,4 @@ vue((state) => {
   return state.vueSelectorMutation;
 });
 vue.readOnly().vueReadResultMutation = 1;
+vue().state.value.vueFullResultMutation = 1;

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-invalid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-invalid/index.ts
@@ -1,0 +1,66 @@
+import { create as createAngular } from '@ilokesto/state/angular';
+import { create as createReact } from '@ilokesto/state/react';
+import { create as createSolid } from '@ilokesto/state/solid';
+import { create as createSvelte } from '@ilokesto/state/svelte';
+import { create as createVue } from '@ilokesto/state/vue';
+
+type State = {
+  angularReadResultMutation: number;
+  angularSelectorMutation: number;
+  reactReadResultMutation: number;
+  reactSelectorMutation: number;
+  solidReadResultMutation: number;
+  solidSelectorMutation: number;
+  svelteReadResultMutation: number;
+  svelteSelectorMutation: number;
+  vueReadResultMutation: number;
+  vueSelectorMutation: number;
+};
+
+const initialState: State = {
+  angularReadResultMutation: 0,
+  angularSelectorMutation: 0,
+  reactReadResultMutation: 0,
+  reactSelectorMutation: 0,
+  solidReadResultMutation: 0,
+  solidSelectorMutation: 0,
+  svelteReadResultMutation: 0,
+  svelteSelectorMutation: 0,
+  vueReadResultMutation: 0,
+  vueSelectorMutation: 0,
+};
+
+const angular = createAngular<State>(initialState);
+angular((state) => {
+  state.angularSelectorMutation = 1;
+  return state.angularSelectorMutation;
+});
+angular.readOnly().angularReadResultMutation = 1;
+
+const react = createReact<State>(initialState);
+react((state) => {
+  state.reactSelectorMutation = 1;
+  return state.reactSelectorMutation;
+});
+react.readOnly().reactReadResultMutation = 1;
+
+const solid = createSolid<State>(initialState);
+solid((state) => {
+  state.solidSelectorMutation = 1;
+  return state.solidSelectorMutation;
+});
+solid.readOnly().solidReadResultMutation = 1;
+
+const svelte = createSvelte<State>(initialState);
+svelte.select((state) => {
+  state.svelteSelectorMutation = 1;
+  return state.svelteSelectorMutation;
+});
+svelte.readOnly().svelteReadResultMutation = 1;
+
+const vue = createVue<State>(initialState);
+vue((state) => {
+  state.vueSelectorMutation = 1;
+  return state.vueSelectorMutation;
+});
+vue.readOnly().vueReadResultMutation = 1;

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-valid/index.ts
@@ -1,0 +1,44 @@
+import { create as createAngular } from '@ilokesto/state/angular';
+import { create as createReact } from '@ilokesto/state/react';
+import { create as createSolid } from '@ilokesto/state/solid';
+import { create as createSvelte } from '@ilokesto/state/svelte';
+import { create as createVue } from '@ilokesto/state/vue';
+
+type State = {
+  angular: number;
+  react: number;
+  solid: number;
+  svelte: number;
+  vue: number;
+};
+
+const initialState: State = { angular: 0, react: 0, solid: 0, svelte: 0, vue: 0 };
+
+const angular = createAngular<State>(initialState);
+const angularSelection = angular((state) => state.angular).state;
+angularSelection().toFixed();
+angular.readOnly().angular.toFixed();
+angular.writeOnly()((state) => ({ ...state, angular: state.angular + 1 }));
+
+const react = createReact<State>(initialState);
+const [reactSelection] = react((state) => state.react);
+reactSelection.toFixed();
+react.readOnly().react.toFixed();
+react.writeOnly()((state) => ({ ...state, react: state.react + 1 }));
+
+const solid = createSolid<State>(initialState);
+const solidSelection = solid((state) => state.solid).state;
+solidSelection().toFixed();
+solid.readOnly().solid.toFixed();
+solid.writeOnly()((state) => ({ ...state, solid: state.solid + 1 }));
+
+const svelte = createSvelte<State>(initialState);
+svelte.select((state) => state.svelte);
+svelte.readOnly().svelte.toFixed();
+svelte.writeOnly()((state) => ({ ...state, svelte: state.svelte + 1 }));
+
+const vue = createVue<State>(initialState);
+const vueSelection = vue((state) => state.vue).state;
+vueSelection.value.toFixed();
+vue.readOnly().vue.toFixed();
+vue.writeOnly()((state) => ({ ...state, vue: state.vue + 1 }));

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-valid/index.ts
@@ -18,27 +18,36 @@ const angular = createAngular<State>(initialState);
 const angularSelection = angular((state) => state.angular).state;
 angularSelection().toFixed();
 angular.readOnly().angular.toFixed();
-angular.writeOnly()((state) => ({ ...state, angular: state.angular + 1 }));
+const angularFullResult = angular();
+angularFullResult.state().angular.toFixed();
+angularFullResult.setState((state) => ({ ...state, angular: state.angular + 1 }));
 
 const react = createReact<State>(initialState);
 const [reactSelection] = react((state) => state.react);
 reactSelection.toFixed();
 react.readOnly().react.toFixed();
-react.writeOnly()((state) => ({ ...state, react: state.react + 1 }));
+const [reactFullState, reactSetState] = react();
+reactFullState.react.toFixed();
+reactSetState((state) => ({ ...state, react: state.react + 1 }));
 
 const solid = createSolid<State>(initialState);
 const solidSelection = solid((state) => state.solid).state;
 solidSelection().toFixed();
 solid.readOnly().solid.toFixed();
-solid.writeOnly()((state) => ({ ...state, solid: state.solid + 1 }));
+const solidFullResult = solid();
+solidFullResult.state().solid.toFixed();
+solidFullResult.setState((state) => ({ ...state, solid: state.solid + 1 }));
 
 const svelte = createSvelte<State>(initialState);
 svelte.select((state) => state.svelte);
 svelte.readOnly().svelte.toFixed();
-svelte.writeOnly()((state) => ({ ...state, svelte: state.svelte + 1 }));
+svelte.subscribe((state) => state.svelte.toFixed());
+svelte.setState((state) => ({ ...state, svelte: state.svelte + 1 }));
 
 const vue = createVue<State>(initialState);
 const vueSelection = vue((state) => state.vue).state;
 vueSelection.value.toFixed();
 vue.readOnly().vue.toFixed();
-vue.writeOnly()((state) => ({ ...state, vue: state.vue + 1 }));
+const vueFullResult = vue();
+vueFullResult.state.value.vue.toFixed();
+vueFullResult.setState((state) => ({ ...state, vue: state.vue + 1 }));

--- a/packages/state/test/fixtures/adapter-readonly-types/source-callable-signatures-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-callable-signatures-valid/index.ts
@@ -1,0 +1,67 @@
+import { create as createAngular } from '../../../../src/core/Angular/index.js';
+import { create as createReact } from '../../../../src/core/React/index.js';
+import { create as createSolid } from '../../../../src/core/Solid/index.js';
+import { create as createSvelte } from '../../../../src/core/Svelte/index.js';
+import { create as createVue } from '../../../../src/core/Vue/index.js';
+
+type GenericIdentity = <Value>(value: Value) => Value;
+type OverloadedState = {
+  (value: number): number;
+  (value: string): string;
+  label: string;
+};
+
+declare const genericIdentity: GenericIdentity;
+declare const overloadedState: OverloadedState;
+
+const angularGeneric = createAngular<GenericIdentity>(genericIdentity);
+angularGeneric.readOnly()('angular').toUpperCase();
+angularGeneric((state) => state(1)).state().toFixed();
+angularGeneric().state()({ angular: true }).angular.valueOf();
+const angularOverloaded = createAngular<OverloadedState>(overloadedState);
+angularOverloaded.readOnly()('angular').toUpperCase();
+angularOverloaded((state) => state(1)).state().toFixed();
+angularOverloaded().state()('angular').toUpperCase();
+angularOverloaded().state().label = 'angular';
+
+const reactGeneric = createReact<GenericIdentity>(genericIdentity);
+reactGeneric.readOnly()('react').toUpperCase();
+reactGeneric((state) => state(1))[0].toFixed();
+reactGeneric()[0]({ react: true }).react.valueOf();
+const reactOverloaded = createReact<OverloadedState>(overloadedState);
+reactOverloaded.readOnly()('react').toUpperCase();
+reactOverloaded((state) => state(1))[0].toFixed();
+reactOverloaded()[0]('react').toUpperCase();
+reactOverloaded()[0].label = 'react';
+
+const solidGeneric = createSolid<GenericIdentity>(genericIdentity);
+solidGeneric.readOnly()('solid').toUpperCase();
+solidGeneric((state) => state(1)).state().toFixed();
+solidGeneric().state()({ solid: true }).solid.valueOf();
+const solidOverloaded = createSolid<OverloadedState>(overloadedState);
+solidOverloaded.readOnly()('solid').toUpperCase();
+solidOverloaded((state) => state(1)).state().toFixed();
+solidOverloaded().state()('solid').toUpperCase();
+solidOverloaded().state().label = 'solid';
+
+const svelteGeneric = createSvelte<GenericIdentity>(genericIdentity);
+svelteGeneric.readOnly()('svelte').toUpperCase();
+svelteGeneric.select((state) => state(1)).subscribe((value) => value.toFixed());
+svelteGeneric.subscribe((state) => state({ svelte: true }).svelte.valueOf());
+const svelteOverloaded = createSvelte<OverloadedState>(overloadedState);
+svelteOverloaded.readOnly()('svelte').toUpperCase();
+svelteOverloaded.select((state) => state(1)).subscribe((value) => value.toFixed());
+svelteOverloaded.subscribe((state) => {
+  state('svelte').toUpperCase();
+  state.label = 'svelte';
+});
+
+const vueGeneric = createVue<GenericIdentity>(genericIdentity);
+vueGeneric.readOnly()('vue').toUpperCase();
+vueGeneric((state) => state(1)).state.value.toFixed();
+vueGeneric().state.value({ vue: true }).vue.valueOf();
+const vueOverloaded = createVue<OverloadedState>(overloadedState);
+vueOverloaded.readOnly()('vue').toUpperCase();
+vueOverloaded((state) => state(1)).state.value.toFixed();
+vueOverloaded().state.value('vue').toUpperCase();
+vueOverloaded().state.value.label = 'vue';

--- a/packages/state/test/fixtures/adapter-readonly-types/source-callable-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-callable-valid/index.ts
@@ -1,0 +1,40 @@
+import { create as createAngular } from '../../../../src/core/Angular/index.js';
+import { create as createReact } from '../../../../src/core/React/index.js';
+import { create as createSolid } from '../../../../src/core/Solid/index.js';
+import { create as createSvelte } from '../../../../src/core/Svelte/index.js';
+import { create as createVue } from '../../../../src/core/Vue/index.js';
+
+type CallableState = {
+  (): number;
+  label: string;
+};
+
+declare const initialState: CallableState;
+
+const angular = createAngular<CallableState>(initialState);
+angular.readOnly()().toFixed();
+angular((state) => state()).state().toFixed();
+angular().state()().toFixed();
+
+const react = createReact<CallableState>(initialState);
+react.readOnly()().toFixed();
+react((state) => state())[0].toFixed();
+react()[0]().toFixed();
+
+const solid = createSolid<CallableState>(initialState);
+solid.readOnly()().toFixed();
+solid((state) => state()).state().toFixed();
+solid().state()().toFixed();
+
+const svelte = createSvelte<CallableState>(initialState);
+svelte.readOnly()().toFixed();
+svelte.select((state) => state()).subscribe((value) => value.toFixed());
+svelte.subscribe((state) => {
+  state().toFixed();
+  state.label.toUpperCase();
+});
+
+const vue = createVue<CallableState>(initialState);
+vue.readOnly()().toFixed();
+vue((state) => state()).state.value.toFixed();
+vue().state.value().toFixed();

--- a/packages/state/test/fixtures/adapter-readonly-types/source-invalid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-invalid/index.ts
@@ -5,27 +5,37 @@ import { create as createSvelte } from '../../../../src/core/Svelte/index.js';
 import { create as createVue } from '../../../../src/core/Vue/index.js';
 
 type State = {
+  angularFullResultMutation: number;
   angularReadResultMutation: number;
   angularSelectorMutation: number;
+  reactFullResultMutation: number;
   reactReadResultMutation: number;
   reactSelectorMutation: number;
+  solidFullResultMutation: number;
   solidReadResultMutation: number;
   solidSelectorMutation: number;
+  svelteFullResultMutation: number;
   svelteReadResultMutation: number;
   svelteSelectorMutation: number;
+  vueFullResultMutation: number;
   vueReadResultMutation: number;
   vueSelectorMutation: number;
 };
 
 const initialState: State = {
+  angularFullResultMutation: 0,
   angularReadResultMutation: 0,
   angularSelectorMutation: 0,
+  reactFullResultMutation: 0,
   reactReadResultMutation: 0,
   reactSelectorMutation: 0,
+  solidFullResultMutation: 0,
   solidReadResultMutation: 0,
   solidSelectorMutation: 0,
+  svelteFullResultMutation: 0,
   svelteReadResultMutation: 0,
   svelteSelectorMutation: 0,
+  vueFullResultMutation: 0,
   vueReadResultMutation: 0,
   vueSelectorMutation: 0,
 };
@@ -36,6 +46,7 @@ angular((state) => {
   return state.angularSelectorMutation;
 });
 angular.readOnly().angularReadResultMutation = 1;
+angular().state().angularFullResultMutation = 1;
 
 const react = createReact<State>(initialState);
 react((state) => {
@@ -43,6 +54,7 @@ react((state) => {
   return state.reactSelectorMutation;
 });
 react.readOnly().reactReadResultMutation = 1;
+react()[0].reactFullResultMutation = 1;
 
 const solid = createSolid<State>(initialState);
 solid((state) => {
@@ -50,6 +62,7 @@ solid((state) => {
   return state.solidSelectorMutation;
 });
 solid.readOnly().solidReadResultMutation = 1;
+solid().state().solidFullResultMutation = 1;
 
 const svelte = createSvelte<State>(initialState);
 svelte.select((state) => {
@@ -57,6 +70,9 @@ svelte.select((state) => {
   return state.svelteSelectorMutation;
 });
 svelte.readOnly().svelteReadResultMutation = 1;
+svelte.subscribe((state) => {
+  state.svelteFullResultMutation = 1;
+});
 
 const vue = createVue<State>(initialState);
 vue((state) => {
@@ -64,3 +80,4 @@ vue((state) => {
   return state.vueSelectorMutation;
 });
 vue.readOnly().vueReadResultMutation = 1;
+vue().state.value.vueFullResultMutation = 1;

--- a/packages/state/test/fixtures/adapter-readonly-types/source-invalid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-invalid/index.ts
@@ -1,0 +1,66 @@
+import { create as createAngular } from '../../../../src/core/Angular/index.js';
+import { create as createReact } from '../../../../src/core/React/index.js';
+import { create as createSolid } from '../../../../src/core/Solid/index.js';
+import { create as createSvelte } from '../../../../src/core/Svelte/index.js';
+import { create as createVue } from '../../../../src/core/Vue/index.js';
+
+type State = {
+  angularReadResultMutation: number;
+  angularSelectorMutation: number;
+  reactReadResultMutation: number;
+  reactSelectorMutation: number;
+  solidReadResultMutation: number;
+  solidSelectorMutation: number;
+  svelteReadResultMutation: number;
+  svelteSelectorMutation: number;
+  vueReadResultMutation: number;
+  vueSelectorMutation: number;
+};
+
+const initialState: State = {
+  angularReadResultMutation: 0,
+  angularSelectorMutation: 0,
+  reactReadResultMutation: 0,
+  reactSelectorMutation: 0,
+  solidReadResultMutation: 0,
+  solidSelectorMutation: 0,
+  svelteReadResultMutation: 0,
+  svelteSelectorMutation: 0,
+  vueReadResultMutation: 0,
+  vueSelectorMutation: 0,
+};
+
+const angular = createAngular<State>(initialState);
+angular((state) => {
+  state.angularSelectorMutation = 1;
+  return state.angularSelectorMutation;
+});
+angular.readOnly().angularReadResultMutation = 1;
+
+const react = createReact<State>(initialState);
+react((state) => {
+  state.reactSelectorMutation = 1;
+  return state.reactSelectorMutation;
+});
+react.readOnly().reactReadResultMutation = 1;
+
+const solid = createSolid<State>(initialState);
+solid((state) => {
+  state.solidSelectorMutation = 1;
+  return state.solidSelectorMutation;
+});
+solid.readOnly().solidReadResultMutation = 1;
+
+const svelte = createSvelte<State>(initialState);
+svelte.select((state) => {
+  state.svelteSelectorMutation = 1;
+  return state.svelteSelectorMutation;
+});
+svelte.readOnly().svelteReadResultMutation = 1;
+
+const vue = createVue<State>(initialState);
+vue((state) => {
+  state.vueSelectorMutation = 1;
+  return state.vueSelectorMutation;
+});
+vue.readOnly().vueReadResultMutation = 1;

--- a/packages/state/test/fixtures/adapter-readonly-types/source-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-valid/index.ts
@@ -18,27 +18,36 @@ const angular = createAngular<State>(initialState);
 const angularSelection = angular((state) => state.angular).state;
 angularSelection().toFixed();
 angular.readOnly().angular.toFixed();
-angular.writeOnly()((state) => ({ ...state, angular: state.angular + 1 }));
+const angularFullResult = angular();
+angularFullResult.state().angular.toFixed();
+angularFullResult.setState((state) => ({ ...state, angular: state.angular + 1 }));
 
 const react = createReact<State>(initialState);
 const [reactSelection] = react((state) => state.react);
 reactSelection.toFixed();
 react.readOnly().react.toFixed();
-react.writeOnly()((state) => ({ ...state, react: state.react + 1 }));
+const [reactFullState, reactSetState] = react();
+reactFullState.react.toFixed();
+reactSetState((state) => ({ ...state, react: state.react + 1 }));
 
 const solid = createSolid<State>(initialState);
 const solidSelection = solid((state) => state.solid).state;
 solidSelection().toFixed();
 solid.readOnly().solid.toFixed();
-solid.writeOnly()((state) => ({ ...state, solid: state.solid + 1 }));
+const solidFullResult = solid();
+solidFullResult.state().solid.toFixed();
+solidFullResult.setState((state) => ({ ...state, solid: state.solid + 1 }));
 
 const svelte = createSvelte<State>(initialState);
 svelte.select((state) => state.svelte);
 svelte.readOnly().svelte.toFixed();
-svelte.writeOnly()((state) => ({ ...state, svelte: state.svelte + 1 }));
+svelte.subscribe((state) => state.svelte.toFixed());
+svelte.setState((state) => ({ ...state, svelte: state.svelte + 1 }));
 
 const vue = createVue<State>(initialState);
 const vueSelection = vue((state) => state.vue).state;
 vueSelection.value.toFixed();
 vue.readOnly().vue.toFixed();
-vue.writeOnly()((state) => ({ ...state, vue: state.vue + 1 }));
+const vueFullResult = vue();
+vueFullResult.state.value.vue.toFixed();
+vueFullResult.setState((state) => ({ ...state, vue: state.vue + 1 }));

--- a/packages/state/test/fixtures/adapter-readonly-types/source-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-valid/index.ts
@@ -1,0 +1,44 @@
+import { create as createAngular } from '../../../../src/core/Angular/index.js';
+import { create as createReact } from '../../../../src/core/React/index.js';
+import { create as createSolid } from '../../../../src/core/Solid/index.js';
+import { create as createSvelte } from '../../../../src/core/Svelte/index.js';
+import { create as createVue } from '../../../../src/core/Vue/index.js';
+
+type State = {
+  angular: number;
+  react: number;
+  solid: number;
+  svelte: number;
+  vue: number;
+};
+
+const initialState: State = { angular: 0, react: 0, solid: 0, svelte: 0, vue: 0 };
+
+const angular = createAngular<State>(initialState);
+const angularSelection = angular((state) => state.angular).state;
+angularSelection().toFixed();
+angular.readOnly().angular.toFixed();
+angular.writeOnly()((state) => ({ ...state, angular: state.angular + 1 }));
+
+const react = createReact<State>(initialState);
+const [reactSelection] = react((state) => state.react);
+reactSelection.toFixed();
+react.readOnly().react.toFixed();
+react.writeOnly()((state) => ({ ...state, react: state.react + 1 }));
+
+const solid = createSolid<State>(initialState);
+const solidSelection = solid((state) => state.solid).state;
+solidSelection().toFixed();
+solid.readOnly().solid.toFixed();
+solid.writeOnly()((state) => ({ ...state, solid: state.solid + 1 }));
+
+const svelte = createSvelte<State>(initialState);
+svelte.select((state) => state.svelte);
+svelte.readOnly().svelte.toFixed();
+svelte.writeOnly()((state) => ({ ...state, svelte: state.svelte + 1 }));
+
+const vue = createVue<State>(initialState);
+const vueSelection = vue((state) => state.vue).state;
+vueSelection.value.toFixed();
+vue.readOnly().vue.toFixed();
+vue.writeOnly()((state) => ({ ...state, vue: state.vue + 1 }));

--- a/packages/state/test/fixtures/adapter-readonly-types/tsconfig.json
+++ b/packages/state/test/fixtures/adapter-readonly-types/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../../../",
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["**/index.ts"]
+}

--- a/packages/state/test/framework-create-overloads.test.ts
+++ b/packages/state/test/framework-create-overloads.test.ts
@@ -9,11 +9,11 @@ import { create as createVue } from '../src/core/Vue';
 import type { ReducerAction } from '../src/types/ReduceFn';
 
 type StateAdapter<State> = Readonly<{
-  readOnly: () => State;
+  readOnly: () => Readonly<State>;
 }>;
 
 type ReducerAdapter<State, Action> = Readonly<{
-  readOnly: () => State;
+  readOnly: () => Readonly<State>;
   writeOnly: () => (action: Action) => void;
 }>;
 
@@ -83,7 +83,6 @@ describe('framework create() overload detection', () => {
 
         // Then
         expect(adapter.readOnly()).toBe(initialState);
-        expect(adapter.readOnly()()).toBe(1);
       });
 
       test('Given a reducer and initial state, When create receives two arguments, Then dispatch uses the reducer', () => {

--- a/packages/state/test/framework-create-overloads.test.ts
+++ b/packages/state/test/framework-create-overloads.test.ts
@@ -6,14 +6,15 @@ import { create as createReact } from '../src/core/React';
 import { create as createSolid } from '../src/core/Solid';
 import { create as createSvelte } from '../src/core/Svelte';
 import { create as createVue } from '../src/core/Vue';
+import type { ReadonlySnapshot } from '../src/core/shared/readonlySnapshot';
 import type { ReducerAction } from '../src/types/ReduceFn';
 
 type StateAdapter<State> = Readonly<{
-  readOnly: () => Readonly<State>;
+  readOnly: () => ReadonlySnapshot<State>;
 }>;
 
 type ReducerAdapter<State, Action> = Readonly<{
-  readOnly: () => Readonly<State>;
+  readOnly: () => ReadonlySnapshot<State>;
   writeOnly: () => (action: Action) => void;
 }>;
 
@@ -83,6 +84,7 @@ describe('framework create() overload detection', () => {
 
         // Then
         expect(adapter.readOnly()).toBe(initialState);
+        expect(adapter.readOnly()()).toBe(1);
       });
 
       test('Given a reducer and initial state, When create receives two arguments, Then dispatch uses the reducer', () => {

--- a/packages/state/test/helpers/compileTypeFixture.ts
+++ b/packages/state/test/helpers/compileTypeFixture.ts
@@ -16,6 +16,7 @@ export type CompileTypeFixtureResult =
 
 type CompileTypeFixtureOptions = {
   readonly configPath?: string;
+  readonly fixtureRoot?: string;
 };
 
 type ParsedConfigCache = {
@@ -23,8 +24,7 @@ type ParsedConfigCache = {
   readonly source: string;
 };
 
-const fixtureRoot = join(import.meta.dir, '..', 'fixtures', 'pipe-types');
-const sharedConfigPath = join(fixtureRoot, 'tsconfig.json');
+const defaultFixtureRoot = join(import.meta.dir, '..', 'fixtures', 'pipe-types');
 const parsedConfigs = new Map<string, ParsedConfigCache>();
 const diagnosticHost: ts.FormatDiagnosticsHost = {
   getCanonicalFileName: (fileName) => fileName,
@@ -71,7 +71,7 @@ function parseConfig(configPath: string): ts.ParsedCommandLine | CompileTypeFixt
   return config;
 }
 
-function fixtureIndexPath(fixture: string): string | CompileTypeFixtureResult {
+function fixtureIndexPath(fixtureRoot: string, fixture: string): string | CompileTypeFixtureResult {
   const segments = fixture.split('/');
   if (
     fixture.length === 0 ||
@@ -92,12 +92,13 @@ export function compileTypeFixture(
   fixture: string,
   options: CompileTypeFixtureOptions = {},
 ): CompileTypeFixtureResult {
-  const indexPath = fixtureIndexPath(fixture);
+  const fixtureRoot = options.fixtureRoot ?? defaultFixtureRoot;
+  const indexPath = fixtureIndexPath(fixtureRoot, fixture);
   if (typeof indexPath !== 'string') {
     return indexPath;
   }
 
-  const configPath = options.configPath ?? sharedConfigPath;
+  const configPath = options.configPath ?? join(fixtureRoot, 'tsconfig.json');
   const config = parseConfig(configPath);
   if ('success' in config) {
     return config;

--- a/packages/state/test/pipe-type-fixtures-structure.test.ts
+++ b/packages/state/test/pipe-type-fixtures-structure.test.ts
@@ -5,7 +5,7 @@ import { pipeTypeFixtureCases } from './helpers/pipeTypeFixtureRegistry';
 
 const projectRoot = join(import.meta.dir, '..');
 
-test('Given pipe type fixtures, when their compiler configs are listed, then only the shared fixture and test configs remain', () => {
+test('Given state type fixtures, when their compiler configs are listed, then only shared fixture and test configs remain', () => {
   // Given / When
   const configs = [
     ...new Bun.Glob('test/**/tsconfig.json').scanSync({ cwd: projectRoot }),
@@ -13,6 +13,7 @@ test('Given pipe type fixtures, when their compiler configs are listed, then onl
 
   // Then
   expect(configs).toEqual([
+    'test/fixtures/adapter-readonly-types/tsconfig.json',
     'test/fixtures/pipe-types/tsconfig.json',
     'test/tsconfig.json',
   ]);

--- a/packages/state/test/tsconfig.json
+++ b/packages/state/test/tsconfig.json
@@ -8,6 +8,8 @@
   },
   "include": ["../src", "."],
   "exclude": [
+    "fixtures/adapter-readonly-types/source-invalid",
+    "fixtures/adapter-readonly-types/dist-invalid",
     "fixtures/pipe-types/invalid-callable-root",
     "fixtures/pipe-types/invalid-conflict",
     "fixtures/pipe-types/invalid-cycle",


### PR DESCRIPTION
## Summary

- preserve Store Readonly<T> selector and read contracts across React, Vue, Angular, Svelte, and Solid adapters
- keep writer APIs mutable-by-contract while exposing full reactive state as readonly
- add source and generated-public-subpath compile fixtures for all five adapters
- update English and Korean selector/read documentation
- include a major changeset with migration guidance

## Verification

- pnpm --filter @ilokesto/state exec bun test test/adapter-readonly-types.test.ts test/framework-adapters.test.ts test/framework-create-overloads.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file LSP diagnostics
- git diff --check

Closes #74