### PR TITLE
fix(state): preserve declaration JSDoc

### DIFF
--- a/.changeset/state-declaration-jsdoc.md
+++ b/.changeset/state-declaration-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@ilokesto/state": patch
+---
+
+Preserve public JSDoc in emitted declarations for editor IntelliSense.

--- a/packages/state/src/core/Angular/index.ts
+++ b/packages/state/src/core/Angular/index.ts
@@ -7,13 +7,6 @@ export type { AngularOptions, UseReducer, UseState } from './types.js';
 import { createFrameworkAdapter } from '../shared/createFrameworkAdapter.js';
 import { createUseSignal } from './createUseSignal.js';
 
-export function create<T, Action extends ReducerAction>(
-  reduceFn: ReduceFn<T, Action>,
-  initialState: T | Store<T>,
-): UseReducer<T, Action>;
-
-export function create<T>(initialState: T | Store<T>): UseState<T>;
-
 /**
  * Create an Angular signal from plain state or a reducer.
  *
@@ -23,6 +16,13 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * remains exact `T`, including its declared own-property modifiers. Selectors
  * and `.readOnly()` use the same snapshot.
  */
+export function create<T, Action extends ReducerAction>(
+  reduceFn: ReduceFn<T, Action>,
+  initialState: T | Store<T>,
+): UseReducer<T, Action>;
+
+export function create<T>(initialState: T | Store<T>): UseState<T>;
+
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,

--- a/packages/state/src/core/Angular/index.ts
+++ b/packages/state/src/core/Angular/index.ts
@@ -21,6 +21,15 @@ export function create<T, Action extends ReducerAction>(
   initialState: T | Store<T>,
 ): UseReducer<T, Action>;
 
+/**
+ * Create an Angular signal from plain state or a reducer.
+ *
+ * Returns a function that must be called inside an injection context or with
+ * an explicit `{ destroyRef }`. Without a selector, `state` is a `Signal` of a
+ * read-only snapshot: object state is `Readonly<T>`, while callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
+ */
 export function create<T>(initialState: T | Store<T>): UseState<T>;
 
 export function create<T, Action extends ReducerAction>(

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -20,6 +20,15 @@ export function create<T, Action extends ReducerAction>(
   initialState: T | Store<T>,
 ): UseReducer<T, Action>;
 
+/**
+ * Create a React state hook from plain state or a reducer.
+ *
+ * Returns a hook compatible with `useSyncExternalStore`. Call it with a
+ * selector to subscribe to a slice; call without arguments to receive a
+ * read-only first tuple item. Object state is `Readonly<T>`; callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
+ */
 export function create<T>(initialState: T | Store<T>): UseState<T>;
 
 export function create<T, Action extends ReducerAction>(

--- a/packages/state/src/core/React/index.ts
+++ b/packages/state/src/core/React/index.ts
@@ -6,13 +6,6 @@ export type { UseReducer, UseState } from './types.js';
 import { createFrameworkAdapter } from '../shared/createFrameworkAdapter.js';
 import { createUseState } from './createUseState.js';
 
-export function create<T, Action extends ReducerAction>(
-  reduceFn: ReduceFn<T, Action>,
-  initialState: T | Store<T>,
-): UseReducer<T, Action>;
-
-export function create<T>(initialState: T | Store<T>): UseState<T>;
-
 /**
  * Create a React state hook from plain state or a reducer.
  *
@@ -22,6 +15,13 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * remains exact `T`, including its declared own-property modifiers. Selectors
  * and `.readOnly()` use the same snapshot.
  */
+export function create<T, Action extends ReducerAction>(
+  reduceFn: ReduceFn<T, Action>,
+  initialState: T | Store<T>,
+): UseReducer<T, Action>;
+
+export function create<T>(initialState: T | Store<T>): UseState<T>;
+
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,

--- a/packages/state/src/core/Solid/index.ts
+++ b/packages/state/src/core/Solid/index.ts
@@ -7,13 +7,6 @@ export type { UseReducer, UseState } from './types.js';
 import { createFrameworkAdapter } from '../shared/createFrameworkAdapter.js';
 import { createUseAccessor } from './createUseAccessor.js';
 
-export function create<T, Action extends ReducerAction>(
-  reduceFn: ReduceFn<T, Action>,
-  initialState: T | Store<T>,
-): UseReducer<T, Action>;
-
-export function create<T>(initialState: T | Store<T>): UseState<T>;
-
 /**
  * Create a Solid accessor from plain state or a reducer.
  *
@@ -23,6 +16,13 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * remains exact `T`, including its declared own-property modifiers. Selectors
  * and `.readOnly()` use the same snapshot.
  */
+export function create<T, Action extends ReducerAction>(
+  reduceFn: ReduceFn<T, Action>,
+  initialState: T | Store<T>,
+): UseReducer<T, Action>;
+
+export function create<T>(initialState: T | Store<T>): UseState<T>;
+
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,

--- a/packages/state/src/core/Solid/index.ts
+++ b/packages/state/src/core/Solid/index.ts
@@ -21,6 +21,15 @@ export function create<T, Action extends ReducerAction>(
   initialState: T | Store<T>,
 ): UseReducer<T, Action>;
 
+/**
+ * Create a Solid accessor from plain state or a reducer.
+ *
+ * Returns a function that must be called inside a reactive owner (component
+ * or `createRoot()`). Without a selector, `state` is an `Accessor` of a
+ * read-only snapshot: object state is `Readonly<T>`, while callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
+ */
 export function create<T>(initialState: T | Store<T>): UseState<T>;
 
 export function create<T, Action extends ReducerAction>(

--- a/packages/state/src/core/Svelte/index.ts
+++ b/packages/state/src/core/Svelte/index.ts
@@ -22,6 +22,16 @@ export function create<T, Action extends ReducerAction>(
   initialState: T | Store<T>,
 ): UseReducer<T, Action>;
 
+/**
+ * Create a Svelte store from plain state or a reducer.
+ *
+ * Returns a writable Svelte store with `subscribe`, `set`, `update`,
+ * `select`, `writeOnly()`, and `readOnly()`. Full-store subscriptions,
+ * selectors, and `.readOnly()` receive snapshots: object state is `Readonly<T>`,
+ * while callable state remains exact `T`, including its declared own-property
+ * modifiers. For reducer state, returns a readable store with `dispatch`
+ * instead of `set`/`update`.
+ */
 export function create<T>(initialState: T | Store<T>): UseState<T>;
 
 export function create<T, Action extends ReducerAction>(

--- a/packages/state/src/core/Svelte/index.ts
+++ b/packages/state/src/core/Svelte/index.ts
@@ -7,13 +7,6 @@ export type { UseReducer, UseState } from './types.js';
 import { createFrameworkAdapter } from '../shared/createFrameworkAdapter.js';
 import { createStore } from './createStore.js';
 
-export function create<T, Action extends ReducerAction>(
-  reduceFn: ReduceFn<T, Action>,
-  initialState: T | Store<T>,
-): UseReducer<T, Action>;
-
-export function create<T>(initialState: T | Store<T>): UseState<T>;
-
 /**
  * Create a Svelte store from plain state or a reducer.
  *
@@ -24,6 +17,13 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * modifiers. For reducer state, returns a readable store with `dispatch`
  * instead of `set`/`update`.
  */
+export function create<T, Action extends ReducerAction>(
+  reduceFn: ReduceFn<T, Action>,
+  initialState: T | Store<T>,
+): UseReducer<T, Action>;
+
+export function create<T>(initialState: T | Store<T>): UseState<T>;
+
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,

--- a/packages/state/src/core/Vue/index.ts
+++ b/packages/state/src/core/Vue/index.ts
@@ -21,6 +21,15 @@ export function create<T, Action extends ReducerAction>(
   initialState: T | Store<T>,
 ): UseReducer<T, Action>;
 
+/**
+ * Create a Vue composable from plain state or a reducer.
+ *
+ * Returns a function that must be called inside `setup()` or an active
+ * `effectScope()`. Without a selector, `state` is a `ComputedRef` of a
+ * read-only snapshot: object state is `Readonly<T>`, while callable state
+ * remains exact `T`, including its declared own-property modifiers. Selectors
+ * and `.readOnly()` use the same snapshot.
+ */
 export function create<T>(initialState: T | Store<T>): UseState<T>;
 
 export function create<T, Action extends ReducerAction>(

--- a/packages/state/src/core/Vue/index.ts
+++ b/packages/state/src/core/Vue/index.ts
@@ -7,13 +7,6 @@ export type { UseReducer, UseState } from './types.js';
 import { createFrameworkAdapter } from '../shared/createFrameworkAdapter.js';
 import { createUseComposable } from './createUseComposable.js';
 
-export function create<T, Action extends ReducerAction>(
-  reduceFn: ReduceFn<T, Action>,
-  initialState: T | Store<T>,
-): UseReducer<T, Action>;
-
-export function create<T>(initialState: T | Store<T>): UseState<T>;
-
 /**
  * Create a Vue composable from plain state or a reducer.
  *
@@ -23,6 +16,13 @@ export function create<T>(initialState: T | Store<T>): UseState<T>;
  * remains exact `T`, including its declared own-property modifiers. Selectors
  * and `.readOnly()` use the same snapshot.
  */
+export function create<T, Action extends ReducerAction>(
+  reduceFn: ReduceFn<T, Action>,
+  initialState: T | Store<T>,
+): UseReducer<T, Action>;
+
+export function create<T>(initialState: T | Store<T>): UseState<T>;
+
 export function create<T, Action extends ReducerAction>(
   firstArg: Store<T> | T | ReduceFn<T, Action>,
   secondArg?: T | Store<T>,

--- a/packages/state/src/middleware/persist/index.ts
+++ b/packages/state/src/middleware/persist/index.ts
@@ -143,10 +143,6 @@ const applyPersist = <T>(
   return persistedStore;
 };
 
-export function persist<DecodedState, const Steps extends readonly MigrationFn[]>(
-  options: SafePersistConfig<DecodedState, Steps>,
-): SafeCurriedPersist<DecodedState>;
-
 /**
  * Create a pipe middleware that persists store state to browser storage.
  *
@@ -164,6 +160,10 @@ export function persist<DecodedState, const Steps extends readonly MigrationFn[]
  *   `onRehydrateStorage`.
  * @returns Pipe middleware registered with `@ilokesto/state/persist` metadata.
  */
+export function persist<DecodedState, const Steps extends readonly MigrationFn[]>(
+  options: SafePersistConfig<DecodedState, Steps>,
+): SafeCurriedPersist<DecodedState>;
+
 export function persist<DecodedState, const Steps extends readonly MigrationFn[]>(
   options: SafePersistConfig<DecodedState, Steps>,
 ): object {

--- a/packages/state/src/utils/pipe/metadata.ts
+++ b/packages/state/src/utils/pipe/metadata.ts
@@ -138,6 +138,27 @@ export function getCapturedPipeMiddleware(entry: object): object {
   return capturedPipeMiddleware.get(entry) ?? entry;
 }
 
+/**
+ * Register metadata on a pipe middleware function.
+ *
+ * Every middleware passed to `pipe.use(...)` must be registered with this
+ * helper. The metadata declares the middleware's ID, capability requirements,
+ * conflicts, and ordering constraints that the pipe builder validates.
+ *
+ * @param middleware - The middleware function to tag.
+ * @param metadata - Pipe metadata describing ID, capabilities, conflicts, and ordering.
+ * @returns The same middleware function, now tagged with metadata.
+ *
+ * @example
+ * ```ts
+ * import { definePipeableMiddleware } from '@ilokesto/state/utils';
+ *
+ * const myMiddleware = definePipeableMiddleware(
+ *   (store) => store,
+ *   { id: '@my-app/middleware' },
+ * );
+ * ```
+ */
 export function definePipeableMiddleware<
   const Id extends string,
   const Requires extends readonly PipeCapability[] = readonly [],
@@ -151,22 +172,6 @@ export function definePipeableMiddleware<
   metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,
 ): PipeableMiddleware<
   PipeAnyMiddleware<Requires, Adds>,
-  PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>
->;
-export function definePipeableMiddleware<
-  State,
-  const Id extends string,
-  const Requires extends readonly PipeCapability[] = readonly [],
-  const Adds extends readonly PipeCapability[] = readonly [],
-  const Duplicate extends PipeDuplicatePolicy = 'reject',
-  const Conflicts extends readonly string[] = readonly string[],
-  const Before extends readonly string[] = readonly string[],
-  const After extends readonly string[] = readonly string[],
->(
-  middleware: PipeMiddleware<State, Requires, Adds>,
-  metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,
-): PipeableMiddleware<
-  PipeMiddleware<State, Requires, Adds>,
   PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>
 >;
 /**
@@ -190,6 +195,22 @@ export function definePipeableMiddleware<
  * );
  * ```
  */
+export function definePipeableMiddleware<
+  State,
+  const Id extends string,
+  const Requires extends readonly PipeCapability[] = readonly [],
+  const Adds extends readonly PipeCapability[] = readonly [],
+  const Duplicate extends PipeDuplicatePolicy = 'reject',
+  const Conflicts extends readonly string[] = readonly string[],
+  const Before extends readonly string[] = readonly string[],
+  const After extends readonly string[] = readonly string[],
+>(
+  middleware: PipeMiddleware<State, Requires, Adds>,
+  metadata: PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>,
+): PipeableMiddleware<
+  PipeMiddleware<State, Requires, Adds>,
+  PipeMiddlewareMetadata<Id, Requires, Adds, Duplicate, Conflicts, Before, After>
+>;
 export function definePipeableMiddleware(
   middleware: object,
   metadata: PipeMiddlewareMetadata,

--- a/packages/state/test/declaration-jsdoc.test.ts
+++ b/packages/state/test/declaration-jsdoc.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import ts from 'typescript';
+
+type PublicDeclaration = Readonly<{
+  readonly exportName: string;
+  readonly relativePath: string;
+}>;
+
+const projectRoot = join(import.meta.dir, '..');
+const publicDeclarations = [
+  { exportName: 'create', relativePath: 'dist/core/React/index.d.ts' },
+  { exportName: 'throttle', relativePath: 'dist/middleware/throttle.d.ts' },
+  { exportName: 'adaptor', relativePath: 'dist/utils/adaptor.d.ts' },
+] as const satisfies readonly PublicDeclaration[];
+
+test('Given a fresh state build, When public declarations are emitted, Then framework and middleware utility exports retain JSDoc', () => {
+  // Given
+  const build = Bun.spawnSync({
+    cmd: ['pnpm', 'build'],
+    cwd: projectRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  // When
+  expect(build.exitCode).toBe(0);
+  const declarations = publicDeclarations.map((declaration) => {
+    const declarationPath = join(projectRoot, declaration.relativePath);
+    const sourceFile = ts.createSourceFile(
+      declarationPath,
+      readFileSync(declarationPath, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+    const functions = sourceFile.statements.filter(
+      (statement): statement is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(statement) &&
+        statement.name?.text === declaration.exportName &&
+        statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) === true,
+    );
+
+    if (functions.length === 0) {
+      throw new Error(`Missing exported declaration: ${declaration.relativePath}#${declaration.exportName}`);
+    }
+
+    return functions;
+  });
+
+  // Then
+  for (const declarationsForExport of declarations) {
+    expect(
+      declarationsForExport.some(
+        (declaration) => ts.getJSDocCommentsAndTags(declaration).length > 0,
+      ),
+    ).toBeTrue();
+  }
+}, { timeout: 180_000 });

--- a/packages/state/test/declaration-jsdoc.test.ts
+++ b/packages/state/test/declaration-jsdoc.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import ts from 'typescript';
 
 type PublicDeclaration = Readonly<{
@@ -10,51 +11,67 @@ type PublicDeclaration = Readonly<{
 
 const projectRoot = join(import.meta.dir, '..');
 const publicDeclarations = [
-  { exportName: 'create', relativePath: 'dist/core/React/index.d.ts' },
-  { exportName: 'throttle', relativePath: 'dist/middleware/throttle.d.ts' },
-  { exportName: 'adaptor', relativePath: 'dist/utils/adaptor.d.ts' },
+  { exportName: 'create', relativePath: 'core/React/index.d.ts' },
+  { exportName: 'create', relativePath: 'core/Vue/index.d.ts' },
+  { exportName: 'create', relativePath: 'core/Angular/index.d.ts' },
+  { exportName: 'create', relativePath: 'core/Svelte/index.d.ts' },
+  { exportName: 'create', relativePath: 'core/Solid/index.d.ts' },
+  { exportName: 'persist', relativePath: 'middleware/persist/index.d.ts' },
+  { exportName: 'definePipeableMiddleware', relativePath: 'utils/pipe/metadata.d.ts' },
+  { exportName: 'throttle', relativePath: 'middleware/throttle.d.ts' },
+  { exportName: 'adaptor', relativePath: 'utils/adaptor.d.ts' },
 ] as const satisfies readonly PublicDeclaration[];
 
-test('Given a fresh state build, When public declarations are emitted, Then framework and middleware utility exports retain JSDoc', () => {
+test('Given an isolated declaration build, When public declarations are emitted, Then framework and middleware utility exports retain JSDoc', () => {
   // Given
-  const build = Bun.spawnSync({
-    cmd: ['pnpm', 'build'],
-    cwd: projectRoot,
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
+  const declarationDirectory = mkdtempSync(join(tmpdir(), 'ilokesto-state-declarations-'));
 
-  // When
-  expect(build.exitCode).toBe(0);
-  const declarations = publicDeclarations.map((declaration) => {
-    const declarationPath = join(projectRoot, declaration.relativePath);
-    const sourceFile = ts.createSourceFile(
-      declarationPath,
-      readFileSync(declarationPath, 'utf8'),
-      ts.ScriptTarget.Latest,
-      true,
-      ts.ScriptKind.TS,
-    );
-    const functions = sourceFile.statements.filter(
-      (statement): statement is ts.FunctionDeclaration =>
-        ts.isFunctionDeclaration(statement) &&
-        statement.name?.text === declaration.exportName &&
-        statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) === true,
-    );
+  try {
+    const build = Bun.spawnSync({
+      cmd: [
+        'pnpm',
+        'exec',
+        'tsc',
+        '--outDir',
+        declarationDirectory,
+        '--declarationDir',
+        declarationDirectory,
+      ],
+      cwd: projectRoot,
+    });
 
-    if (functions.length === 0) {
-      throw new Error(`Missing exported declaration: ${declaration.relativePath}#${declaration.exportName}`);
+    // When
+    expect(build.exitCode).toBe(0);
+    const declarations = publicDeclarations.map((declaration) => {
+      const declarationPath = join(declarationDirectory, declaration.relativePath);
+      const sourceFile = ts.createSourceFile(
+        declarationPath,
+        readFileSync(declarationPath, 'utf8'),
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+      );
+      const functions = sourceFile.statements.filter(
+        (statement): statement is ts.FunctionDeclaration =>
+          ts.isFunctionDeclaration(statement) &&
+          statement.name?.text === declaration.exportName &&
+          statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) === true,
+      );
+
+      if (functions.length === 0) {
+        throw new Error(`Missing exported declaration: ${declaration.relativePath}#${declaration.exportName}`);
+      }
+
+      return functions;
+    });
+
+    // Then
+    for (const declarationsForExport of declarations) {
+      for (const declaration of declarationsForExport) {
+        expect(ts.getJSDocCommentsAndTags(declaration).length).toBeGreaterThan(0);
+      }
     }
-
-    return functions;
-  });
-
-  // Then
-  for (const declarationsForExport of declarations) {
-    expect(
-      declarationsForExport.some(
-        (declaration) => ts.getJSDocCommentsAndTags(declaration).length > 0,
-      ),
-    ).toBeTrue();
+  } finally {
+    rmSync(declarationDirectory, { force: true, recursive: true });
   }
 }, { timeout: 180_000 });

--- a/packages/state/tsconfig.json
+++ b/packages/state/tsconfig.json
@@ -13,7 +13,6 @@
     "allowJs": true,
     "checkJs": true,
     "esModuleInterop": true,
-    "removeComments": true,
     "types": ["node"]
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary

- preserve source JSDoc in emitted state declarations
- attach framework create documentation to emitted overload declarations
- structurally parse fresh .d.ts output for framework, middleware, and utility exports without pinning prose
- keep runtime export keys unchanged
- include a patch changeset

## Verification

- pnpm --filter @ilokesto/state exec bun test test/declaration-jsdoc.test.ts
- pnpm --filter @ilokesto/state test
- pnpm --filter @ilokesto/state typecheck
- pnpm --filter @ilokesto/state test:typecheck
- changed-file diagnostics
- git diff --check

Closes #78