### PR TITLE
fix(state): restore DevTools dispatch reporting

### DIFF
--- a/.changeset/state-devtools-dispatch-recovery.md
+++ b/.changeset/state-devtools-dispatch-recovery.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Restore DevTools update reporting after a RESET or ROLLBACK state write fails.

--- a/packages/state/src/middleware/devtools.ts
+++ b/packages/state/src/middleware/devtools.ts
@@ -47,6 +47,15 @@ const applyDevtools = <T>(initialState: T | Store<T>, name: string) => {
 
   let isDispatchAction = false;
 
+  const runDispatchAction = (action: () => void): void => {
+    isDispatchAction = true;
+    try {
+      action();
+    } finally {
+      isDispatchAction = false;
+    }
+  };
+
   if (devTools) {
     devTools.init(store.getState() as T);
 
@@ -57,25 +66,27 @@ const applyDevtools = <T>(initialState: T | Store<T>, name: string) => {
 
       switch (message.payload?.type) {
         case 'RESET':
-          isDispatchAction = true;
-          store.setState(
-            initialState instanceof Store
-              ? (initialState.getInitialState() as T)
-              : (initialState as T),
-          );
-          isDispatchAction = false;
+          runDispatchAction(() => {
+            store.setState(
+              initialState instanceof Store
+                ? (initialState.getInitialState() as T)
+                : (initialState as T),
+            );
+          });
           devTools.init(store.getState() as T);
           break;
         case 'COMMIT':
           devTools.init(store.getState() as T);
           break;
-        case 'ROLLBACK':
-          if (typeof message.state === 'string') {
-            isDispatchAction = true;
-            store.setState(JSON.parse(message.state) as T);
-            isDispatchAction = false;
+        case 'ROLLBACK': {
+          const state = message.state;
+          if (typeof state === 'string') {
+            runDispatchAction(() => {
+              store.setState(JSON.parse(state) as T);
+            });
           }
           break;
+        }
         default:
           break;
       }

--- a/packages/state/src/middleware/devtools.ts
+++ b/packages/state/src/middleware/devtools.ts
@@ -48,11 +48,12 @@ const applyDevtools = <T>(initialState: T | Store<T>, name: string) => {
   let isDispatchAction = false;
 
   const runDispatchAction = (action: () => void): void => {
+    const wasDispatchAction = isDispatchAction;
     isDispatchAction = true;
     try {
       action();
     } finally {
-      isDispatchAction = false;
+      isDispatchAction = wasDispatchAction;
     }
   };
 

--- a/packages/state/test/devtools-dispatch-recovery.test.ts
+++ b/packages/state/test/devtools-dispatch-recovery.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test';
+import { Store } from '@ilokesto/store';
+
+import { withBrowserFakes } from './helpers/browserFakes';
+import { devtools } from '../src/middleware';
+import { definePipeableMiddleware } from '../src/utils/pipe/metadata';
+import { pipe } from '../src/utils/pipe/index';
+
+type CounterState = {
+  readonly count: number;
+};
+
+const createRejectFirstStateWrite = (failure: Error) => {
+  let shouldThrow = true;
+
+  return definePipeableMiddleware(
+    <State>(store: Store<State>): Store<State> => {
+      store.pushMiddleware((nextState, next) => {
+        if (shouldThrow) {
+          shouldThrow = false;
+          throw failure;
+        }
+
+        next(nextState);
+      });
+      return store;
+    },
+    { id: '@test/reject-first-state-write' } as const,
+  );
+};
+
+test('Given DevTools RESET and a once-throwing downstream middleware, when RESET fails then a later update succeeds, then DevTools sends the later update', () => {
+  // Given
+  withBrowserFakes<CounterState>((_, connections) => {
+    const failure = new Error('RESET state write failed');
+    const store = pipe
+      .use(devtools('reset-recovery'))
+      .use(createRejectFirstStateWrite(failure))
+      .create<CounterState>({ count: 0 });
+    const connection = connections[0];
+
+    // When
+    expect(() => connection.listener?.({ payload: { type: 'RESET' }, type: 'DISPATCH' })).toThrow(failure);
+    store.setState({ count: 2 });
+
+    // Then
+    expect(connection.sends).toEqual([
+      { action: 'reset-recovery:anonymous action', state: { count: 2 } },
+    ]);
+  });
+});
+
+test('Given DevTools ROLLBACK and a once-throwing downstream middleware, when ROLLBACK fails then a later update succeeds, then DevTools sends the later update', () => {
+  // Given
+  withBrowserFakes<CounterState>((_, connections) => {
+    const failure = new Error('ROLLBACK state write failed');
+    const store = pipe
+      .use(devtools('rollback-recovery'))
+      .use(createRejectFirstStateWrite(failure))
+      .create<CounterState>({ count: 0 });
+    const connection = connections[0];
+
+    // When
+    expect(() =>
+      connection.listener?.({
+        payload: { type: 'ROLLBACK' },
+        state: JSON.stringify({ count: 1 }),
+        type: 'DISPATCH',
+      }),
+    ).toThrow(failure);
+    store.setState({ count: 2 });
+
+    // Then
+    expect(connection.sends).toEqual([
+      { action: 'rollback-recovery:anonymous action', state: { count: 2 } },
+    ]);
+  });
+});

--- a/packages/state/test/devtools-dispatch-recovery.test.ts
+++ b/packages/state/test/devtools-dispatch-recovery.test.ts
@@ -76,3 +76,34 @@ test('Given DevTools ROLLBACK and a once-throwing downstream middleware, when RO
     ]);
   });
 });
+
+test('Given a synchronous listener that dispatches ROLLBACK during DevTools RESET, when RESET completes then an ordinary update follows, then only the ordinary update is sent', () => {
+  // Given
+  withBrowserFakes<CounterState>((_, connections) => {
+    const store = pipe.use(devtools('nested-dispatch-recovery')).create<CounterState>({ count: 0 });
+    const connection = connections[0];
+    let shouldRollback = true;
+    store.setState({ count: 1 });
+    connection.sends.length = 0;
+    store.subscribe(() => {
+      if (shouldRollback) {
+        shouldRollback = false;
+        connection.listener?.({
+          payload: { type: 'ROLLBACK' },
+          state: JSON.stringify({ count: 2 }),
+          type: 'DISPATCH',
+        });
+      }
+    });
+
+    // When
+    connection.listener?.({ payload: { type: 'RESET' }, type: 'DISPATCH' });
+    store.setState({ count: 3 });
+
+    // Then
+    expect(store.getState()).toEqual({ count: 3 });
+    expect(connection.sends).toEqual([
+      { action: 'nested-dispatch-recovery:anonymous action', state: { count: 3 } },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- restore DevTools dispatch suppression state with a shared try/finally helper
- preserve propagation of RESET and ROLLBACK state-write errors
- add deterministic regressions proving later successful updates are reported
- include a patch changeset

## Verification

- pnpm --filter @ilokesto/state exec bun test test/devtools-dispatch-recovery.test.ts test/pipe-devtools-dispose.test.ts test/pipe-persist-devtools.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file LSP diagnostics
- git diff --check

Closes #75