### PR TITLE
fix(state): merge partial logger defaults

### DIFF
--- a/.changeset/state-logger-default-options.md
+++ b/.changeset/state-logger-default-options.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Fix logger defaults when options are partial.

--- a/packages/state/src/middleware/logger.ts
+++ b/packages/state/src/middleware/logger.ts
@@ -28,10 +28,7 @@ const getValueForKey = (value: unknown, key: string) => {
   return isRecord(value) ? value[key] : value;
 };
 
-const applyLogger = <T>(
-  initialState: T | Store<T>,
-  options: LoggerOptions = DEFAULT_LOGGER_OPTIONS,
-) => {
+const applyLogger = <T>(initialState: T | Store<T>, options: LoggerOptions) => {
   const store = getStore(initialState);
   const isProduction = typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
 
@@ -112,7 +109,8 @@ const applyLogger = <T>(
  * ```
  */
 export function logger(options?: LoggerOptions): LoggerPipeMiddleware {
-  const middleware: PipeAnyMiddleware = (initialState) => applyLogger(initialState, options);
+  const resolvedOptions = { ...DEFAULT_LOGGER_OPTIONS, ...options };
+  const middleware: PipeAnyMiddleware = (initialState) => applyLogger(initialState, resolvedOptions);
   return definePipeableMiddleware(middleware, {
     adds: [],
     after: [],

--- a/packages/state/test/logger-defaults.test.ts
+++ b/packages/state/test/logger-defaults.test.ts
@@ -1,0 +1,52 @@
+import { expect, spyOn, test } from 'bun:test';
+
+import { logger } from '../src/middleware';
+import { pipe } from '../src/utils/pipe';
+
+const RENDERED_TIME = 'logger-defaults-time-sentinel';
+
+function captureLoggerOutput(middleware: ReturnType<typeof logger>): readonly (readonly unknown[])[] {
+  const logs: unknown[][] = [];
+  const groupSpy = spyOn(console, 'group').mockImplementation(() => undefined);
+  const collapsedSpy = spyOn(console, 'groupCollapsed').mockImplementation(() => undefined);
+  const groupEndSpy = spyOn(console, 'groupEnd').mockImplementation(() => undefined);
+  const logSpy = spyOn(console, 'log').mockImplementation((...args: readonly unknown[]) => {
+    logs.push([...args]);
+  });
+  const timeSpy = spyOn(Date.prototype, 'toLocaleTimeString').mockReturnValue(RENDERED_TIME);
+
+  try {
+    const store = pipe.use(middleware).create({ count: 0 });
+    store.setState({ count: 1 });
+
+    return logs;
+  } finally {
+    timeSpy.mockRestore();
+    logSpy.mockRestore();
+    groupEndSpy.mockRestore();
+    collapsedSpy.mockRestore();
+    groupSpy.mockRestore();
+  }
+}
+
+test('Given collapsed logger options, when timestamp is omitted, then the default timestamp is logged', () => {
+  // Given
+  const middleware = logger({ collapsed: true });
+
+  // When
+  const logs = captureLoggerOutput(middleware);
+
+  // Then
+  expect(logs.some((arguments_) => arguments_.includes(RENDERED_TIME))).toBe(true);
+});
+
+test('Given logger options, when timestamp is explicitly false, then no timestamp is logged', () => {
+  // Given
+  const middleware = logger({ timestamp: false });
+
+  // When
+  const logs = captureLoggerOutput(middleware);
+
+  // Then
+  expect(logs.some((arguments_) => arguments_.includes(RENDERED_TIME))).toBe(false);
+});


### PR DESCRIPTION
## Summary

- merge partial logger options over complete defaults without mutating inputs
- preserve explicit false values such as timestamp: false
- add deterministic sentinel-time coverage without pinning console prose
- isolate console group spies in every test path
- include a patch changeset

## Verification

- pnpm --filter @ilokesto/state exec bun test test/logger-defaults.test.ts test/pipe-logger-debounce.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file diagnostics
- git diff --check

Closes #76