### PR TITLE
feat(state): export React adapter types

### DIFF
--- a/.changeset/state-react-adapter-type-exports.md
+++ b/.changeset/state-react-adapter-type-exports.md
@@ -1,0 +1,7 @@
+---
+"@ilokesto/state": minor
+---
+
+Export the React adapter's `UseState` and `UseReducer` types from `@ilokesto/state/react`.
+
+> Migration: No runtime migration is required because this adds type-only exports and leaves JavaScript exports unchanged.

--- a/packages/state/docs/integrations/react.ko.mdx
+++ b/packages/state/docs/integrations/react.ko.mdx
@@ -7,6 +7,14 @@ description: "React 컴포넌트와 hook에서 @ilokesto/state를 사용합니�
 
 React component가 `@ilokesto/store` 기반 상태를 구독해야 할 때 React adapter를 사용하세요. root package가 아니라 `@ilokesto/state/react`에서 import합니다.
 
+## Adapter type
+
+`UseState`와 `UseReducer`는 plain-state와 reducer `create()` overload가 반환하는 hook을 나타냅니다. public API가 이 hook type을 받을 때 같은 React subpath에서 import하세요.
+
+```ts lineNumbers
+import type { UseReducer, UseState } from '@ilokesto/state/react';
+```
+
 ## Plain state hook
 
 plain state는 작은 React state hook처럼 `[selection, setState]`를 반환합니다.

--- a/packages/state/docs/integrations/react.mdx
+++ b/packages/state/docs/integrations/react.mdx
@@ -7,6 +7,14 @@ description: "Use @ilokesto/state from React components and hooks."
 
 Use the React adapter when a React component needs a subscribed value from an `@ilokesto/store`-backed state container. Import from `@ilokesto/state/react`, not from the root package.
 
+## Adapter types
+
+`UseState` and `UseReducer` describe the hooks returned by the plain-state and reducer `create()` overloads. Import them from the same React subpath when a public API accepts either hook type.
+
+```ts lineNumbers
+import type { UseReducer, UseState } from '@ilokesto/state/react';
+```
+
 ## Plain state hook
 
 Plain state returns the same shape as a small React state hook: `[selection, setState]`.

--- a/packages/state/docs/reference/package-surface.ko.mdx
+++ b/packages/state/docs/reference/package-surface.ko.mdx
@@ -12,7 +12,7 @@ public package surface는 `state/package.json`의 exports가 기준입니다.
 | Import | Purpose |
 |---|---|
 | `@ilokesto/state` | package identity와 현재 empty runtime root입니다. source는 `export {}`입니다. |
-| `@ilokesto/state/react` | React `create()` adapter입니다. |
+| `@ilokesto/state/react` | React `create()` adapter와 `UseState`, `UseReducer` type입니다. |
 | `@ilokesto/state/vue` | Vue `create()` adapter입니다. |
 | `@ilokesto/state/svelte` | Svelte `create()` adapter입니다. |
 | `@ilokesto/state/solid` | Solid `create()` adapter입니다. |

--- a/packages/state/docs/reference/package-surface.mdx
+++ b/packages/state/docs/reference/package-surface.mdx
@@ -12,7 +12,7 @@ The public package surface is defined by `state/package.json` exports.
 | Import | Purpose |
 |---|---|
 | `@ilokesto/state` | Package identity and current empty runtime root. The source is `export {}`. |
-| `@ilokesto/state/react` | React `create()` adapter. |
+| `@ilokesto/state/react` | React `create()` adapter and the `UseState` and `UseReducer` types. |
 | `@ilokesto/state/vue` | Vue `create()` adapter. |
 | `@ilokesto/state/svelte` | Svelte `create()` adapter. |
 | `@ilokesto/state/solid` | Solid `create()` adapter. |

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -1,6 +1,7 @@
 import type { Store } from '@ilokesto/store';
 import type { ReduceFn, ReducerAction } from '../../types/ReduceFn.js';
 import type { UseReducer, UseState } from './types.js';
+export type { UseReducer, UseState } from './types.js';
 
 import { createFrameworkAdapter } from '../shared/createFrameworkAdapter.js';
 import { createUseState } from './createUseState.js';

--- a/packages/state/test/adapter-readonly-types.test.ts
+++ b/packages/state/test/adapter-readonly-types.test.ts
@@ -81,6 +81,26 @@ test('Given source adapter contracts, when selectors or lifecycle-free reads mut
   expectReadonlyMutationErrors('source-invalid');
 });
 
+test('Given source React adapter declarations, when consumers use the exported hook types, then they compile', () => {
+  // Given / When
+  const result = compileAdapterFixture('source-type-exports-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
+test('Given generated React adapter declarations, when consumers use the exported hook types, then they compile', () => {
+  // Given / When
+  const result = compileAdapterFixture('dist-type-exports-valid');
+
+  // Then
+  expect(result.success, result.diagnostics).toBeTrue();
+  expect(result.exitCode).toBe(0);
+  expect(result.diagnostics).toBe('');
+});
+
 test('Given generated adapter declarations, when valid public-subpath consumers compile, then every adapter accepts them', () => {
   // Given / When
   const result = compileAdapterFixture('dist-valid');

--- a/packages/state/test/fixtures/adapter-readonly-types/dist-type-exports-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/dist-type-exports-valid/index.ts
@@ -1,0 +1,27 @@
+import {
+  create,
+  type UseReducer,
+  type UseState,
+} from '@ilokesto/state/react';
+
+type CounterState = {
+  count: number;
+};
+
+type CounterAction = {
+  amount: number;
+  type: 'increment';
+};
+
+const useCounter: UseState<CounterState> = create({ count: 0 });
+const [count, setCounter] = useCounter((state) => state.count);
+count.toFixed();
+setCounter((state) => ({ count: state.count + 1 }));
+
+const useReducer: UseReducer<CounterState, CounterAction> = create(
+  (state, action) => ({ count: state.count + action.amount }),
+  { count: 0 },
+);
+const [reducerCount, dispatch] = useReducer((state) => state.count);
+reducerCount.toFixed();
+dispatch({ amount: 1, type: 'increment' });

--- a/packages/state/test/fixtures/adapter-readonly-types/source-type-exports-valid/index.ts
+++ b/packages/state/test/fixtures/adapter-readonly-types/source-type-exports-valid/index.ts
@@ -1,0 +1,27 @@
+import {
+  create,
+  type UseReducer,
+  type UseState,
+} from '../../../../src/core/React/index.js';
+
+type CounterState = {
+  count: number;
+};
+
+type CounterAction = {
+  amount: number;
+  type: 'increment';
+};
+
+const useCounter: UseState<CounterState> = create({ count: 0 });
+const [count, setCounter] = useCounter((state) => state.count);
+count.toFixed();
+setCounter((state) => ({ count: state.count + 1 }));
+
+const useReducer: UseReducer<CounterState, CounterAction> = create(
+  (state, action) => ({ count: state.count + action.amount }),
+  { count: 0 },
+);
+const [reducerCount, dispatch] = useReducer((state) => state.count);
+reducerCount.toFixed();
+dispatch({ amount: 1, type: 'increment' });


### PR DESCRIPTION
## Summary

- export UseState and UseReducer as type-only symbols from @ilokesto/state/react
- add meaningful source and generated-public-subpath type consumers
- verify emitted JavaScript gains no runtime export
- document the named types in English and Korean React/package-surface docs
- include a minor changeset with no runtime migration

## Verification

- pnpm --filter @ilokesto/state exec bun test test/adapter-readonly-types.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file LSP diagnostics
- git diff --check

Closes #77