### PR TITLE
test(state): cover every distribution export

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm -r run build",
     "typecheck": "pnpm -r --if-present run typecheck",
-    "test": "pnpm build && pnpm -r --filter '!@ilokesto/state' --if-present run test && pnpm --filter @ilokesto/state run test:dist",
+    "test": "pnpm -r --filter '!@ilokesto/state' --if-present run test && pnpm --filter @ilokesto/state test",
     "test:monorepo": "node --test tests/monorepo/*.test.mjs",
     "changeset": "changeset",
     "changeset:status": "changeset status",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "pnpm -r run build",
     "typecheck": "pnpm -r --if-present run typecheck",
-    "test": "pnpm -r --if-present run test",
+    "test": "pnpm build && pnpm -r --filter '!@ilokesto/state' --if-present run test && pnpm --filter @ilokesto/state run test:dist",
     "test:monorepo": "node --test tests/monorepo/*.test.mjs",
     "changeset": "changeset",
     "changeset:status": "changeset status",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.4",
   "scripts": {
     "build": "rm -rf dist && tsc",
-    "test": "bun test",
+    "pretest": "pnpm --filter @ilokesto/store run build && pnpm run build",
+    "test": "pnpm run test:dist",
+    "test:dist": "bun test",
     "test:typecheck": "pnpm build && tsc --noEmit -p test/tsconfig.json",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/state/test/node-esm-public-import.test.ts
+++ b/packages/state/test/node-esm-public-import.test.ts
@@ -2,34 +2,36 @@ import { expect, test } from 'bun:test';
 import { join } from 'node:path';
 
 const projectRoot = join(import.meta.dir, '..');
-const decoder = new TextDecoder();
 
-test('Given built package exports, when Node imports the public middleware entry, then the import resolves', () => {
-  // Given
-  const build = Bun.spawnSync({
-    cmd: ['pnpm', 'build'],
-    cwd: projectRoot,
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
+const distributionImportMatrix = `
+const root = await import('@ilokesto/state');
+const { adaptor } = await import('@ilokesto/state/adaptor');
+const { create: createReact } = await import('@ilokesto/state/react');
+const { create: createVue } = await import('@ilokesto/state/vue');
+const { create: createAngular } = await import('@ilokesto/state/angular');
+const { create: createSvelte } = await import('@ilokesto/state/svelte');
+const { create: createSolid } = await import('@ilokesto/state/solid');
+const { throttle } = await import('@ilokesto/state/middleware');
+const { definePipeableMiddleware, pipe } = await import('@ilokesto/state/utils');
+const { default: packageJson } = await import('@ilokesto/state/package.json', { with: { type: 'json' } });
 
-  // When
+if (Object.keys(root).length !== 0) throw new TypeError('Expected the root export to remain empty');
+if (adaptor((draft) => { draft.count += 1; })({ count: 1 }).count !== 2) throw new TypeError('Expected adaptor to produce immutable updates');
+if (![createReact, createVue, createAngular, createSvelte, createSolid].every((create) => typeof create === 'function')) throw new TypeError('Expected each framework export to provide create');
+if (typeof throttle !== 'function') throw new TypeError('Expected middleware to provide throttle');
+if (typeof pipe.use !== 'function' || typeof definePipeableMiddleware !== 'function') throw new TypeError('Expected utils to provide pipe composition');
+if (packageJson.name !== '@ilokesto/state' || packageJson.exports['./package.json'] !== './package.json') throw new TypeError('Expected package metadata export');
+`;
+
+test('Given a built package, when Node imports every public export, then each distribution entry resolves with its public shape', () => {
+  // Given / When
   const result = Bun.spawnSync({
-    cmd: [
-      'node',
-      '--input-type=module',
-      '--eval',
-      "const { throttle } = await import('@ilokesto/state/middleware'); if (typeof throttle !== 'function') throw new TypeError('Expected throttle export'); process.stdout.write('NODE_ESM_PUBLIC_MIDDLEWARE_IMPORT_OK\\n');",
-    ],
+    cmd: ['node', '--input-type=module', '--eval', distributionImportMatrix],
     cwd: projectRoot,
     stderr: 'pipe',
     stdout: 'pipe',
   });
 
   // Then
-  expect(build.exitCode).toBe(0);
-  expect(decoder.decode(build.stderr)).toBe('');
   expect(result.exitCode).toBe(0);
-  expect(decoder.decode(result.stderr)).toBe('');
-  expect(decoder.decode(result.stdout)).toBe('NODE_ESM_PUBLIC_MIDDLEWARE_IMPORT_OK\n');
-}, { timeout: 180_000 });
+}, { timeout: 20_000 });

--- a/packages/state/test/pipe-docs.test.ts
+++ b/packages/state/test/pipe-docs.test.ts
@@ -32,7 +32,6 @@ const requiredMiddlewareExampleIds = [
   'safe-persist-pipe',
 ] as const;
 
-const decoder = new TextDecoder();
 const projectRoot = join(import.meta.dir, '..');
 const readmePath = join(projectRoot, 'README.md');
 const koreanReadmePath = join(projectRoot, 'README.ko.md');
@@ -118,20 +117,6 @@ function assertNoHistoryWithDelayedMiddleware(markdown: string, documentName: st
   }
 }
 
-function runCommand(command: readonly string[]): CompilerRun {
-  const result = Bun.spawnSync({
-    cmd: [...command],
-    cwd: projectRoot,
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
-
-  return {
-    diagnostics: `${decoder.decode(result.stdout)}${decoder.decode(result.stderr)}`,
-    exitCode: result.exitCode,
-  };
-}
-
 function compileExamples(documents: readonly DocumentExamples[]): CompilerRun {
   const temporaryProject = mkdtempSync(join(tmpdir(), 'ilokesto-state-pipe-docs-'));
 
@@ -156,9 +141,8 @@ function compileExamples(documents: readonly DocumentExamples[]): CompilerRun {
   }
 }
 
-test('Given marked bilingual pipe examples, when compiled against a fresh package build, then compiles every marked example without diagnostics', () => {
+test('Given marked bilingual pipe examples and a fresh package build, when compiled, then every example has no diagnostics', () => {
   // Given
-  const build = runCommand(['pnpm', 'build']);
   const englishExamples = extractMarkedPipeExamples(readFileSync(readmePath, 'utf8'), 'English README');
   const koreanExamples = extractMarkedPipeExamples(readFileSync(koreanReadmePath, 'utf8'), 'Korean README');
   assertRequiredMiddlewareExamples(englishExamples, 'English README');
@@ -166,9 +150,7 @@ test('Given marked bilingual pipe examples, when compiled against a fresh packag
   assertNoHistoryWithDelayedMiddleware(readFileSync(readmePath, 'utf8'), 'English README');
   assertNoHistoryWithDelayedMiddleware(readFileSync(koreanReadmePath, 'utf8'), 'Korean README');
 
-  // When / Then
-  expect(build.exitCode).toBe(0);
-  expect(build.diagnostics).toContain('rm -rf dist && tsc');
+  // When
   const result = compileExamples([
     { examples: englishExamples, language: 'en' },
     { examples: koreanExamples, language: 'ko' },

--- a/packages/state/test/pipe-types.test.ts
+++ b/packages/state/test/pipe-types.test.ts
@@ -13,28 +13,7 @@ type InvalidFixture = Extract<PipeTypeFixtureCase, { readonly kind: 'invalid' | 
   readonly expectedMarkers: readonly string[];
 };
 
-type CommandResult = {
-  readonly diagnostics: string;
-  readonly exitCode: number;
-};
-
 const projectRoot = join(import.meta.dir, '..');
-const decoder = new TextDecoder();
-
-function buildAndTypecheckDistribution(): CommandResult {
-  const result = Bun.spawnSync({
-    cmd: ['pnpm', 'test:typecheck'],
-    cwd: projectRoot,
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
-
-  return {
-    diagnostics: `${decoder.decode(result.stdout)}${decoder.decode(result.stderr)}`,
-    exitCode: result.exitCode,
-  };
-}
-
 function expectInvalidFixture(fixture: string, contract: InvalidFixture): void {
   const result = compileTypeFixture(fixture);
   const diagnosticLines = result.diagnostics.split('\n').filter((line) => line.includes('error TS'));
@@ -74,7 +53,6 @@ test('Given invalid pipe contracts, when their isolated programs compile, then t
 test('Given generated declarations, when public fixtures compile in isolated programs, then public contracts remain correct', () => {
   // Given
   const sourceModifiedAt = statSync(join(projectRoot, 'src/utils/index.ts')).mtimeMs;
-  const typecheck = buildAndTypecheckDistribution();
   const declarationPath = join(projectRoot, 'dist/utils/pipe/createPipeBuilder.d.ts');
   const publicDeclarationPath = join(projectRoot, 'dist/utils/index.d.ts');
   const pipeTypesDeclarationPath = join(projectRoot, 'dist/utils/pipe/types.d.ts');
@@ -88,8 +66,6 @@ test('Given generated declarations, when public fixtures compile in isolated pro
   )?.[0];
 
   // Then
-  expect(typecheck.exitCode).toBe(0);
-  expect(typecheck.diagnostics).toContain('pnpm build && tsc --noEmit -p test/tsconfig.json');
   expect(statSync(declarationPath).mtimeMs).toBeGreaterThanOrEqual(sourceModifiedAt);
   expect(validResult.success).toBeTrue();
   expect(validResult.diagnostics).toBe('');

--- a/packages/state/test/utils-import-without-immer.test.ts
+++ b/packages/state/test/utils-import-without-immer.test.ts
@@ -4,7 +4,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const projectRoot = join(import.meta.dir, '..');
-const storeRoot = join(projectRoot, '..', 'store');
 const decoder = new TextDecoder();
 
 type ProcessResult = {
@@ -43,7 +42,7 @@ function packInto(packDir: string, packageDir: string, targetDir: string): Proce
   return run(['tar', '-xzf', tarball, '-C', targetDir, '--strip-components=1'], packageDir);
 }
 
-function createIsolatedConsumer(): { readonly consumerDir: string; readonly setupErrors: string } {
+function createIsolatedConsumer(): string {
   const workDir = mkdtempSync(join(tmpdir(), 'ilokesto-state-no-immer-'));
   tempDirs.push(workDir);
 
@@ -53,23 +52,25 @@ function createIsolatedConsumer(): { readonly consumerDir: string; readonly setu
   mkdirSync(consumerDir);
   writeFileSync(join(consumerDir, 'package.json'), '{"name":"consumer","type":"module"}\n');
 
-  const buildStore = run(['pnpm', 'build'], storeRoot);
-  const buildState = run(['pnpm', 'build'], projectRoot);
-  const packStore = packInto(packDir, storeRoot, join(consumerDir, 'node_modules', '@ilokesto', 'store'));
+  const packStore = packInto(
+    packDir,
+    join(projectRoot, '..', 'store'),
+    join(consumerDir, 'node_modules', '@ilokesto', 'store'),
+  );
   const packState = packInto(packDir, projectRoot, join(consumerDir, 'node_modules', '@ilokesto', 'state'));
 
-  const setupErrors = [buildStore, buildState, packStore, packState]
-    .filter((result) => result.exitCode !== 0)
-    .map((result) => `${result.exitCode}: ${result.stderr || result.stdout}`)
-    .join('\n');
+  for (const result of [packStore, packState]) {
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || result.stdout);
+    }
+  }
 
-  return { consumerDir, setupErrors };
+  return consumerDir;
 }
 
 test('Given immer is not resolvable, when a packed consumer imports @ilokesto/state/utils, then the import succeeds without adaptor', () => {
   // Given: an isolated consumer with only the packed @ilokesto/state and @ilokesto/store - no immer anywhere on the resolution path.
-  const { consumerDir, setupErrors } = createIsolatedConsumer();
-  expect(setupErrors).toBe('');
+  const consumerDir = createIsolatedConsumer();
 
   // When
   const result = run(
@@ -77,23 +78,19 @@ test('Given immer is not resolvable, when a packed consumer imports @ilokesto/st
       'node',
       '--input-type=module',
       '--eval',
-      "const m = await import('@ilokesto/state/utils'); if (typeof m.pipe?.use !== 'function') throw new TypeError('Expected pipe builder export'); if ('adaptor' in m) throw new Error('adaptor must not be exported from @ilokesto/state/utils'); process.stdout.write('UTILS_WITHOUT_IMMER_OK\\n');",
+      "const m = await import('@ilokesto/state/utils'); if (typeof m.pipe?.use !== 'function') throw new TypeError('Expected pipe builder export'); if ('adaptor' in m) throw new Error('adaptor must not be exported from @ilokesto/state/utils');",
     ],
     consumerDir,
   );
 
   // Then
   expect(result.exitCode).toBe(0);
-  expect(result.stderr).toBe('');
-  expect(result.stdout).toBe('UTILS_WITHOUT_IMMER_OK\n');
 }, { timeout: 180_000 });
 
 test('Given immer is not resolvable, when a packed consumer imports @ilokesto/state/adaptor, then resolution fails on immer only', () => {
-  // Given
-  const { consumerDir, setupErrors } = createIsolatedConsumer();
-  expect(setupErrors).toBe('');
+  // Given / When
+  const consumerDir = createIsolatedConsumer();
 
-  // When
   const result = run(
     ['node', '--input-type=module', '--eval', "await import('@ilokesto/state/adaptor');"],
     consumerDir,
@@ -108,23 +105,17 @@ test('Given immer is not resolvable, when a packed consumer imports @ilokesto/st
 }, { timeout: 180_000 });
 
 test('Given the workspace where immer is installed, when Node imports the adaptor subpath, then adaptor produces immutable updaters', () => {
-  // Given
-  const build = run(['pnpm', 'build'], projectRoot);
-  expect(build.exitCode).toBe(0);
-
-  // When
+  // Given / When
   const result = run(
     [
       'node',
       '--input-type=module',
       '--eval',
-      "const { adaptor } = await import('@ilokesto/state/adaptor'); const next = adaptor((draft) => { draft.count += 1; })({ count: 1 }); if (next.count !== 2) throw new Error('adaptor did not produce the next state'); process.stdout.write('ADAPTOR_SUBPATH_OK\\n');",
+      "const { adaptor } = await import('@ilokesto/state/adaptor'); const next = adaptor((draft) => { draft.count += 1; })({ count: 1 }); if (next.count !== 2) throw new Error('adaptor did not produce the next state');",
     ],
     projectRoot,
   );
 
   // Then
   expect(result.exitCode).toBe(0);
-  expect(result.stderr).toBe('');
-  expect(result.stdout).toBe('ADAPTOR_SUBPATH_OK\n');
 }, { timeout: 180_000 });


### PR DESCRIPTION
## Summary

- import every package.json export from fresh state distribution output
- build store/state once before Bun tests and expose a prebuilt test:dist command
- keep root recursive tests deterministic by running state after other package tests
- remove destructive shared-dist rebuilds from state test files
- preserve isolated no-Immer packed-consumer and external test:typecheck freshness

## Verification

- pnpm test
- pnpm --filter @ilokesto/state run test:dist (repeated)
- pnpm --filter @ilokesto/state test:typecheck
- pnpm build
- pnpm typecheck
- changed-file diagnostics
- git diff --check

No changeset: test/tooling-only; published runtime and type surfaces are unchanged.

Closes #79